### PR TITLE
LPS-200946 Stabilize configuration framework tests

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/administration/portalconfiguration/systemmanagement/InstanceSettings.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/administration/portalconfiguration/systemmanagement/InstanceSettings.testcase
@@ -16,6 +16,8 @@ definition {
 		var testLiferayVirtualInstance = PropsUtil.get("test.liferay.virtual.instance");
 
 		if (${testLiferayVirtualInstance} == "true") {
+			PortalSettings.tearDownCP();
+
 			PortalInstances.tearDownCP();
 		}
 		else {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/administration/portalconfiguration/systemmanagement/InstanceSettings.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/administration/portalconfiguration/systemmanagement/InstanceSettings.testcase
@@ -255,21 +255,19 @@ definition {
 
 		User.logoutPG();
 
-		Navigator.openURL();
+		AssertClick(
+			locator1 = "UserBar#USER_SIGN_IN",
+			value1 = "Sign In");
 
-		Navigator.gotoLoginPage();
-
-		Type(
+		Type.typePause(
 			locator1 = "TextInput#EMAIL_ADDRESS",
 			value1 = "userea@liferay.com");
 
-		Type(
+		Type.typePause(
 			locator1 = "TextInput#PASSWORD",
 			value1 = "test");
 
-		AssertClick(
-			locator1 = "Button#SIGN_IN",
-			value1 = "Sign In");
+		User._clickSignInButton(localization = ${localization});
 
 		AssertElementNotPresent(locator1 = "Button#SIGN_IN");
 
@@ -652,21 +650,19 @@ definition {
 
 		User.logoutPG();
 
-		Navigator.openURL();
+		AssertClick(
+			locator1 = "UserBar#USER_SIGN_IN",
+			value1 = "Sign In");
 
-		Navigator.gotoLoginPage();
-
-		Type(
+		Type.typePause(
 			locator1 = "TextInput#EMAIL_ADDRESS",
 			value1 = "userea@liferay.com");
 
-		Type(
+		Type.typePause(
 			locator1 = "TextInput#PASSWORD",
 			value1 = "test");
 
-		AssertClick(
-			locator1 = "Button#SIGN_IN",
-			value1 = "Sign In");
+		User._clickSignInButton(localization = ${localization});
 
 		AssertElementNotPresent(locator1 = "Button#SIGN_IN");
 


### PR DESCRIPTION
**Description**
Instance Settings tests are failing for a couple reasons. 
1. Portal settings needs to teardown first otherwise instance teardown throws a JSON null error
2. Sign in is hanging on a specific macro that is not reproducible locally. Proposal is to use other log in macros as a workaround.

**Test Plan**
- [x] `ci:test:configuration-framework` have affected Instance settings tests pass

**JIRA Ticket**
https://liferay.atlassian.net/browse/LPS-200946