### PR TITLE
LPD-18518 Control Menu links and buttons should have their own CSS class name `control-menu-nav-link`

### DIFF
--- a/modules/apps/digital-signature/digital-signature-web/src/main/resources/META-INF/resources/js/components/control-menu/ControlMenu.js
+++ b/modules/apps/digital-signature/digital-signature-web/src/main/resources/META-INF/resources/js/components/control-menu/ControlMenu.js
@@ -37,7 +37,7 @@ export function BackButtonPortal({backURL = '/'}) {
 		<ReactPortal container={container}>
 			<li className="control-menu-nav-item">
 				<Link
-					className="btn-monospaced btn-sm lfr-icon-item"
+					className="btn-monospaced btn-sm control-menu-nav-link lfr-icon-item"
 					tabIndex={1}
 					to={backURL}
 				>

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/IconOptionsTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/IconOptionsTag.java
@@ -8,6 +8,7 @@ package com.liferay.frontend.taglib.servlet.taglib;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemList;
 import com.liferay.frontend.taglib.internal.servlet.ServletContextUtil;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIcon;
 import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIconTracker;
 import com.liferay.portal.kernel.theme.PortletDisplay;
@@ -44,8 +45,20 @@ public class IconOptionsTag extends IncludeTag {
 		return super.doEndTag();
 	}
 
+	public String getCssClass() {
+		if (_cssClass != null) {
+			return _cssClass;
+		}
+
+		return StringPool.BLANK;
+	}
+
 	public boolean isMonospaced() {
 		return _monospaced;
+	}
+
+	public void setCssClass(String cssClass) {
+		_cssClass = cssClass;
 	}
 
 	public void setMonospaced(boolean monospaced) {
@@ -63,6 +76,7 @@ public class IconOptionsTag extends IncludeTag {
 	protected void cleanUp() {
 		super.cleanUp();
 
+		_cssClass = null;
 		_monospaced = false;
 		_portletConfigurationIcons = null;
 	}
@@ -79,6 +93,8 @@ public class IconOptionsTag extends IncludeTag {
 
 	@Override
 	protected void setAttributes(HttpServletRequest httpServletRequest) {
+		httpServletRequest.setAttribute(
+			"liferay-frontend:icon-options:cssClass", getCssClass());
 		httpServletRequest.setAttribute(
 			"liferay-frontend:icon-options:dropdownItems", _getDropdownItems());
 		httpServletRequest.setAttribute(
@@ -226,6 +242,7 @@ public class IconOptionsTag extends IncludeTag {
 
 	private static final String _PAGE = "/icon_options/page.jsp";
 
+	private String _cssClass;
 	private boolean _monospaced;
 	private List<PortletConfigurationIcon> _portletConfigurationIcons;
 

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/liferay-frontend.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/liferay-frontend.tld
@@ -575,6 +575,11 @@
 		<tag-class>com.liferay.frontend.taglib.servlet.taglib.IconOptionsTag</tag-class>
 		<body-content>JSP</body-content>
 		<attribute>
+			<name>cssClass</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
 			<name>monospaced</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/icon_options/page.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/icon_options/page.jsp
@@ -8,13 +8,15 @@
 <%@ include file="/icon_options/init.jsp" %>
 
 <%
+String cssClass = (String)request.getAttribute("liferay-frontend:icon-options:cssClass");
+
 List<PortletConfigurationIcon> portletConfigurationIcons = (List<PortletConfigurationIcon>)request.getAttribute("liferay-frontend:icon-options:portletConfigurationIcons");
 %>
 
 <clay:dropdown-menu
 	aria-label='<%= LanguageUtil.get(request, "options") %>'
 	borderless="<%= true %>"
-	cssClass="component-action portlet-options"
+	cssClass='<%= cssClass + " component-action portlet-options" %>'
 	displayType="secondary"
 	dropdownItems='<%= (List<DropdownItem>)request.getAttribute("liferay-frontend:icon-options:dropdownItems") %>'
 	icon="ellipsis-v"

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/control/menu/customization_settings.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/control/menu/customization_settings.jsp
@@ -19,6 +19,7 @@ String portletNamespace = PortalUtil.getPortletNamespace(LayoutAdminPortletKeys.
 			).build()
 		%>'
 		aria-label='<%= LanguageUtil.get(request, "this-page-can-be-customized") %>'
+		cssClass="control-menu-nav-link"
 		data-qa-id="customizations"
 		displayType="unstyled"
 		icon="pencil"

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/control/menu/edit_layout_control_menu_entry_icon.tmpl
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/control/menu/edit_layout_control_menu_entry_icon.tmpl
@@ -1,5 +1,5 @@
 <li class="control-menu-nav-item">
-	<a aria-label="${configurePage}" class="btn btn-monospaced btn-sm lfr-portal-tooltip" data-qa-id="editLayout" data-title="${configurePage}" href="${editPageURL}">
+	<a aria-label="${configurePage}" class="btn btn-monospaced btn-sm control-menu-nav-link lfr-portal-tooltip" data-qa-id="editLayout" data-title="${configurePage}" href="${editPageURL}">
 		${iconCog}
 	</a>
 </li>

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/control/menu/layout_actions.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/control/menu/layout_actions.jsp
@@ -14,7 +14,7 @@ LayoutActionsDisplayContext layoutActionsDisplayContext = (LayoutActionsDisplayC
 <li class="control-menu-nav-item">
 	<clay:dropdown-menu
 		aria-label='<%= LanguageUtil.get(resourceBundle, "options") %>'
-		borderless="<%= true %>"
+		cssClass="control-menu-nav-link"
 		displayType="unstyled"
 		dropdownItems="<%= layoutActionsDisplayContext.getDropdownItems() %>"
 		icon="ellipsis-v"

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/dynamic_include/information_messages.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/dynamic_include/information_messages.jsp
@@ -14,6 +14,7 @@ LayoutInformationMessagesDisplayContext layoutInformationMessagesDisplayContext 
 <li class="control-menu-nav-item lfr-portal-tooltip">
 	<clay:button
 		aria-label='<%= LanguageUtil.get(request, "additional-information") %>'
+		cssClass="control-menu-nav-link"
 		data-qa-id="info"
 		displayType="unstyled"
 		monospaced="<%= true %>"

--- a/modules/apps/layout/layout-admin-web/src/main/resources/com/liferay/layout/admin/web/internal/product/navigation/control/menu/icon.tmpl
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/com/liferay/layout/admin/web/internal/product/navigation/control/menu/icon.tmpl
@@ -1,5 +1,5 @@
 <li class="control-menu-nav-item">
-	<button aria-label="${title}" aria-pressed="false" class="btn-monospaced btn-sm lfr-portal-tooltip toggle-controls" data-qa-id="showControls" data-title="${title}">
+	<button aria-label="${title}" aria-pressed="false" class="btn-monospaced btn-sm control-menu-nav-link lfr-portal-tooltip toggle-controls" data-qa-id="showControls" data-title="${title}">
 		${iconTag}
 	</button>
 </li>

--- a/modules/apps/layout/layout-reports-web/src/main/resources/com/liferay/layout/reports/web/internal/product/navigation/control/menu/icon.tmpl
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/com/liferay/layout/reports/web/internal/product/navigation/control/menu/icon.tmpl
@@ -1,5 +1,5 @@
 <li class="control-menu-nav-item layout-reports-icon ${cssClass}">
-	<button aria-label="${title}" aria-pressed="false" class="btn btn-monospaced btn-sm lfr-portal-tooltip product-menu-toggle sidenav-toggler" data-content="body" data-open-class="lfr-has-layout-reports-panel open-admin-panel open" data-target="#layoutReportsPanelId" data-title="${title}" data-toggle="liferay-sidenav" data-type="fixed-push" data-type-mobile="fixed" id="layoutReportsPanelToggleId">
+	<button aria-label="${title}" aria-pressed="false" class="btn btn-monospaced btn-sm control-menu-nav-link lfr-portal-tooltip product-menu-toggle sidenav-toggler" data-content="body" data-open-class="lfr-has-layout-reports-panel open-admin-panel open" data-target="#layoutReportsPanelId" data-title="${title}" data-toggle="liferay-sidenav" data-type="fixed-push" data-type-mobile="fixed" id="layoutReportsPanelToggleId">
 		${iconTag}
 	</button>
 </li>

--- a/modules/apps/layout/layout-set-prototype-web/src/main/resources/META-INF/resources/dynamic_include/propagation_message.jsp
+++ b/modules/apps/layout/layout-set-prototype-web/src/main/resources/META-INF/resources/dynamic_include/propagation_message.jsp
@@ -13,6 +13,7 @@ PropagationMessageDisplayContext propagationMessageDisplayContext = new Propagat
 
 <li class="control-menu-nav-item">
 	<clay:button
+		cssClass="control-menu-nav-link"
 		displayType="unstyled"
 		icon="merge"
 		monospaced="<%= true %>"

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-collection/src/main/resources/META-INF/resources/entries/add_collection_item.jsp
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-collection/src/main/resources/META-INF/resources/entries/add_collection_item.jsp
@@ -26,7 +26,7 @@ List<AssetPublisherAddItemHolder> assetPublisherAddItemHolders = (List<AssetPubl
 			<clay:link
 				aria-label="<%= label %>"
 				borderless="<%= true %>"
-				cssClass="lfr-portal-tooltip"
+				cssClass="control-menu-nav-link lfr-portal-tooltip"
 				data-title="<%= label %>"
 				displayType="unstyled"
 				href="<%= String.valueOf(assetPublisherAddItemHolder.getPortletURL()) %>"

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-collection/src/main/resources/META-INF/resources/entries/collection_items_detail.jsp
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-collection/src/main/resources/META-INF/resources/entries/collection_items_detail.jsp
@@ -13,7 +13,7 @@ CollectionItemsDetailDisplayContext collectionItemsDetailDisplayContext = (Colle
 
 <li class="control-menu-nav-item">
 	<clay:button
-		cssClass="text-muted"
+		cssClass="control-menu-nav-link text-muted"
 		displayType="unstyled"
 		id='<%= collectionItemsDetailDisplayContext.getNamespace() + "viewCollectionItems" %>'
 		label='<%= "(" + LanguageUtil.format(resourceBundle, "x-items", collectionItemsDetailDisplayContext.getCollectionItemsCount(), false) + ")" %>'

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-display-page/src/main/resources/META-INF/resources/page_template/edit_menu.jsp
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-display-page/src/main/resources/META-INF/resources/page_template/edit_menu.jsp
@@ -14,6 +14,7 @@ EditDisplayPageMenuDisplayContext editDisplayPageMenuDisplayContext = (EditDispl
 <li class="control-menu-nav-item">
 	<clay:dropdown-menu
 		borderless="<%= true %>"
+		cssClass="control-menu-nav-link"
 		displayType="unstyled"
 		dropdownItems="<%= editDisplayPageMenuDisplayContext.getDropdownItems() %>"
 		icon="pencil"

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/applications_menu/applications_menu.jsp
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/applications_menu/applications_menu.jsp
@@ -14,7 +14,7 @@ ApplicationsMenuDisplayContext applicationsMenuDisplayContext = new Applications
 <li class="control-menu-nav-item control-menu-nav-item-separator">
 	<clay:button
 		aria-haspopup="dialog"
-		cssClass="lfr-portal-tooltip"
+		cssClass="control-menu-nav-link lfr-portal-tooltip"
 		displayType="unstyled"
 		icon="grid"
 		small="<%= true %>"

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/js/index.js
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/js/index.js
@@ -531,7 +531,7 @@ const ApplicationsMenu = ({
 			<ClayButtonWithIcon
 				aria-haspopup="dialog"
 				aria-labelledby={buttonTitleId}
-				className="dropdown-toggle lfr-portal-tooltip"
+				className="control-menu-nav-link dropdown-toggle lfr-portal-tooltip"
 				data-qa-id="applicationsMenu"
 				data-title={ReactDOMServer.renderToString(buttonTitle)}
 				data-title-set-as-html

--- a/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/src/main/resources/META-INF/resources/control_menu/_control_menu.scss
+++ b/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/src/main/resources/META-INF/resources/control_menu/_control_menu.scss
@@ -45,8 +45,7 @@ html#{$cadmin-selector} {
 				width: 19.2px;
 			}
 
-			a:not(.dropdown-item),
-			button:not(.btn-link):not(.dropdown-item):not(.nav-link) {
+			.control-menu-nav-link {
 				&:focus,
 				&:hover {
 					text-decoration: none;
@@ -63,8 +62,7 @@ html#{$cadmin-selector} {
 			background-color: $control-menu-level-1-bg;
 			color: $control-menu-level-1-color;
 
-			a:not(.dropdown-item),
-			button:not(.btn-link):not(.dropdown-item):not(.nav-link) {
+			.control-menu-nav-link {
 				color: $control-menu-level-1-link-color;
 
 				&:focus,
@@ -84,8 +82,7 @@ html#{$cadmin-selector} {
 			border-bottom: $control-menu-level-1-light-border;
 			color: $control-menu-level-1-light-color;
 
-			a:not(.dropdown-item),
-			button:not(.btn-link):not(.btn-translucent):not(.dropdown-item):not(.nav-link) {
+			.control-menu-nav-link {
 				color: $control-menu-level-1-light-link-color;
 
 				&:focus,

--- a/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/java/com/liferay/product/navigation/control/menu/web/internal/LayoutBackLinkProductNavigationControlMenuEntry.java
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/java/com/liferay/product/navigation/control/menu/web/internal/LayoutBackLinkProductNavigationControlMenuEntry.java
@@ -83,7 +83,7 @@ public class LayoutBackLinkProductNavigationControlMenuEntry
 
 	@Override
 	public String getLinkCssClass(HttpServletRequest httpServletRequest) {
-		return "lfr-back-link";
+		return "control-menu-nav-link lfr-back-link";
 	}
 
 	@Override

--- a/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/entries/add_content_icon.jsp
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/entries/add_content_icon.jsp
@@ -14,7 +14,7 @@ String portletNamespace = PortalUtil.getPortletNamespace(ProductNavigationContro
 <li class="control-menu-nav-item">
 	<clay:button
 		aria-label='<%= LanguageUtil.get(request, "add") %>'
-		cssClass="lfr-portal-tooltip product-menu-toggle sidenav-toggler"
+		cssClass="control-menu-nav-link lfr-portal-tooltip product-menu-toggle sidenav-toggler"
 		data-content="body"
 		data-open-class="open-admin-panel open"
 		data-qa-id="add"

--- a/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/entries/portlet_options.jsp
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/entries/portlet_options.jsp
@@ -9,6 +9,7 @@
 
 <li class="control-menu-nav-item" data-qa-id="headerOptions">
 	<liferay-frontend:icon-options
+		cssClass="control-menu-nav-link"
 		monospaced="<%= true %>"
 	/>
 </li>

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/com/liferay/product/navigation/product/menu/web/internal/product/navigation/control/menu/icon.tmpl
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/com/liferay/product/navigation/product/menu/web/internal/product/navigation/control/menu/icon.tmpl
@@ -1,6 +1,6 @@
 <li class="control-menu-nav-item ${cssClass}">
 	<div role="tablist">
-		<button aria-controls="${portletNamespace}sidenavSliderId" aria-label="${title}" aria-selected="${isOpen}" class="btn btn-monospaced btn-sm lfr-portal-tooltip product-menu-toast-toggle product-menu-toggle sidenav-toggler" data-content="body" data-open-class="open product-menu-open" data-qa-id="productMenu" data-target="#${portletNamespace}sidenavSliderId" data-title="${title}" data-toggle="liferay-sidenav" data-type="fixed-push" data-type-mobile="fixed" ${dataURL} id="${portletNamespace}sidenavToggleId" role="tab">
+		<button aria-controls="${portletNamespace}sidenavSliderId" aria-label="${title}" aria-selected="${isOpen}" class="btn btn-monospaced btn-sm control-menu-nav-link lfr-portal-tooltip product-menu-toast-toggle product-menu-toggle sidenav-toggler" data-content="body" data-open-class="open product-menu-open" data-qa-id="productMenu" data-target="#${portletNamespace}sidenavSliderId" data-title="${title}" data-toggle="liferay-sidenav" data-type="fixed-push" data-type-mobile="fixed" ${dataURL} id="${portletNamespace}sidenavToggleId" role="tab">
 			${closedIcon}
 
 			${openIcon}

--- a/modules/apps/product-navigation/product-navigation-simulation-web/src/main/resources/com/liferay/product/navigation/simulation/web/internal/product/navigation/control/menu/icon.tmpl
+++ b/modules/apps/product-navigation/product-navigation-simulation-web/src/main/resources/com/liferay/product/navigation/simulation/web/internal/product/navigation/control/menu/icon.tmpl
@@ -1,5 +1,5 @@
 <li class="control-menu-nav-item simulation-icon">
-	<button aria-label="${title}" class="btn btn-monospaced btn-sm lfr-portal-tooltip overflow-hidden product-menu-toggle sidenav-toggler" data-content="body" data-open-class="lfr-has-simulation-panel open-admin-panel open" data-qa-id="simulation"  data-target="#${portletNamespace}simulationPanelId" data-title="${title}" data-toggle="liferay-sidenav" data-type="fixed-push" data-type-mobile="fixed" data-url="${simulationPanelURL}" id="${portletNamespace}simulationToggleId">
+	<button aria-label="${title}" class="btn btn-monospaced btn-sm control-menu-nav-link lfr-portal-tooltip overflow-hidden product-menu-toggle sidenav-toggler" data-content="body" data-open-class="lfr-has-simulation-panel open-admin-panel open" data-qa-id="simulation"  data-target="#${portletNamespace}simulationPanelId" data-title="${title}" data-toggle="liferay-sidenav" data-type="fixed-push" data-type-mobile="fixed" data-url="${simulationPanelURL}" id="${portletNamespace}simulationToggleId">
 		${iconTag}
 	</button>
 </li>

--- a/modules/apps/product-navigation/product-navigation-taglib/src/main/java/com/liferay/product/navigation/taglib/display/context/ProductNavigationControlMenuTagDisplayContext.java
+++ b/modules/apps/product-navigation/product-navigation-taglib/src/main/java/com/liferay/product/navigation/taglib/display/context/ProductNavigationControlMenuTagDisplayContext.java
@@ -233,7 +233,8 @@ public class ProductNavigationControlMenuTagDisplayContext {
 		String linkCssClass = productNavigationControlMenuEntry.getLinkCssClass(
 			_httpServletRequest);
 
-		iconTag.setLinkCssClass("btn btn-monospaced btn-sm " + linkCssClass);
+		iconTag.setLinkCssClass(
+			"btn btn-monospaced btn-sm control-menu-nav-link " + linkCssClass);
 
 		ThemeDisplay themeDisplay =
 			(ThemeDisplay)_httpServletRequest.getAttribute(

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/com/liferay/analytics/reports/web/internal/product/navigation/control/menu/icon.tmpl
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/com/liferay/analytics/reports/web/internal/product/navigation/control/menu/icon.tmpl
@@ -1,7 +1,7 @@
 <li class="control-menu-nav-item hidden-xs analytics-reports-icon ${cssClass}">
 	<button
 		aria-label="${title}"
-		class="btn btn-monospaced btn-sm lfr-portal-tooltip product-menu-toggle sidenav-toggler"
+		class="btn btn-monospaced btn-sm control-menu-nav-link lfr-portal-tooltip product-menu-toggle sidenav-toggler"
 		data-content="body"
 		data-open-class="lfr-has-analytics-reports-panel open-admin-panel open"
 		data-target="#${portletNamespace}analyticsReportsPanelId"

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/shared/components/header/HeaderBackButton.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/shared/components/header/HeaderBackButton.es.js
@@ -30,7 +30,10 @@ const HeaderBackButton = ({basePath, container}) => {
 			container={container}
 			elementId="backButton"
 		>
-			<Link className="btn-monospaced btn-sm" to={backPath}>
+			<Link
+				className="btn-monospaced btn-sm control-menu-nav-link"
+				to={backPath}
+			>
 				<ClayIcon symbol="angle-left" />
 			</Link>
 		</Portal>

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/com/liferay/segments/experiment/web/internal/product/navigation/control/menu/icon.tmpl
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/com/liferay/segments/experiment/web/internal/product/navigation/control/menu/icon.tmpl
@@ -1,7 +1,7 @@
 <li class="control-menu-nav-item segments-experiment-icon ${cssClass}">
 	<button
 		aria-label="${title}"
-		class="btn btn-monospaced btn-sm lfr-portal-tooltip product-menu-toggle sidenav-toggler"
+		class="btn btn-monospaced btn-sm control-menu-nav-link lfr-portal-tooltip product-menu-toggle sidenav-toggler"
 		data-content="body"
 		data-open-class="open-admin-panel open"
 		data-qa-id="segmentsExperimentPanel"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-18518

This adds the class `control-menu-nav-link` to links and buttons in the Control Menu. We were using the do not match selectors that are difficult to maintain as more items like Feature Indicator are being included in the Control Menu.

![data-set-beta](https://github.com/liferay-platform-experience/liferay-portal/assets/788266/b5db1ff5-32a0-455d-8d2d-fccede9b6610)

![page-audit](https://github.com/liferay-platform-experience/liferay-portal/assets/788266/e417284c-6fb2-47ca-b738-dd0839ba8494)
