### PR TITLE
LPD-24216 check if configuration screen is visible before adding to search result

### DIFF
--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/portlet/action/SearchResultsMVCRenderCommand.java
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/portlet/action/SearchResultsMVCRenderCommand.java
@@ -127,7 +127,9 @@ public class SearchResultsMVCRenderCommand implements MVCRenderCommand {
 			for (ConfigurationScreen configurationScreen :
 					_configurationEntryRetriever.getAllConfigurationScreens()) {
 
-				if (!scope.equals(configurationScreen.getScope())) {
+				if (!configurationScreen.isVisible() ||
+					!scope.equals(configurationScreen.getScope())) {
+
 					continue;
 				}
 


### PR DESCRIPTION
~~Just noticed a small improvement on the `ConfigurationEntryRetriever`. Currently the client code, i.e. `SearchResultsMVCRenderCommand`, is handling the filtering for `ConfigurationScreen` by visibility and scope. Since that's the only usage of the method and getting visible `ConfigurationScreens` is the usual, I create a method for that on `ConfigurationEntryRetriever`~~

The above is over-engineering, talked to Brian, learned something new :D (when is _necessary_ to do). Removing the commit.


## Original description
=====
Context:
We are hiding some configurations using the Feature Flag, one of those configurations uses a customized screen (`com.liferay.portal.security.script.management.web.internal.configuration.admin.display.ScriptManagementConfigurationScreen`). Even if we add the Feature Flag annotation on `ScriptManagementConfiguration` class the configuration still appears when the user search for the configuration title. I noticed that this happens because the ConfigurationScreen is being considered for the search result even if it is not visible.
Let me know if more details are needed.

https://liferay.atlassian.net/issues/LPD-2419
https://liferay.atlassian.net/browse/LPD-24216