### PR TITLE
LPD-15629 - Ensure that the link is not associated with the previous paragraph.

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/links.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/links.jsp
@@ -17,12 +17,14 @@
 	<p>Used for stand-alone hyperlinks. Can be a text or an image.</p>
 </blockquote>
 
-<clay:link
-	data-custom-property="customValue"
-	href="#"
-	label="link text"
-	target="_blank"
-/>
+<div>
+	<clay:link
+		data-custom-property="customValue"
+		href="#"
+		label="link text"
+		target="_blank"
+	/>
+</div>
 
 <clay:link
 	displayType="primary"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-15629

This test is failing only on CI. In order to reproduce this locally we have to change the display resolution to something smaller like `1080 x 760`. At this smaller resolution, AXE is interpreting the link as being part of the previous paragraph and therefore comparing the contrast between link text and body text. We are not concerned with the contrast between links and body text color because we have a setting in the accessibility menu that forces all links to be underlined so that they are distinguishable without needing to increase text size.

The fix simply adds a div around the link so that it is not accidentally associated with the previous paragraph. 