### PR TITLE
LPS-199223 Publications dropdown menu should be above the search bar

### DIFF
--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/components/ChangeTrackingIndicator.js
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/components/ChangeTrackingIndicator.js
@@ -363,6 +363,7 @@ export default function ChangeTrackingIndicator({
 			<ClayDropDownWithItems
 				alignmentPosition={Align.BottomCenter}
 				items={dropdownItems}
+				menuElementAttrs={{style: {zIndex: 1021}}}
 				trigger={renderTrigger}
 			/>
 		);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-199223

I inlined the `z-index` here because we run into a chicken or the egg problem. If I set the `z-index` of all dropdown menus higher than sticky-top, dropdown menus lower on the page will overlap the sticky nav.

![instance-settings](https://github.com/liferay-platform-experience/liferay-portal/assets/788266/b1a9c236-98c5-4049-a642-861032ffd846)
![system-settings](https://github.com/liferay-platform-experience/liferay-portal/assets/788266/fca646f7-8903-4219-b82b-0a7a719e2968)
