### PR TITLE
LPD-6579 Applying and Configuring JS Client Extension with Script Element Attributes on a given page or page set

### DIFF
--- a/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/internal/service/taglib/BaseDynamicInclude.java
+++ b/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/internal/service/taglib/BaseDynamicInclude.java
@@ -107,11 +107,15 @@ public abstract class BaseDynamicInclude implements DynamicInclude {
 				printWriter.print(
 					_toScriptElementAttributes(
 						globalJSCET.getScriptElementAttributesJSON()));
+				printWriter.print(" src=\"");
+				printWriter.print(globalJSCET.getURL());
+				printWriter.print("\"></script>");
 			}
-
-			printWriter.print(" data-senna-track=\"temporary\" src=\"");
-			printWriter.print(globalJSCET.getURL());
-			printWriter.print("\" type=\"text/javascript\"></script>");
+			else {
+				printWriter.print(" data-senna-track=\"temporary\" src=\"");
+				printWriter.print(globalJSCET.getURL());
+				printWriter.print("\" type=\"text/javascript\"></script>");
+			}
 		}
 	}
 
@@ -134,8 +138,20 @@ public abstract class BaseDynamicInclude implements DynamicInclude {
 
 			Iterator<String> iterator = jsonObject.keys();
 
+			if (!jsonObject.has("data-senna-track")) {
+				stringBuilder.append("data-senna-track=\"temporary\" ");
+			}
+
+			if (!jsonObject.has("type")) {
+				stringBuilder.append("type=\"text/javascript\" ");
+			}
+
 			while (iterator.hasNext()) {
 				String key = iterator.next();
+
+				if (key.equals("async") || key.equals("defer")) {
+					continue;
+				}
 
 				Object value = jsonObject.get(key);
 

--- a/modules/apps/client-extension/client-extension-type-item-selector-web/src/main/java/com/liferay/client/extension/type/item/selector/web/internal/item/selector/CETItemDescriptor.java
+++ b/modules/apps/client-extension/client-extension-type-item-selector-web/src/main/java/com/liferay/client/extension/type/item/selector/web/internal/item/selector/CETItemDescriptor.java
@@ -7,8 +7,10 @@ package com.liferay.client.extension.type.item.selector.web.internal.item.select
 
 import com.liferay.client.extension.constants.ClientExtensionEntryConstants;
 import com.liferay.client.extension.type.CET;
+import com.liferay.client.extension.type.GlobalJSCET;
 import com.liferay.client.extension.type.ThemeFaviconCET;
 import com.liferay.item.selector.ItemSelectorViewDescriptor;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 
@@ -47,6 +49,21 @@ public class CETItemDescriptor
 			"cetExternalReferenceCode", _cet.getExternalReferenceCode()
 		).put(
 			"name", _cet.getName(LocaleUtil.getMostRelevantLocale())
+		).put(
+			"scriptElementAttributesJSON",
+			() -> {
+				if (Objects.equals(
+						_cet.getType(),
+						ClientExtensionEntryConstants.TYPE_GLOBAL_JS) &&
+					FeatureFlagManagerUtil.isEnabled("LPD-10981")) {
+
+					GlobalJSCET globalJSCET = (GlobalJSCET)_cet;
+
+					return globalJSCET.getScriptElementAttributesJSON();
+				}
+
+				return null;
+			}
 		).put(
 			"type", _cet.getType()
 		).put(

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutLookAndFeelDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutLookAndFeelDisplayContext.java
@@ -9,6 +9,7 @@ import com.liferay.client.extension.constants.ClientExtensionEntryConstants;
 import com.liferay.client.extension.model.ClientExtensionEntryRel;
 import com.liferay.client.extension.service.ClientExtensionEntryRelLocalServiceUtil;
 import com.liferay.client.extension.type.CET;
+import com.liferay.client.extension.type.GlobalJSCET;
 import com.liferay.client.extension.type.manager.CETManager;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.TabsItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.TabsItemListBuilder;
@@ -21,6 +22,7 @@ import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeCon
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalServiceUtil;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
@@ -439,6 +441,21 @@ public class LayoutLookAndFeelDisplayContext {
 			() -> typeSettingsUnicodeProperties.getProperty("loadType", null)
 		).put(
 			"name", cet.getName(_themeDisplay.getLocale())
+		).put(
+			"scriptElementAttributesJSON",
+			() -> {
+				if (Objects.equals(
+						cet.getType(),
+						ClientExtensionEntryConstants.TYPE_GLOBAL_JS) &&
+					FeatureFlagManagerUtil.isEnabled("LPD-10981")) {
+
+					GlobalJSCET globalJSCET = (GlobalJSCET)cet;
+
+					return globalJSCET.getScriptElementAttributesJSON();
+				}
+
+				return null;
+			}
 		).put(
 			"scriptLocation",
 			() -> typeSettingsUnicodeProperties.getProperty(

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/layout/look_and_feel/GlobalJSCETsConfiguration.tsx
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/layout/look_and_feel/GlobalJSCETsConfiguration.tsx
@@ -36,6 +36,33 @@ const SCRIPT_LOCATION_LABELS: Array<{
 
 const DEFAULT_SCRIPT_LOCATION_OPTION: IScriptLocationOptions = 'bottom';
 
+const getLoadTypeOptions = (scriptElementAttributesJSON: any) => {
+	const loadTypeOptions = LOAD_TYPE_OPTIONS;
+
+	if (!scriptElementAttributesJSON) {
+		return loadTypeOptions;
+	}
+
+	return loadTypeOptions.filter(
+		(option) => scriptElementAttributesJSON[option.label] !== false
+	);
+};
+
+const getPredefinedLoadType = (scriptElementAttributesJSON: any) => {
+	if (!scriptElementAttributesJSON) {
+		return null;
+	}
+
+	if (scriptElementAttributesJSON.async) {
+		return 'async';
+	}
+	else if (scriptElementAttributesJSON.defer) {
+		return 'defer';
+	}
+
+	return null;
+};
+
 export default function GlobalJSCETsConfiguration({
 	globalJSCETSelectorURL,
 	globalJSCETs: initialGlobalJSCETs,
@@ -369,6 +396,17 @@ function ExtensionRow({
 	const disabled = globalJSCET.inherited;
 	const dropdownTriggerId = `${portletNamespace}_GlobalJSCETsConfigurationOptionsButton_${globalJSCET.cetExternalReferenceCode}`;
 
+	const scriptElementAttributesJSONString =
+		globalJSCET.scriptElementAttributesJSON;
+
+	const scriptElementAttributesJSON = useMemo(() => {
+		if (!scriptElementAttributesJSONString) {
+			return null;
+		}
+
+		return JSON.parse(scriptElementAttributesJSONString);
+	}, [scriptElementAttributesJSONString]);
+
 	const dropdownItems = [
 		{
 			label: Liferay.Language.get('delete'),
@@ -376,6 +414,18 @@ function ExtensionRow({
 			symbolLeft: 'trash',
 		},
 	];
+
+	const predefinedLoadType = getPredefinedLoadType(
+		scriptElementAttributesJSON
+	);
+
+	if (predefinedLoadType && predefinedLoadType !== globalJSCET.loadType) {
+		updateGlobalJSCET(
+			globalJSCET,
+			'loadType',
+			predefinedLoadType as ILoadTypeOptions
+		);
+	}
 
 	return (
 		<ClayTable.Row
@@ -392,9 +442,11 @@ function ExtensionRow({
 				<ClaySelectWithOption
 					className="load-type-select"
 					defaultValue={
-						globalJSCET.loadType || DEFAULT_LOAD_TYPE_OPTION
+						globalJSCET.loadType ||
+						predefinedLoadType ||
+						DEFAULT_LOAD_TYPE_OPTION
 					}
-					disabled={disabled}
+					disabled={disabled || !!predefinedLoadType}
 					onChange={(event) =>
 						updateGlobalJSCET(
 							globalJSCET,
@@ -402,7 +454,7 @@ function ExtensionRow({
 							event.target.value as ILoadTypeOptions
 						)
 					}
-					options={LOAD_TYPE_OPTIONS}
+					options={getLoadTypeOptions(scriptElementAttributesJSON)}
 					sizing="sm"
 				/>
 			</ClayTable.Cell>
@@ -428,6 +480,7 @@ interface IGlobalJSCET {
 	inheritedLabel: string;
 	loadType?: ILoadTypeOptions;
 	name: string;
+	scriptElementAttributesJSON?: string;
 	scriptLocation?: IScriptLocationOptions;
 }
 

--- a/modules/apps/layout/layout-admin-web/types/src/main/resources/META-INF/resources/js/layout/look_and_feel/GlobalJSCETsConfiguration.d.ts
+++ b/modules/apps/layout/layout-admin-web/types/src/main/resources/META-INF/resources/js/layout/look_and_feel/GlobalJSCETsConfiguration.d.ts
@@ -20,6 +20,7 @@ interface IGlobalJSCET {
 	inheritedLabel: string;
 	loadType?: ILoadTypeOptions;
 	name: string;
+	scriptElementAttributesJSON?: string;
 	scriptLocation?: IScriptLocationOptions;
 }
 interface IProps {


### PR DESCRIPTION
[LPD-18885](https://liferay.atlassian.net/browse/LPD-18885)

When configuring the JavaScript Client Extensions on a page (via Control Menu > Configure Page > Design > Customization > JavaScript):

If `async`/`defer` Boolean attributes are present in the CX, then:

- The value set in the CX will be used and the ability to change it when assigning to a page is be disabled.
    - When both attributes are set, `async` is going to be applied.
- If async/defer Boolean attributes are NOT PRESENT in the CX: the user can choose from the dropdown when applying on a page as-is now.
- If async/defer is set to `false`, the option will be removed from the dropdown.
- Both `data-senna-track` and `type` attributes should be able to be overridden.


## Preview

https://github.com/liferay-platform-experience/liferay-portal/assets/57292581/22962e75-7126-4b53-8250-23993410d03b



