### PR TITLE
LPS-201892

### DIFF
--- a/modules/apps/server/server-admin-web/src/main/java/com/liferay/server/admin/web/internal/portlet/action/EditServerMVCActionCommand.java
+++ b/modules/apps/server/server-admin-web/src/main/java/com/liferay/server/admin/web/internal/portlet/action/EditServerMVCActionCommand.java
@@ -822,6 +822,9 @@ public class EditServerMVCActionCommand
 			portletPreferences.setValue(
 				PropsKeys.MAIL_SESSION_MAIL_POP3_HOST, pop3Host);
 		}
+		else {
+			portletPreferences.reset(PropsKeys.MAIL_SESSION_MAIL_POP3_HOST);
+		}
 
 		if (!pop3Password.equals(Portal.TEMP_OBFUSCATION_VALUE)) {
 			portletPreferences.setValue(
@@ -833,15 +836,24 @@ public class EditServerMVCActionCommand
 				PropsKeys.MAIL_SESSION_MAIL_POP3_PORT,
 				String.valueOf(pop3Port));
 		}
+		else {
+			portletPreferences.reset(PropsKeys.MAIL_SESSION_MAIL_POP3_PORT);
+		}
 
 		if (!Validator.isBlank(pop3User)) {
 			portletPreferences.setValue(
 				PropsKeys.MAIL_SESSION_MAIL_POP3_USER, pop3User);
 		}
+		else {
+			portletPreferences.reset(PropsKeys.MAIL_SESSION_MAIL_POP3_USER);
+		}
 
 		if (!Validator.isBlank(smtpHost)) {
 			portletPreferences.setValue(
 				PropsKeys.MAIL_SESSION_MAIL_SMTP_HOST, smtpHost);
+		}
+		else {
+			portletPreferences.reset(PropsKeys.MAIL_SESSION_MAIL_SMTP_HOST);
 		}
 
 		if (!smtpPassword.equals(Portal.TEMP_OBFUSCATION_VALUE)) {
@@ -854,6 +866,9 @@ public class EditServerMVCActionCommand
 				PropsKeys.MAIL_SESSION_MAIL_SMTP_PORT,
 				String.valueOf(smtpPort));
 		}
+		else {
+			portletPreferences.reset(PropsKeys.MAIL_SESSION_MAIL_SMTP_PORT);
+		}
 
 		portletPreferences.setValue(
 			PropsKeys.MAIL_SESSION_MAIL_SMTP_STARTTLS_ENABLE,
@@ -862,6 +877,9 @@ public class EditServerMVCActionCommand
 		if (!Validator.isBlank(smtpUser)) {
 			portletPreferences.setValue(
 				PropsKeys.MAIL_SESSION_MAIL_SMTP_USER, smtpUser);
+		}
+		else {
+			portletPreferences.reset(PropsKeys.MAIL_SESSION_MAIL_SMTP_USER);
 		}
 
 		portletPreferences.setValue(

--- a/modules/apps/server/server-admin-web/src/main/resources/META-INF/resources/mail_fields.jsp
+++ b/modules/apps/server/server-admin-web/src/main/resources/META-INF/resources/mail_fields.jsp
@@ -23,7 +23,7 @@ Function<String, String> unrestrictedPreferenceFunction = basePreferenceFunction
 <aui:fieldset>
 	<aui:input name="preferencesCompanyId" type="hidden" value="<%= companyId %>" />
 
-	<aui:input label="enable-pop-server-notifications" name="popServerNotificationsEnabled" type="checkbox" value="<%= restrictedPreferenceFunction.apply(PropsKeys.POP_SERVER_NOTIFICATIONS_ENABLED) %>" />
+	<aui:input label="enable-pop-server-notifications" name="popServerNotificationsEnabled" type="checkbox" value="<%= unrestrictedPreferenceFunction.apply(PropsKeys.POP_SERVER_NOTIFICATIONS_ENABLED) %>" />
 
 	<aui:input cssClass="lfr-input-text-container" label="incoming-pop-server" name="pop3Host" type="text" value="<%= restrictedPreferenceFunction.apply(PropsKeys.MAIL_SESSION_MAIL_POP3_HOST) %>" />
 


### PR DESCRIPTION
# Motivation

Right now there is no way to clean mail fields since the blank value is consider an obfuscated value and no action is performed over the PortletPreferences.

**Steps to Reproduce:**

1. Access Instance Settings > Email >Mail Settings and change Outgoing port to 123
2. Access again Instance Settings > Email > Mail Settings and try to leave that field blank.

**Expected Results:**
The field can be saved with a blank value

**Current Results:**
The value 123 doesn’t get deleted.

# Proposed Solution
Right now blank is the default value when the properties need to be obfuscated. The reason to do this is to avoid providing specific configuration details, specially for LXC environments, see [LPS-163793](https://liferay.atlassian.net/browse/LPS-163793)

So the idea is to reset preferences at the backend when a null/empty value is received.

A blank value can mean two things:
 * The user hasn't changed the "obfuscated" value, so the preferences can be reset because that means that the default (system setting or portal.properties) will be used.
 * The user introduced previously a value, saved it, and know wants to remove it to use the default value. In this case the property must be reset to reflect this change.