### PR TITLE
LPS-75924 json query browser look&feel is dependent on open/close state of control menu

### DIFF
--- a/modules/apps/portal-remote/portal-remote-json-web-service-web/src/main/java/com/liferay/portal/remote/json/web/service/web/internal/struts/JSONWebServiceStrutsAction.java
+++ b/modules/apps/portal-remote/portal-remote-json-web-service-web/src/main/java/com/liferay/portal/remote/json/web/service/web/internal/struts/JSONWebServiceStrutsAction.java
@@ -65,6 +65,8 @@ public class JSONWebServiceStrutsAction implements StrutsAction {
 
 			Element bodyElement = document.body();
 
+			bodyElement.removeClass("product-menu-open");
+
 			bodyElement.prepend(unsyncStringWriter.toString());
 
 			ServletResponseUtil.write(httpServletResponse, document.html());


### PR DESCRIPTION
[Ticket](https://liferay.atlassian.net/browse/LPS-75924)

**Issue:** The UI in /api/jsonws is affected by the product menu state, if open the pages gets a left padding.
![image](https://github.com/liferay-platform-experience/liferay-portal/assets/57292581/902524f8-bf29-4e9e-919d-d151a820b2bd)

Fix: removed the body element class that indicates that the product menu is open for the /api/jsonws page.