### PR TITLE
LPD-4209 Add FeatureIndicator Tag in frontend-taglib

### DIFF
--- a/modules/apps/frontend-js/frontend-js-components-sample-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/frontend-js/frontend-js-components-sample-web/src/main/resources/META-INF/resources/init.jsp
@@ -7,6 +7,7 @@
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
 taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
+taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/react" prefix="react" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %><%@

--- a/modules/apps/frontend-js/frontend-js-components-sample-web/src/main/resources/META-INF/resources/js/FeatureIndicatorSamples.js
+++ b/modules/apps/frontend-js/frontend-js-components-sample-web/src/main/resources/META-INF/resources/js/FeatureIndicatorSamples.js
@@ -10,7 +10,7 @@ import React from 'react';
 export default function FeatureIndicatorSamples({learnResourceContext}) {
 	return (
 		<>
-			<ClayLayout.Row>
+			<ClayLayout.Row className="p-3">
 				<ClayLayout.Col>
 					<h3>Beta Interactive</h3>
 
@@ -44,9 +44,9 @@ export default function FeatureIndicatorSamples({learnResourceContext}) {
 				</ClayLayout.Col>
 			</ClayLayout.Row>
 
-			<ClayLayout.Row className="bg-dark clay-dark text-white">
+			<ClayLayout.Row className="bg-dark clay-dark mb-3 p-3 text-white">
 				<ClayLayout.Col>
-					<h3>Beta Interactive</h3>
+					<h3>Dark Beta Interactive</h3>
 
 					<FeatureIndicator
 						interactive
@@ -56,13 +56,13 @@ export default function FeatureIndicatorSamples({learnResourceContext}) {
 				</ClayLayout.Col>
 
 				<ClayLayout.Col>
-					<h3>Beta</h3>
+					<h3>Dark Beta</h3>
 
 					<FeatureIndicator type="beta" />
 				</ClayLayout.Col>
 
 				<ClayLayout.Col>
-					<h3>Deprecated Interactive</h3>
+					<h3>Dark Deprecated Interactive</h3>
 
 					<FeatureIndicator
 						interactive
@@ -72,7 +72,7 @@ export default function FeatureIndicatorSamples({learnResourceContext}) {
 				</ClayLayout.Col>
 
 				<ClayLayout.Col>
-					<h3>Deprecated</h3>
+					<h3>Dark Deprecated</h3>
 
 					<FeatureIndicator type="deprecated" />
 				</ClayLayout.Col>

--- a/modules/apps/frontend-js/frontend-js-components-sample-web/src/main/resources/META-INF/resources/partials/feature_indicator.jsp
+++ b/modules/apps/frontend-js/frontend-js-components-sample-web/src/main/resources/META-INF/resources/partials/feature_indicator.jsp
@@ -27,72 +27,86 @@
 
 	<clay:row>
 		<clay:col>
-			<h2>JSP Direct Instantiation of React Component</h2>
+			<h2>liferay-frontend:feature-indicator Tag in JSP</h2>
 		</clay:col>
 	</clay:row>
 
-	<clay:row>
+	<clay:row
+		cssClass="p-3"
+	>
 		<clay:col>
 			<h3>Beta Interactive</h3>
 
-			<react:component
-				module="{FeatureIndicator} from frontend-js-components-web"
-				props='<%=
-					HashMapBuilder.<String, Object>put(
-						"interactive", "true"
-					).put(
-						"learnResourceContext", LearnMessageUtil.getReactDataJSONObject("frontend-js-components-web")
-					).put(
-						"type", "beta"
-					).build()
-				%>'
+			<liferay-frontend:feature-indicator
+				interactive="<%= true %>"
+				type="beta"
 			/>
 		</clay:col>
 
 		<clay:col>
 			<h3>Beta</h3>
 
-			<react:component
-				module="{FeatureIndicator} from frontend-js-components-web"
-				props='<%=
-					HashMapBuilder.<String, Object>put(
-						"learnResourceContext", LearnMessageUtil.getReactDataJSONObject("frontend-js-components-web")
-					).put(
-						"type", "beta"
-					).build()
-				%>'
+			<liferay-frontend:feature-indicator
+				type="beta"
 			/>
 		</clay:col>
 
 		<clay:col>
 			<h3>Deprecated Interactive</h3>
 
-			<react:component
-				module="{FeatureIndicator} from frontend-js-components-web"
-				props='<%=
-					HashMapBuilder.<String, Object>put(
-						"interactive", "true"
-					).put(
-						"learnResourceContext", LearnMessageUtil.getReactDataJSONObject("frontend-js-components-web")
-					).put(
-						"type", "deprecated"
-					).build()
-				%>'
+			<liferay-frontend:feature-indicator
+				interactive="<%= true %>"
+				type="deprecated"
 			/>
 		</clay:col>
 
 		<clay:col>
 			<h3>Deprecated</h3>
 
-			<react:component
-				module="{FeatureIndicator} from frontend-js-components-web"
-				props='<%=
-					HashMapBuilder.<String, Object>put(
-						"learnResourceContext", LearnMessageUtil.getReactDataJSONObject("frontend-js-components-web")
-					).put(
-						"type", "deprecated"
-					).build()
-				%>'
+			<liferay-frontend:feature-indicator
+				type="deprecated"
+			/>
+		</clay:col>
+	</clay:row>
+
+	<clay:row
+		cssClass="bg-dark p-3 text-light"
+	>
+		<clay:col>
+			<h3>Dark Beta Interactive</h3>
+
+			<liferay-frontend:feature-indicator
+				dark="<%= true %>"
+				interactive="<%= true %>"
+				type="beta"
+			/>
+		</clay:col>
+
+		<clay:col>
+			<h3>Dark Beta</h3>
+
+			<liferay-frontend:feature-indicator
+				dark="<%= true %>"
+				type="beta"
+			/>
+		</clay:col>
+
+		<clay:col>
+			<h3>Dark Deprecated Interactive</h3>
+
+			<liferay-frontend:feature-indicator
+				dark="<%= true %>"
+				interactive="<%= true %>"
+				type="deprecated"
+			/>
+		</clay:col>
+
+		<clay:col>
+			<h3>Dark Deprecated</h3>
+
+			<liferay-frontend:feature-indicator
+				dark="<%= true %>"
+				type="deprecated"
 			/>
 		</clay:col>
 	</clay:row>

--- a/modules/apps/frontend-taglib/frontend-taglib/build.gradle
+++ b/modules/apps/frontend-taglib/frontend-taglib/build.gradle
@@ -12,6 +12,7 @@ dependencies {
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-form-navigator")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-react")
+	compileOnly project(":apps:learn:learn-api")
 	compileOnly project(":apps:portal-url-builder:portal-url-builder-api")
 	compileOnly project(":apps:users-admin:users-admin-api")
 	compileOnly project(":core:osgi-service-tracker-collections")

--- a/modules/apps/frontend-taglib/frontend-taglib/package.json
+++ b/modules/apps/frontend-taglib/frontend-taglib/package.json
@@ -11,6 +11,7 @@
 		"@clayui/tabs": "3.109.0",
 		"@liferay/frontend-data-set-web": "*",
 		"@liferay/frontend-js-react-web": "*",
+		"frontend-js-components-web": "*",
 		"frontend-js-web": "*",
 		"prop-types": "15.7.2",
 		"react": "16.12.0"

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/FeatureIndicatorTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/FeatureIndicatorTag.java
@@ -1,0 +1,92 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.frontend.taglib.servlet.taglib;
+
+import com.liferay.frontend.taglib.internal.servlet.ServletContextUtil;
+import com.liferay.taglib.util.IncludeTag;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.jsp.PageContext;
+
+/**
+ * @author Patrick Yeo
+ */
+public class FeatureIndicatorTag extends IncludeTag {
+
+	public boolean getDark() {
+		return _dark;
+	}
+
+	public boolean getInteractive() {
+		return _interactive;
+	}
+
+	public String getTooltipAlign() {
+		return _tooltipAlign;
+	}
+
+	public String getType() {
+		return _type;
+	}
+
+	public void setDark(boolean dark) {
+		_dark = dark;
+	}
+
+	public void setInteractive(boolean interactive) {
+		_interactive = interactive;
+	}
+
+	@Override
+	public void setPageContext(PageContext pageContext) {
+		super.setPageContext(pageContext);
+
+		setServletContext(ServletContextUtil.getServletContext());
+	}
+
+	public void setTooltipAlign(String tooltipAlign) {
+		_tooltipAlign = tooltipAlign;
+	}
+
+	public void setType(String type) {
+		_type = type;
+	}
+
+	@Override
+	protected void cleanUp() {
+		super.cleanUp();
+
+		_dark = false;
+		_interactive = false;
+		_tooltipAlign = null;
+		_type = null;
+	}
+
+	@Override
+	protected String getPage() {
+		return _PAGE;
+	}
+
+	@Override
+	protected void setAttributes(HttpServletRequest httpServletRequest) {
+		httpServletRequest.setAttribute(
+			"liferay-frontend:feature-indicator:dark", _dark);
+		httpServletRequest.setAttribute(
+			"liferay-frontend:feature-indicator:interactive", _interactive);
+		httpServletRequest.setAttribute(
+			"liferay-frontend:feature-indicator:tooltipAlign", _tooltipAlign);
+		httpServletRequest.setAttribute(
+			"liferay-frontend:feature-indicator:type", _type);
+	}
+
+	private static final String _PAGE = "/feature_indicator/page.jsp";
+
+	private boolean _dark;
+	private boolean _interactive;
+	private String _tooltipAlign;
+	private String _type;
+
+}

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/liferay-frontend.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/liferay-frontend.tld
@@ -390,6 +390,34 @@
 		</attribute>
 	</tag>
 	<tag>
+		<description>Creates the Feature Indicator component.</description>
+		<name>feature-indicator</name>
+		<tag-class>com.liferay.frontend.taglib.servlet.taglib.FeatureIndicatorTag</tag-class>
+		<body-content>JSP</body-content>
+		<attribute>
+			<name>dark</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+			<type>boolean</type>
+		</attribute>
+		<attribute>
+			<name>interactive</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+			<type>boolean</type>
+		</attribute>
+		<attribute>
+			<name>tooltipAlign</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<name>type</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+	</tag>
+	<tag>
 		<description>Creates a <![CDATA[<code>&lt;div&gt;</code>]]> tag to group related form elements and offer additional styling.</description>
 		<name>fieldset</name>
 		<tag-class>com.liferay.frontend.taglib.servlet.taglib.FieldsetTag</tag-class>

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/feature_indicator/init.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/feature_indicator/init.jsp
@@ -1,0 +1,11 @@
+<%--
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+--%>
+
+<%@ include file="/init.jsp" %>
+
+<%@ page import="com.liferay.learn.LearnMessageUtil" %><%@
+page import="com.liferay.portal.kernel.util.HashMapBuilder" %>

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/feature_indicator/page.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/feature_indicator/page.jsp
@@ -1,0 +1,34 @@
+<%--
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+--%>
+
+<%@ include file="/feature_indicator/init.jsp" %>
+
+<%
+boolean dark = GetterUtil.getBoolean(request.getAttribute("liferay-frontend:feature-indicator:dark"));
+boolean interactive = GetterUtil.getBoolean(request.getAttribute("liferay-frontend:feature-indicator:interactive"));
+String tooltipAlign = (String)request.getAttribute("liferay-frontend:feature-indicator:tooltipAlign");
+String type = (String)request.getAttribute("liferay-frontend:feature-indicator:type");
+%>
+
+<div>
+	<react:component
+		module="{FeatureIndicator} from frontend-js-components-web"
+		props='<%=
+			HashMapBuilder.<String, Object>put(
+				"dark", dark
+			).put(
+				"interactive", interactive
+			).put(
+				"learnResourceContext", LearnMessageUtil.getReactDataJSONObject("frontend-js-components-web")
+			).put(
+				"tooltipAlign", tooltipAlign
+			).put(
+				"type", type
+			).build()
+		%>'
+	/>
+</div>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-4209

Putting this up for review. There is a test directory but no tests for most of the components in `frontend-taglib`. One thing that confuses me is the link to "Learn more about..." doesn't show up for me. I've experienced this before but it ends up showing up when it gets merged.

![feat-indicator](https://github.com/liferay-platform-experience/liferay-portal/assets/788266/ad92ca18-d827-43e8-a40a-0c9027da776e)
