### PR TITLE
LPD-17672 clay:select tag should output a for attribute on label

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/form_elements.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/form_elements.jsp
@@ -31,7 +31,7 @@
 			<td>Off</td>
 		</tr>
 		<tr>
-			<td><clay:checkbox checked="<%= true %>" cssClass="custom-css-class" id="customId" name="name" /></td>
+			<td><clay:checkbox checked="<%= true %>" cssClass="custom-css-class" id="wdui6khbj" name="name" /></td>
 			<td>With custom class and id</td>
 		</tr>
 		<tr>
@@ -114,7 +114,7 @@ for (int i = 0; i < 8; i++) {
 <clay:select
 	containerCssClass="custom-container-css-class"
 	cssClass="custom-css-class"
-	id="customId"
+	id="pe0mdaf1n"
 	label="Regular Select Element"
 	name="name"
 	options="<%= selectOptions %>"
@@ -122,12 +122,14 @@ for (int i = 0; i < 8; i++) {
 
 <clay:select
 	disabled="<%= true %>"
+	id="6e0paj9ij"
 	label="Disabled Regular Select Element"
 	name="name"
 	options="<%= selectOptions %>"
 />
 
 <clay:select
+	id="lb6e0l8fq"
 	label="Multiple Select Element"
 	multiple="<%= true %>"
 	name="name"
@@ -136,6 +138,7 @@ for (int i = 0; i < 8; i++) {
 
 <clay:select
 	disabled="<%= true %>"
+	id="c8fs6qlrj"
 	label="Disabled Multiple Select Element"
 	multiple="<%= true %>"
 	name="name"

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/SelectTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/SelectTag.java
@@ -150,7 +150,15 @@ public class SelectTag extends BaseContainerTag {
 		JspWriter jspWriter = pageContext.getOut();
 
 		if (Validator.isNotNull(_label)) {
-			jspWriter.write("<label>");
+			jspWriter.write("<label ");
+
+			if (Validator.isNotNull(getId())) {
+				jspWriter.write(" for=\"");
+				jspWriter.write(getId());
+				jspWriter.write("\"");
+			}
+
+			jspWriter.write(">");
 			jspWriter.write(getLabel());
 			jspWriter.write("</label>");
 		}


### PR DESCRIPTION
    - when `clay:select` has an `id` attribute and `label`, it should output a `for`
      attribute on the `label` with the value of the `id`. It associates the `label`
      with the form element.

LPD-17672 Clay Sample add unique id's to form elements

https://liferay.atlassian.net/browse/LPD-17672