### PR TITLE
LPD-7009 read and validate script element attributes from .yaml file for deployed client extension

### DIFF
--- a/modules/sdk/gradle-plugins-workspace/src/gradleTest/clientExtensionTypeGlobalJS/build.gradle
+++ b/modules/sdk/gradle-plugins-workspace/src/gradleTest/clientExtensionTypeGlobalJS/build.gradle
@@ -1,0 +1,17 @@
+task runGradleTest
+
+runGradleTest {
+	dependsOn ":global-js-client-extension:deploy"
+
+	doLast {
+		Project clientExtensionProject = project ":global-js-client-extension"
+
+		File clientExtensionConfigJSONFile = new File(
+			new File(clientExtensionProject.buildDir, "liferay-client-extension-build"),
+			"global-js-client-extension.client-extension-config.json")
+
+		assert clientExtensionConfigJSONFile.exists()
+
+		assert clientExtensionConfigJSONFile.text.contains('scriptElementAttributes={\\"async\\":false,\\"data-bool-false\\":false,\\"data-bool-true\\":true,\\"data-empty\\":\\"\\",\\"data-str-false\\":\\"false\\",\\"data-str-true\\":\\"true\\",\\"defer\\":true,\\"nomodule\\":false}')
+	}
+}

--- a/modules/sdk/gradle-plugins-workspace/src/gradleTest/clientExtensionTypeGlobalJS/global-js-client-extension/client-extension.yaml
+++ b/modules/sdk/gradle-plugins-workspace/src/gradleTest/clientExtensionTypeGlobalJS/global-js-client-extension/client-extension.yaml
@@ -1,0 +1,12 @@
+global-js-client-extension:
+    scriptElementAttributes:
+        async: false
+        data-bool-false: false
+        data-bool-true: true
+        data-empty: ""
+        data-str-false: "false"
+        data-str-true: "true"
+        defer: true
+        nomodule: false
+    type: globalJS
+    url: src/dummy.js

--- a/modules/sdk/gradle-plugins-workspace/src/gradleTest/clientExtensionTypeGlobalJS/settings.gradle
+++ b/modules/sdk/gradle-plugins-workspace/src/gradleTest/clientExtensionTypeGlobalJS/settings.gradle
@@ -1,0 +1,7 @@
+buildscript {
+	dependencies {
+		classpath fileTree(dir: pluginClasspathDir, include: "*.jar")
+	}
+}
+
+apply plugin: "com.liferay.workspace"

--- a/modules/sdk/gradle-plugins-workspace/src/gradleTest/clientExtensionTypeGlobalJSShouldFail/_baseShouldFailTestCase.gradle
+++ b/modules/sdk/gradle-plugins-workspace/src/gradleTest/clientExtensionTypeGlobalJSShouldFail/_baseShouldFailTestCase.gradle
@@ -1,0 +1,30 @@
+task runGradleTest
+
+assert ext.properties.containsKey("taskPath") : "No ext.taskPath extension property set"
+assert ext.properties.containsKey("expectedErrorMessage") : "No ext.expectedErrorMessage extension property set"
+
+gradle.taskGraph.afterTask {
+	Task task, TaskState taskState ->
+
+	if (task.ext.properties.containsKey("expectedErrorMessage")) {
+		assert taskState.failure != null : "expected task ${task.path} to fail"
+
+		String actualErrorMessage = taskState.failure.cause.message
+
+		assert actualErrorMessage.equals(task.ext.expectedErrorMessage)
+
+		taskState.failure = null
+	}
+}
+
+Task task = tasks.getByPath(ext.taskPath)
+
+task.ext.expectedErrorMessage = ext.expectedErrorMessage
+
+runGradleTest {
+	dependsOn task
+
+	doLast {
+		assert true
+	}
+}

--- a/modules/sdk/gradle-plugins-workspace/src/gradleTest/clientExtensionTypeGlobalJSShouldFail/settings.gradle
+++ b/modules/sdk/gradle-plugins-workspace/src/gradleTest/clientExtensionTypeGlobalJSShouldFail/settings.gradle
@@ -1,0 +1,7 @@
+buildscript {
+	dependencies {
+		classpath fileTree(dir: pluginClasspathDir, include: "*.jar")
+	}
+}
+
+apply plugin: "com.liferay.workspace"

--- a/modules/sdk/gradle-plugins-workspace/src/gradleTest/clientExtensionTypeGlobalJSShouldFail/testWhenArrayAttributeIsDefined.gradle
+++ b/modules/sdk/gradle-plugins-workspace/src/gradleTest/clientExtensionTypeGlobalJSShouldFail/testWhenArrayAttributeIsDefined.gradle
@@ -1,0 +1,4 @@
+ext.expectedErrorMessage = "The value for the attribute 'att' must be a scalar"
+ext.taskPath = ":with-array-attribute-global-js-client-extension:validateClientExtensions"
+
+apply from: "./_baseShouldFailTestCase.gradle"

