### PR TITLE
LPD-24385 Review & adapt tests using hard-coded test password

### DIFF
--- a/modules/apps/accessibility/accessibility-test/src/testFunctional/tests/AccessibilityMenuSmoke.testcase
+++ b/modules/apps/accessibility/accessibility-test/src/testFunctional/tests/AccessibilityMenuSmoke.testcase
@@ -237,8 +237,10 @@ definition {
 		task ("And accessibility menu is not available on virtual instance B") {
 			Navigator.openSpecificURL(url = "http://www.able.com:8080");
 
+			var password = PropsUtil.get("default.admin.password");
+
 			User.firstLoginUI(
-				password = "test",
+				password = ${password},
 				specificURL = "http://www.able.com:8080",
 				userEmailAddress = "test@liferay.com");
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/administration/portalconfiguration/systemmanagement/InstanceSettings.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/administration/portalconfiguration/systemmanagement/InstanceSettings.testcase
@@ -273,7 +273,7 @@ definition {
 
 		Type.typePause(
 			locator1 = "TextInput#PASSWORD",
-			value1 = "test");
+			value1 = ${password});
 
 		User._clickSignInButton(localization = ${localization});
 
@@ -674,7 +674,7 @@ definition {
 
 		Type.typePause(
 			locator1 = "TextInput#PASSWORD",
-			value1 = "test");
+			value1 = ${password});
 
 		User._clickSignInButton(localization = ${localization});
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/administration/portalconfiguration/systemmanagement/SystemSettings.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/administration/portalconfiguration/systemmanagement/SystemSettings.testcase
@@ -300,8 +300,10 @@ definition {
 				virtualHost = "www.able.com",
 				webId = "www.able.com");
 
+			var password = PropsUtil.get("default.admin.password");
+
 			User.firstLoginUI(
-				password = "test",
+				password = ${password},
 				specificURL = "http://www.able.com:8080",
 				userEmailAddress = "test@www.able.com");
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/controlmenu/applicationsmenu/ApplicationsMenu.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/controlmenu/applicationsmenu/ApplicationsMenu.testcase
@@ -264,8 +264,10 @@ definition {
 		}
 
 		task ("Sign In virtual instance") {
+			var password = PropsUtil.get("default.admin.password");
+
 			User.firstLoginPG(
-				password = "test",
+				password = ${password},
 				portalInstanceName = "www.able.com",
 				userEmailAddress = "test@www.able.com",
 				virtualHostsURL = "http://www.able.com:8080");


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-24385

## Context
App Sec is going to remove the value of the `default.admin.password` property permanently according to https://liferay.atlassian.net/browse/LPD-4254?focusedCommentId=2628865.

**Changes needed**

"The value to the property `default.admin.password` is going to be set blank in portal.properies and set to different value in the ci, so it is needed to change all tests that have hardcoded "test" as the value as admin's password ". Reason, we can't deliver a product setting a default admin's password and we want to avoid the customer use "test" as password.

## Solution
Replace hard coded `test` passwords from our component with `PropsUtil.get("default.admin.password")`
