### PR TITLE
LPD-4984 Fix the warning message with non-plain text content is not c…

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/VerticalNav.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/VerticalNav.js
@@ -41,6 +41,7 @@ export default function VerticalNav({
 					href={item.href}
 					items={item.items}
 					key={item.id}
+					textValue={item.label}
 				>
 					{item.label}
 


### PR DESCRIPTION
…ompatible with the type being selected

https://liferay.atlassian.net/browse/LPD-4984

I couldn't figure this one out. @matuzalemsteles do you happen to know why the error message, `@clayui$core.js:2 Clay: <Item key="Accessibility Menu" /> with non-plain text content is not compatible with the type being selected. Please add a 'textValue' prop.`, pops up on https://github.com/liferay/liferay-portal/blob/fe27dbca8c5695b10dc158e42258aed97e5d7f36/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/VerticalNav.js#L39-L44?

When I pass in `textValue={item.id}` the error goes away, but this seems incorrect. I'm not sure what https://github.com/liferay/clay/blob/5c05be4ee081d074a59095145f0397277ebf97f7/packages/clay-core/src/vertical-nav/Item.tsx#L93 is for and if the correct fix should be placed in https://github.com/liferay/clay/blob/5c05be4ee081d074a59095145f0397277ebf97f7/packages/clay-core/src/collection/useCollection.tsx#L502-L522 or if we need to correct it in `configuration-admin-web`.

Edit: So I think the reason is we're assembling the JS object incorrectly? `props.children` should be a string, but in this case it's an array.

```
{
  "active": true,
  "href": "...",
  "children": [
    "Accessibility Menu",
    null
  ]
}
```