### PR TITLE
LPS-203608 Fix Language Override tests

### DIFF
--- a/modules/apps/portal-language/portal-language-override-test/src/testFunctional/tests/LanguageOverride.testcase
+++ b/modules/apps/portal-language/portal-language-override-test/src/testFunctional/tests/LanguageOverride.testcase
@@ -124,9 +124,9 @@ definition {
 		task ("Given that assert no existing keys filter by Any Language") {
 			ManagementBar.setFilterAndOrder(filterBy = "Any Language");
 
-			AssertTextEquals(
+			AssertTextEquals.assertPartialText(
 				locator1 = "Search#SEARCH_INFO",
-				value1 = "0 Results for");
+				value1 = "0 Results Found");
 
 			AssertTextEquals(
 				locator1 = "Message#EMPTY_INFO",
@@ -149,9 +149,9 @@ definition {
 		}
 
 		task ("Then user can only view Overridden keys") {
-			AssertTextEquals(
+			AssertTextEquals.assertPartialText(
 				locator1 = "Search#SEARCH_INFO",
-				value1 = "1 Result for");
+				value1 = "1 Result Found");
 
 			LanguageOverride.assertFilterScope(filterScope = "Any Language");
 
@@ -290,9 +290,9 @@ definition {
 		}
 
 		task ("Then the language key can be viewed in the View page and there is results message") {
-			AssertTextEquals(
+			AssertTextEquals.assertPartialText(
 				locator1 = "Search#SEARCH_INFO",
-				value1 = "1 Result for \"2-synced-contact-data\"");
+				value1 = "1 Result Found for \"2-synced-contact-data\"");
 
 			LanguageOverride.assertLanguageKeyWithoutOverride(
 				languageKey = "2-synced-contact-data",
@@ -382,9 +382,9 @@ definition {
 		}
 
 		task ("Then the language key can be viewed in the View page and there is results message and search for translations") {
-			AssertTextEquals(
+			AssertTextEquals.assertPartialText(
 				locator1 = "Search#SEARCH_INFO",
-				value1 = "1 Result for \"O texto contÃƒÂ©m erro\"");
+				value1 = "1 Result Found for \"O texto contÃƒÂ©m erro\"");
 
 			LanguageOverride.assertSelectedLanguageInListView(
 				currentTranslationOverride = "O texto contÃƒÂ©m erro",
@@ -397,9 +397,9 @@ definition {
 
 			Search.searchCP(searchTerm = "Le texte contient une erreur");
 
-			AssertTextEquals(
+			AssertTextEquals.assertPartialText(
 				locator1 = "Search#SEARCH_INFO",
-				value1 = "1 Result for \"Le texte contient une erreur\"");
+				value1 = "1 Result Found for \"Le texte contient une erreur\"");
 
 			LanguageOverride.assertSelectedLanguageInListView(
 				currentTranslationOverride = "Le texte contient une erreur",

--- a/modules/apps/portal-language/portal-language-override-test/src/testFunctional/tests/LanguageOverrideExportImport.testcase
+++ b/modules/apps/portal-language/portal-language-override-test/src/testFunctional/tests/LanguageOverrideExportImport.testcase
@@ -266,9 +266,9 @@ this-is-a-language-key=This is a language key''',
 
 			Search.searchCP(searchTerm = "newkey");
 
-			AssertTextEquals(
+			AssertTextEquals.assertPartialText(
 				locator1 = "Search#SEARCH_INFO",
-				value1 = "0 Results for \"newkey\"");
+				value1 = "0 Results Found for \"newkey\"");
 		}
 	}
 


### PR DESCRIPTION
**Description**
Language Override tests are failing due to new word "Found" included in the search result info message. Proposed fix is to include this additional word as part of the assertion. And for robustness, use assert partial text to be less fragile since exact phrasing beyond "Found" is not important to test.

![image](https://github.com/liferay-platform-experience/liferay-portal/assets/35235266/d2c49975-6335-412a-bb8f-f29d76e1d351)


**Test Plan**
- [x] language override tests pass - see https://github.com/john-co/liferay-portal/pull/525#issuecomment-1852554273

**JIRA Ticket**
https://liferay.atlassian.net/browse/LPS-203608