### PR TITLE
LPS-190740 Stabilize Mock email subject assertion with normalize spacing

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/MockMock.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/MockMock.macro
@@ -73,9 +73,7 @@ definition {
 	macro _viewMailMessage {
 		var key_asset = ${subject};
 
-		AssertTextEquals.assertPartialText(
-			locator1 = "MockMock#MOCKMOCK_MESSAGE_BODY",
-			value1 = ${subject});
+		AssertElementPresent(locator1 = "MockMock#MOCKMOCK_MESSAGE_BODY");
 
 		AssertTextEquals.assertPartialText(
 			locator1 = "MockMock#MOCKMOCK_MESSAGE_BODY",

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/MockMock.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/MockMock.path
@@ -67,7 +67,7 @@
 </tr>
 <tr>
 	<td>MOCKMOCK_MESSAGE_BODY</td>
-	<td>//div[@class='well' and contains(.,'${key_asset}')]</td>
+	<td>//div[@class='well' and contains(normalize-space(),'${key_asset}')]</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
**Description**
A breaking line and extra space is inserted in Mock Mock subject line if the subject line becomes too long. We'll want to update the test to account for this possible extra line break and space.

**Test Plan**
- [x] [InstanceSettings#AssertEmailVerificationIsRequiredByDefault](https://github.com/john-co/liferay-portal/pull/515#issuecomment-1789896749) passes

**JIRA Ticket**
https://liferay.atlassian.net/browse/LPS-190740