### PR TITLE
LPD-7010 (follow up) Read and validate script element attributes from UI client extension

### DIFF
--- a/modules/apps/client-extension/client-extension-type-impl/src/main/java/com/liferay/client/extension/type/internal/factory/CETFactoryImpl.java
+++ b/modules/apps/client-extension/client-extension-type-impl/src/main/java/com/liferay/client/extension/type/internal/factory/CETFactoryImpl.java
@@ -250,7 +250,7 @@ public class CETFactoryImpl implements CETFactory {
 			new GlobalCSSCETImplFactoryImpl()
 		).put(
 			ClientExtensionEntryConstants.TYPE_GLOBAL_JS,
-			new GlobalJSCETImplFactoryImpl()
+			new GlobalJSCETImplFactoryImpl(_jsonFactory)
 		).put(
 			ClientExtensionEntryConstants.TYPE_IFRAME,
 			new IFrameCETImplFactoryImpl()

--- a/modules/apps/client-extension/client-extension-type-impl/src/main/java/com/liferay/client/extension/type/internal/factory/GlobalJSCETImplFactoryImpl.java
+++ b/modules/apps/client-extension/client-extension-type-impl/src/main/java/com/liferay/client/extension/type/internal/factory/GlobalJSCETImplFactoryImpl.java
@@ -9,6 +9,9 @@ import com.liferay.client.extension.exception.ClientExtensionEntryTypeSettingsEx
 import com.liferay.client.extension.type.GlobalJSCET;
 import com.liferay.client.extension.type.internal.GlobalJSCETImpl;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
@@ -16,6 +19,7 @@ import com.liferay.portal.kernel.util.Validator;
 
 import java.util.Date;
 import java.util.Properties;
+import java.util.Set;
 
 import javax.portlet.PortletRequest;
 
@@ -25,8 +29,10 @@ import javax.portlet.PortletRequest;
 public class GlobalJSCETImplFactoryImpl
 	extends BaseCETImplFactoryImpl<GlobalJSCET> {
 
-	public GlobalJSCETImplFactoryImpl() {
+	public GlobalJSCETImplFactoryImpl(JSONFactory jsonFactory) {
 		super(GlobalJSCET.class);
+
+		_jsonFactory = jsonFactory;
 	}
 
 	@Override
@@ -49,6 +55,9 @@ public class GlobalJSCETImplFactoryImpl
 		return UnicodePropertiesBuilder.create(
 			true
 		).put(
+			"scriptElementAttributesJSON",
+			ParamUtil.getString(portletRequest, "scriptElementAttributesJSON")
+		).put(
 			"url", ParamUtil.getString(portletRequest, "url")
 		).build();
 	}
@@ -64,6 +73,24 @@ public class GlobalJSCETImplFactoryImpl
 				"Invalid JavaScript URL: " + url, "javascript-url-x-is-invalid",
 				url);
 		}
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-10981")) {
+			return;
+		}
+
+		JSONObject scriptElementAttributesJSONObject =
+			_jsonFactory.createJSONObject(
+				newGlobalJSCET.getScriptElementAttributesJSON());
+
+		Set<String> keySet = scriptElementAttributesJSONObject.keySet();
+
+		if (keySet.contains("src")) {
+			throw new ClientExtensionEntryTypeSettingsException(
+				"Use the 'JavaScript URL' field instead of the attribute 'src'",
+				"use-the-javascript-url-field-instead-of-the-attribute-src");
+		}
 	}
+
+	private final JSONFactory _jsonFactory;
 
 }

--- a/modules/apps/client-extension/client-extension-web/src/main/resources/META-INF/resources/admin/edit_global_js.jsp
+++ b/modules/apps/client-extension/client-extension-web/src/main/resources/META-INF/resources/admin/edit_global_js.jsp
@@ -25,6 +25,11 @@ GlobalJSCET globalJSCET = editClientExtensionEntryDisplayContext.getCET();
 	<aui:field-wrapper cssClass="form-group">
 		<react:component
 			module="{ScriptElementAttributesFormField} from client-extension-web"
+			props='<%=
+				HashMapBuilder.<String, Object>put(
+					"attributes", globalJSCET.getScriptElementAttributesJSON()
+				).build()
+			%>'
 		/>
 	</aui:field-wrapper>
 </c:if>

--- a/modules/apps/client-extension/client-extension-web/src/main/resources/META-INF/resources/admin/edit_global_js.jsp
+++ b/modules/apps/client-extension/client-extension-web/src/main/resources/META-INF/resources/admin/edit_global_js.jsp
@@ -27,7 +27,7 @@ GlobalJSCET globalJSCET = editClientExtensionEntryDisplayContext.getCET();
 			module="{ScriptElementAttributesFormField} from client-extension-web"
 			props='<%=
 				HashMapBuilder.<String, Object>put(
-					"attributes", globalJSCET.getScriptElementAttributesJSON()
+					"scriptElementAttributesJSON", globalJSCET.getScriptElementAttributesJSON()
 				).build()
 			%>'
 		/>

