### PR TITLE
LPS-203426 Fix AccessibilityMenuSmoke#CanOverrideSettingsOrderSmoke on release tester

### DIFF
--- a/modules/apps/accessibility/accessibility-test/src/testFunctional/tests/AccessibilityMenuSmoke.testcase
+++ b/modules/apps/accessibility/accessibility-test/src/testFunctional/tests/AccessibilityMenuSmoke.testcase
@@ -165,6 +165,7 @@ definition {
 	test CanOverrideSettingsOrderSmoke {
 		property portal.acceptance = "true";
 		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
 
 		task ("And new virtual instance B is created") {
 			HeadlessPortalInstanceAPI.addPortalInstance(


### PR DESCRIPTION
**Description**
AccessibilityMenuSmoke#CanOverrideSettingsOrderSmoke has been consistently failing on platform-experience and release tester exclusively. Other routines such as Pull requests have been passing. This makes me think there's some kind of contamination from other tests run in the same instance or jenkins node. Running the test in it's own node seems to have resolved the issue.

**Test Plan**
- [x] ci:test:accessibility-menu results in AccessibilityMenuSmoke#CanOverrideSettingsOrderSmoke passing - see https://github.com/john-co/liferay-portal/pull/528#issuecomment-1856280520
- [x] able to reproduce failing test on ci: https://github.com/john-co/liferay-portal/pull/527#issuecomment-1856223475

**JIRA Ticket**
https://liferay.atlassian.net/browse/LPS-203426