### PR TITLE
LPD-24799 - Make sure all images using imgSrcReducedMotion match imgSrc

### DIFF
--- a/modules/apps/feature-flag/feature-flag-web/src/main/resources/META-INF/resources/js/FeatureFlagList.tsx
+++ b/modules/apps/feature-flag/feature-flag-web/src/main/resources/META-INF/resources/js/FeatureFlagList.tsx
@@ -40,7 +40,7 @@ const FeatureFlagList: React.FC<IFeatureFlagListProps> = ({featureFlags}) => {
 						),
 					}}
 					imgSrc={`${Liferay.ThemeDisplay.getPathThemeImages()}/states/search_state.svg`}
-					imgSrcReducedMotion={`${Liferay.ThemeDisplay.getPathThemeImages()}/states/empty_state_reduced_motion.svg`}
+					imgSrcReducedMotion={`${Liferay.ThemeDisplay.getPathThemeImages()}/states/search_state_reduced_motion.svg`}
 				/>
 			)}
 


### PR DESCRIPTION
Jira issue: https://liferay.atlassian.net/browse/LPD-24799

This PR is a follow-up to ensure the path on `imgSrc` matches `imgSrcReducedMotion`.