### PR TITLE
LPD-24216 check if configuration screen is visible before adding to search result

### DIFF
--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/portlet/action/SearchResultsMVCRenderCommand.java
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/portlet/action/SearchResultsMVCRenderCommand.java
@@ -127,7 +127,9 @@ public class SearchResultsMVCRenderCommand implements MVCRenderCommand {
 			for (ConfigurationScreen configurationScreen :
 					_configurationEntryRetriever.getAllConfigurationScreens()) {
 
-				if (!scope.equals(configurationScreen.getScope())) {
+				if (!configurationScreen.isVisible() ||
+					!scope.equals(configurationScreen.getScope())) {
+
 					continue;
 				}
 


### PR DESCRIPTION
Context:
We are hiding some configurations using the Feature Flag, one of those configurations uses a customized screen (`com.liferay.portal.security.script.management.web.internal.configuration.admin.display.ScriptManagementConfigurationScreen`). Even if we add the Feature Flag annotation on `ScriptManagementConfiguration` class the configuration still appears when the user search for the configuration title. I noticed that this happens because the ConfigurationScreen is being considered for the search result even if it is not visible.
Let me know if more details are needed.

https://liferay.atlassian.net/issues/LPD-2419
https://liferay.atlassian.net/browse/LPD-24216