--- a/modules/sdk/gradle-plugins-workspace/src/gradleTest/clientExtensionTypeGlobalJSShouldFail/testWhenMapAttributeIsDefined.gradle
+++ b/modules/sdk/gradle-plugins-workspace/src/gradleTest/clientExtensionTypeGlobalJSShouldFail/testWhenMapAttributeIsDefined.gradle
@@ -1,0 +1,4 @@
+ext.expectedErrorMessage = "The value for the attribute 'att' must be a scalar"
+ext.taskPath = ":with-map-attribute-global-js-client-extension:validateClientExtensions"
+
+apply from: "./_baseShouldFailTestCase.gradle"

--- a/modules/sdk/gradle-plugins-workspace/src/gradleTest/clientExtensionTypeGlobalJSShouldFail/testWhenSrcAttributeIsDefined.gradle
+++ b/modules/sdk/gradle-plugins-workspace/src/gradleTest/clientExtensionTypeGlobalJSShouldFail/testWhenSrcAttributeIsDefined.gradle
@@ -1,0 +1,4 @@
+ext.expectedErrorMessage = "Use the 'url' property instead of the script attribute 'src'"
+ext.taskPath = ":with-src-global-js-client-extension:validateClientExtensions"
+
+apply from: "./_baseShouldFailTestCase.gradle"

--- a/modules/sdk/gradle-plugins-workspace/src/gradleTest/clientExtensionTypeGlobalJSShouldFail/with-array-attribute-global-js-client-extension/client-extension.yaml
+++ b/modules/sdk/gradle-plugins-workspace/src/gradleTest/clientExtensionTypeGlobalJSShouldFail/with-array-attribute-global-js-client-extension/client-extension.yaml
@@ -1,0 +1,7 @@
+with-array-attribute-global-js-client-extension:
+    scriptElementAttributes:
+        att:
+            - a
+            - b
+    type: globalJS
+    url: src/dummy.js

--- a/modules/sdk/gradle-plugins-workspace/src/gradleTest/clientExtensionTypeGlobalJSShouldFail/with-map-attribute-global-js-client-extension/client-extension.yaml
+++ b/modules/sdk/gradle-plugins-workspace/src/gradleTest/clientExtensionTypeGlobalJSShouldFail/with-map-attribute-global-js-client-extension/client-extension.yaml
@@ -1,0 +1,7 @@
+with-map-attribute-global-js-client-extension:
+    scriptElementAttributes:
+        att:
+            a: a
+            b: b
+    type: globalJS
+    url: src/dummy.js

--- a/modules/sdk/gradle-plugins-workspace/src/gradleTest/clientExtensionTypeGlobalJSShouldFail/with-src-global-js-client-extension/client-extension.yaml
+++ b/modules/sdk/gradle-plugins-workspace/src/gradleTest/clientExtensionTypeGlobalJSShouldFail/with-src-global-js-client-extension/client-extension.yaml
@@ -1,0 +1,5 @@
+with-src-global-js-client-extension:
+    scriptElementAttributes:
+        src: src/dummy.js
+    type: globalJS
+    url: src/dummy.js

--- a/modules/sdk/gradle-plugins-workspace/src/main/java/com/liferay/gradle/plugins/workspace/configurator/ClientExtensionProjectConfigurator.java
+++ b/modules/sdk/gradle-plugins-workspace/src/main/java/com/liferay/gradle/plugins/workspace/configurator/ClientExtensionProjectConfigurator.java
@@ -47,6 +47,7 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
@@ -1141,12 +1142,13 @@ public class ClientExtensionProjectConfigurator
 			_validateRequiredTypeSettingsKeys(
 				clientExtension, "oAuthApplicationHeadlessServer");
 		}
