### PR TITLE
LPS-198100 Remove no longer needed H2

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-classic/src/templates/portal_normal.ftl
+++ b/modules/apps/frontend-theme/frontend-theme-classic/src/templates/portal_normal.ftl
@@ -69,8 +69,6 @@
 		</#if>
 
 		<section class="${portal_content_css_class} flex-fill" id="content">
-			<h2 <#if show_control_menu>aria-hidden="true"</#if> class="sr-only">${htmlUtil.escape(the_title)}</h2>
-
 			<#if selectable>
 				<@liferay_util["include"] page=content_include />
 			<#else>

--- a/modules/apps/frontend-theme/frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled/templates/portal_normal.ftl
+++ b/modules/apps/frontend-theme/frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled/templates/portal_normal.ftl
@@ -47,8 +47,6 @@
 	</header>
 
 	<section id="content">
-		<h2 class="hide-accessible sr-only" role="heading" aria-level="1">${htmlUtil.escape(the_title)}</h2>
-
 		<#if selectable>
 			<@liferay_util["include"] page=content_include />
 		<#else>


### PR DESCRIPTION
After removing the H2 we have a correct home validation (singed-out). even with best practices on:

<img width="1727" alt="image" src="https://github.com/liferay-platform-experience/liferay-portal/assets/7963804/3627c2bd-c0b1-4a39-a219-6d5d1252296c">