--- a/modules/apps/client-extension/client-extension-web/src/main/resources/META-INF/resources/js/components/global-js/AttributeFields.tsx
+++ b/modules/apps/client-extension/client-extension-web/src/main/resources/META-INF/resources/js/components/global-js/AttributeFields.tsx
@@ -133,7 +133,9 @@ export default function AttributeFields({
 							id={valueId}
 							items={BOOLEAN_VALUE_ITEMS}
 							onSelectionChange={(value) =>
-								onAttributeChange(index, {value})
+								onAttributeChange(index, {
+									value: JSON.parse(value),
+								})
 							}
 						>
 							{(item) => (
@@ -169,7 +171,7 @@ export default function AttributeFields({
 								)}
 								className="btn btn-primary btn-xs dm-field-repeatable-add-button ml-1 rounded-pill"
 								onClick={() =>
-									name
+									name.trim()
 										? onAddClick(index)
 										: setErrorMessage(
 												Liferay.Language.get(

--- a/modules/apps/client-extension/client-extension-web/src/main/resources/META-INF/resources/js/components/global-js/ScriptElementAttributesFormField.tsx
+++ b/modules/apps/client-extension/client-extension-web/src/main/resources/META-INF/resources/js/components/global-js/ScriptElementAttributesFormField.tsx
@@ -11,9 +11,17 @@ import AttributeFields, {TYPE_BOOLEAN, TYPE_STRING} from './AttributeFields';
 const emptyRow = () => ({id: uuidv4(), name: '', type: TYPE_STRING, value: ''});
 
 const toJSONObjectString = (attributes) => {
+	const validAttributes = attributes.filter((attribute) =>
+		attribute.name.trim()
+	);
+
+	if (!validAttributes.length) {
+		return '';
+	}
+
 	const attributesObject = {};
 
-	attributes.map((attribute) => {
+	validAttributes.map((attribute) => {
 		let value = attribute.value;
 
 		if (attribute.type === 'Boolean') {
@@ -28,31 +36,33 @@ const toJSONObjectString = (attributes) => {
 	return JSON.stringify(attributesObject);
 };
 
+const parseAttributes = (attributes: string) => {
+	const scriptElementAttributesJSONObject: {
+		[key: string]: boolean | string;
+	} = JSON.parse(attributes);
+
+	return Object.keys(scriptElementAttributesJSONObject).map((key) => ({
+		id: uuidv4(),
+		name: key,
+		type:
+			typeof scriptElementAttributesJSONObject[key] === 'boolean'
+				? TYPE_BOOLEAN
+				: TYPE_STRING,
+		value: scriptElementAttributesJSONObject[key],
+	}));
+};
+
 interface IProps {
-	attributes?: {
-		name: string;
-		value: boolean | string;
-	}[];
 	portletNamespace: string;
+	scriptElementAttributesJSON?: string;
 }
 
 export default function ScriptElementAttributesFormField({
-	attributes: initialAttributes,
 	portletNamespace,
+	scriptElementAttributesJSON: initialAttributes,
 }: IProps) {
 	const [attributes, setAttributes] = useState(() =>
-		initialAttributes && !!initialAttributes.length
-			? [
-					initialAttributes.map((attribute) => ({
-						...attribute,
-						id: uuidv4(),
-						type:
-							typeof attribute.value === 'boolean'
-								? TYPE_BOOLEAN
-								: TYPE_STRING,
-					})),
-			  ]
-			: [emptyRow()]
+		initialAttributes ? parseAttributes(initialAttributes) : [emptyRow()]
 	);
 
 	const handleAddClick = (index) => {
@@ -72,7 +82,7 @@ export default function ScriptElementAttributesFormField({
 	return (
 		<>
 			<input
-				name={`${portletNamespace}scriptElementAttributes`}
+				name={`${portletNamespace}scriptElementAttributesJSON`}
 				type="hidden"
 				value={toJSONObjectString(attributes)}
 			/>


### PR DESCRIPTION
Adding the validation for scriptElementAttributesJSON field coming from the Frontend. 

- I updated the way FE receives the attributes, it was expecting an array, but the data is stored as JSON string and it doesn't make sense for the BE to translate it to an array and send to the FE.
- I also found two issues on the FE:
    - It was sending an empty object `{}` when the attributes were empty, it should send an empty string
    - An boolean with false value was being translated to String due to [this](https://github.com/liferay-platform-experience/liferay-portal/pull/529/files#diff-c025c4b1e4ac02274998fbdd17f17a7a03acdb88ea20098f96dc71808d8e495cR137)