### PR TITLE
LPS-199127 - Add Autom. Tests to `AccessibilityMenuSmoke.testcase` and `AccessibilityMenu.testcase`

### DIFF
--- a/modules/apps/accessibility/accessibility-test/src/testFunctional/macros/AccessibilityMenu.macro
+++ b/modules/apps/accessibility/accessibility-test/src/testFunctional/macros/AccessibilityMenu.macro
@@ -55,6 +55,16 @@ definition {
 			locator1 = "AccessibilityMenu#MODAL_TITLE");
 	}
 
+	macro assertCanAccessAccessibilityMenuModalByTheUserProfileMenu {
+		Navigator.openURL();
+
+		UserBar.gotoDropdownItem(dropdownItem = "Accessibility Menu");
+
+		AssertElementPresent(
+			key_modal_title = "Accessibility Menu",
+			locator1 = "AccessibilityMenu#MODAL_TITLE");
+	}
+
 	macro assertCannotAccessAccessibilityMenuModal {
 		KeyPress(
 			locator1 = "//body",

--- a/modules/apps/accessibility/accessibility-test/src/testFunctional/tests/AccessibilityMenuSmoke.testcase
+++ b/modules/apps/accessibility/accessibility-test/src/testFunctional/tests/AccessibilityMenuSmoke.testcase
@@ -126,6 +126,10 @@ definition {
 		task ("Then Accessibility Menu can be reached by keyboard") {
 			AccessibilityMenu.assertCanAccessAccessibilityMenuModal();
 		}
+
+		task ("And Accessibility Menu can be reached through the user's profile menu") {
+			AccessibilityMenu.assertCanAccessAccessibilityMenuModalByTheUserProfileMenu();
+		}
 	}
 
 	@description = "LPS-178192. Verifies that the user can enable it by Site Settings."


### PR DESCRIPTION
[Ticket](https://liferay.atlassian.net/browse/LPS-199127)



Scope | Test Scenarios | Covered by frontend/backend unit test? | Test Priority (business impact) | Testcase File name | Testcase name
-- | -- | -- | -- | -- | --
2 | Given accessibility menu activated by instance settingsWhen the user’s profile menu is accessedThen assert accessibility menu is present | no |   | AccessibilityMenuSmoke.testcase | CanBeEnabledByInstanceSettings
1 | Given accessibility menu is deactivatedWhen the user’s profile menu is accessedThen assert accessibility menu is not present | no |   | AccessibilityMenu.testcase | CanBeDisabledByInstanceSettings

