### PR TITLE
LPS-198660 Apply missing styles in cadmin for autocomplete input list

### DIFF
--- a/modules/apps/frontend-css/frontend-css-cadmin-web/src/main/resources/META-INF/resources/clay_admin.scss
+++ b/modules/apps/frontend-css/frontend-css-cadmin-web/src/main/resources/META-INF/resources/clay_admin.scss
@@ -146,6 +146,35 @@ html#{$cadmin-selector} {
 			color: $user-icon-color-9;
 		}
 
+		// Autocomplete Input List
+
+		.yui3-aclist {
+			&-content {
+				background: $cadmin-white;
+				border: 1px solid #afafaf;
+				box-shadow: 1px 1px 4px rgba(0, 0, 0, 0.58);
+			}
+
+			&-hidden {
+				visibility: hidden;
+			}
+
+			&-item {
+				padding: 2px 5px;
+
+				&-active {
+					background: #2647a0;
+					color: $cadmin-white;
+				}
+			}
+
+			&-list {
+				margin: 0;
+				overflow: hidden;
+				padding: 0;
+			}
+		}
+
 		// Taglib Move Boxes
 
 		.taglib-move-boxes {


### PR DESCRIPTION
Hi guys!

This bug has been reported to the Echo team https://liferay.atlassian.net/browse/LPS-198660, where autocomplete input list styles seem to be overlapped by cadmin classes. I send you this PR where I include these styles in `clay_admin.scss`. @pat270 @marcoscv-work  could you review it?

Thanks in advance! 😄 