-
-		if (Objects.equals(clientExtension.type, "instanceSettings")) {
+		else if (Objects.equals(clientExtension.type, "globalJS")) {
+			_validateGlobalJSScriptElementAttributes(clientExtension);
+		}
+		else if (Objects.equals(clientExtension.type, "instanceSettings")) {
 			_validateRequiredTypeSettingsKeys(clientExtension, "pid");
 		}
-
-		if (Objects.equals(clientExtension.type, "siteInitializer")) {
+		else if (Objects.equals(clientExtension.type, "siteInitializer")) {
 			_validateRequiredDirectory(
 				clientExtension, project, "site-initializer");
 			_validateRequiredTypeSettingsKeys(
@@ -1158,6 +1160,53 @@ public class ClientExtensionProjectConfigurator
 			_validateTypeSettingsValues(
 				clientExtension, "membershipType", "open", "private",
 				"restricted");
+		}
+	}
+
+	private void _validateGlobalJSScriptElementAttributes(
+		ClientExtension clientExtension) {
+
+		Map<String, Object> typeSettings = clientExtension.typeSettings;
+
+		if (!typeSettings.containsKey("scriptElementAttributes")) {
+			return;
+		}
+
+		Object scriptElementAttributes = typeSettings.get(
+			"scriptElementAttributes");
+
+		if (!(scriptElementAttributes instanceof Map)) {
+			throw new GradleException(
+				"The property 'scriptElementAttributes' must be an object");
+		}
+
+		Map<String, Object> scriptElementAttributesMap =
+			(Map<String, Object>)scriptElementAttributes;
+
+		for (Map.Entry<String, Object> entry :
+				scriptElementAttributesMap.entrySet()) {
+
+			if (Objects.equals(entry.getKey(), "src")) {
+				throw new GradleException(
+					"Use the 'url' property instead of the script attribute " +
+						"'src'");
+			}
+
+			Object value = entry.getValue();
+
+			if (value == null) {
+				throw new GradleException(
+					StringBundler.concat(
+						"A value for the attribute '", entry.getKey(),
+						"' must be specified"));
+			}
+
+			if (value instanceof List || value instanceof Map) {
+				throw new GradleException(
+					StringBundler.concat(
+						"The value for the attribute '", entry.getKey(),
+						"' must be a scalar"));
+			}
 		}
 	}
 

--- a/modules/sdk/gradle-plugins-workspace/src/main/java/com/liferay/gradle/plugins/workspace/task/CreateClientExtensionConfigTask.java
+++ b/modules/sdk/gradle-plugins-workspace/src/main/java/com/liferay/gradle/plugins/workspace/task/CreateClientExtensionConfigTask.java
@@ -116,6 +116,11 @@ public class CreateClientExtensionConfigTask extends DefaultTask {
 				batchType = "batch";
 			}
 
+			if (Objects.equals(clientExtension.type, "globalJS")) {
+				_mapGlobalJSScriptElementAttributesToJSONString(
+					clientExtension);
+			}
+
 			if (clientExtension.type.equals("siteInitializer")) {
 				pluginPackageProperties.put(
 					"Liferay-Client-Extension-Site-Initializer",
@@ -489,6 +494,42 @@ public class CreateClientExtensionConfigTask extends DefaultTask {
 		}
 
 		return false;
+	}
+
+	private void _mapGlobalJSScriptElementAttributesToJSONString(
+		ClientExtension clientExtension) {
+
+		Map<String, Object> typeSettings = clientExtension.typeSettings;
+
+		Map<String, Object> scriptElementAttributesMap =
+			(Map<String, Object>)typeSettings.get("scriptElementAttributes");
+
+		if (scriptElementAttributesMap == null) {
+			return;
+		}
+
+		Set<Map.Entry<String, Object>> entrySet =
+			scriptElementAttributesMap.entrySet();
+
+		ObjectNode scriptElementAttributesObjectNode =
+			_objectMapper.createObjectNode();
+
+		for (Map.Entry<String, Object> entry : entrySet) {
+			Object value = entry.getValue();
+
+			if (value instanceof Boolean) {
+				scriptElementAttributesObjectNode.put(
+					entry.getKey(), (Boolean)value);
+			}
+			else {
+				scriptElementAttributesObjectNode.put(
+					entry.getKey(), (String)value);
+			}
+		}
+
+		typeSettings.put(
+			"scriptElementAttributes",
+			scriptElementAttributesObjectNode.toString());
 	}
 
 	private void _processBatchJSONFile(File file) throws IOException {

--- a/modules/sdk/gradle-plugins-workspace/src/main/resources/schemas/client-extension.schema.json
+++ b/modules/sdk/gradle-plugins-workspace/src/main/resources/schemas/client-extension.schema.json
@@ -217,6 +217,27 @@
 					"allOf": [
 						{
 							"$ref": "#/definitions/propertySets/properties/url"
+						},
+						{
+							"properties": {
+								"scriptElementAttributes": {
+									"additionalProperties": {
+										"type": [
+											"boolean",
+											"integer",
+											"number",
+											"string"
+										]
+									},
+									"description": "A list of HTML attributes that will be added to the script element.",
+									"properties": {
+										"src": false
+									},
+									"title": "Script Element Attributes",
+									"type": "object"
+								}
+							},
+							"type": "object"
 						}
 					],
 					"description": "Description for globalJS"


### PR DESCRIPTION
This is the second part of #492 ([part 1](https://github.com/liferay-platform-experience/liferay-portal/pull/507)). 

Adding validation and mapping to `scriptElementAttributes`