### PR TITLE
LPD-22076 - Attribute Name with Space: Parsed as Flag and Attribute

### DIFF
--- a/modules/apps/client-extension/client-extension-web/src/main/resources/META-INF/resources/js/components/global-js/AttributeFields.tsx
+++ b/modules/apps/client-extension/client-extension-web/src/main/resources/META-INF/resources/js/components/global-js/AttributeFields.tsx
@@ -64,16 +64,29 @@ export default function AttributeFields({
 					disabled={disabled}
 					errorMessage={errorMessage}
 					id={nameId}
-					label={Liferay.Language.get('attribute')}
+					label={
+						<>
+							{Liferay.Language.get('attribute')}
+
+							<span className="sr-only">
+								{Liferay.Language.get('spaces-are-not-allowed')}
+							</span>
+						</>
+					}
 					required
 				>
 					<ClayInput
+						aria-describedby={`${nameId}fieldFeedback`}
 						aria-required={true}
 						defaultValue={name}
 						disabled={disabled}
 						id={nameId}
-						onChange={({target}) => {
-							if (target.value.toLowerCase().trim() === 'src') {
+						onChange={(event) => {
+							const value = event.target.value
+								.split(' ')
+								.join('');
+
+							if (value.toLowerCase() === 'src') {
 								setErrorMessage(
 									Liferay.Language.get(
 										'use-the-javascript-url-field'
@@ -84,7 +97,9 @@ export default function AttributeFields({
 								setErrorMessage(null);
 							}
 
-							onAttributeChange(index, {name: target.value});
+							onAttributeChange(index, {
+								name: value,
+							});
 						}}
 						type="text"
 						value={name}

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
@@ -16988,6 +16988,7 @@ spacer-9=Spacer 9
 spacer-10=Spacer 10
 spacer-options=Spacer Options
 spacers=Spacers
+spaces-are-not-allowed=Spaces are not allowed.
 spacing=Spacing
 spam=Spam
 spanish=Spanish


### PR DESCRIPTION
Jira issue: https://liferay.atlassian.net/browse/LPD-22076

**Issues**

- If we add an attribute name with a space between the words, the first word is added in the script as a flag, and the second word as the real attribute;
