### PR TITLE
LPD-19915 return 404 when feature flag not found or 500 when generic internal error

### DIFF
--- a/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/jaxrs/application/FeatureFlagApplication.java
+++ b/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/jaxrs/application/FeatureFlagApplication.java
@@ -95,13 +95,8 @@ public class FeatureFlagApplication extends Application {
 			FeatureFlag featureFlag = featureFlagsBag.getFeatureFlag(key);
 
 			if (featureFlag == null) {
-				return Response.ok(
-					HashMapBuilder.<String, Object>put(
-						"error",
-						"Feature flag \"" + HtmlUtil.escape(key) +
-							"\" is not available"
-					).build(),
-					MediaType.APPLICATION_JSON
+				return Response.status(
+					Response.Status.NOT_FOUND
 				).build();
 			}
 
@@ -120,11 +115,10 @@ public class FeatureFlagApplication extends Application {
 			).build();
 		}
 		catch (Exception exception) {
-			return Response.ok(
-				HashMapBuilder.<String, Object>put(
-					"error", exception.toString()
-				).build(),
-				MediaType.APPLICATION_JSON
+			_log.error(exception);
+
+			return Response.status(
+				Response.Status.INTERNAL_SERVER_ERROR
 			).build();
 		}
 	}

--- a/modules/test/playwright/fixtures/featureFlagsTest.ts
+++ b/modules/test/playwright/fixtures/featureFlagsTest.ts
@@ -12,7 +12,7 @@ export interface FeatureFlagsOptions {
 }
 
 export interface FeatureFlag {
-	readonly enabled: boolean;
+	readonly enabled?: boolean;
 	readonly key: string;
 }
 
@@ -67,10 +67,6 @@ function featureFlagsTest(options: FeatureFlagsOptions) {
 							key,
 						}
 					);
-
-					if (reply.error) {
-						throw new Error(reply.error);
-					}
 
 					const {result} = reply;
 
@@ -161,7 +157,7 @@ interface FeatureFlagResult {
 async function invokeServer<T>(
 	page: Page,
 	url: string,
-	partialBody: object
+	partialBody: FeatureFlag
 ): Promise<ServerReply<T>> {
 	return await page.evaluate(
 		async ({partialBody, url}) =>
@@ -173,20 +169,28 @@ async function invokeServer<T>(
 					}),
 					method: 'POST',
 				})
-					.then((response) => response.text())
-					.then((text) => {
-						const json = JSON.parse(text);
+					.then(async (response) => {
+						if (!response?.ok) {
+							if (response?.status === 404) {
+								reject(
+									`Feature flag "${partialBody.key}" is not available`
+								);
+							}
+							else if (response?.status === 500) {
+								reject('An unexpected error has occurred');
+							}
+							else {
+								reject(
+									`Unable to fetch feature flag "${partialBody.key}"`
+								);
+							}
+						}
 
-						if (json.error) {
-							resolve({
-								error: json.error,
-							});
-						}
-						else {
-							resolve({
-								result: json,
-							});
-						}
+						const json = JSON.parse(await response.text());
+
+						resolve({
+							result: json,
+						});
 					})
 					.catch(reject);
 			}),


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-19915

Currently, when a playwright test needs to check if a feature flag exists, it hits `/is-enabled` and a HTTP 200 response is returned with flag info. But, when the flag does not exists, it still returns a HTTP 200 response with a message error, which is confusing since HTTP 200 means successful response. 

This PR fix this issue.

