### PR TITLE
LPD-4680 Convert h4 elements to use div.h4

### DIFF
--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/account_entry/default_addresses.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/account_entry/default_addresses.jsp
@@ -46,7 +46,7 @@ AccountEntryDisplay accountEntryDisplay = (AccountEntryDisplay)request.getAttrib
 						<liferay-ui:message key="not-set" />
 					</c:when>
 					<c:otherwise>
-						<h4><%= HtmlUtil.escape(defaultBillingAddress.getName()) %></h4>
+						<div class="h4"><%= HtmlUtil.escape(defaultBillingAddress.getName()) %></div>
 
 						<liferay-text-localizer:address-display
 							address="<%= defaultBillingAddress %>"
@@ -113,7 +113,7 @@ AccountEntryDisplay accountEntryDisplay = (AccountEntryDisplay)request.getAttrib
 						<liferay-ui:message key="not-set" />
 					</c:when>
 					<c:otherwise>
-						<h4><%= HtmlUtil.escape(defaultShippingAddress.getName()) %></h4>
+						<div class="h4"><%= HtmlUtil.escape(defaultShippingAddress.getName()) %></div>
 
 						<liferay-text-localizer:address-display
 							address="<%= defaultShippingAddress %>"

--- a/modules/apps/account/account-test/src/testFunctional/paths/Account.path
+++ b/modules/apps/account/account-test/src/testFunctional/paths/Account.path
@@ -141,7 +141,7 @@
 </tr>
 <tr>
 	<td>DEFAULT_ACCOUNT_TERMS_AND_CONDITION_DEFAULT_DELIVERY_ENTRY_INACTIVE_ICON</td>
-	<td>//a[@data-type='delivery-terms']/../../preceding-sibling::h4/strong[contains(@style,'orange')]</td>
+	<td>//a[@data-type='delivery-terms']/../../preceding-sibling::div[contains(@class,'h4')]/strong[contains(@style,'orange')]</td>
 	<td></td>
 </tr>
 <tr>
@@ -151,12 +151,12 @@
 </tr>
 <tr>
 	<td>DEFAULT_ACCOUNT_TERMS_AND_CONDITION_DEFAULT_PAYMENT_ENTRY</td>
-	<td>//a[@data-type='payment-terms']/../../preceding-sibling::h4</td>
+	<td>//a[@data-type='payment-terms']/../../preceding-sibling::div[contains(@class,'h4')]</td>
 	<td></td>
 </tr>
 <tr>
 	<td>DEFAULT_ACCOUNT_TERMS_AND_CONDITION_DEFAULT_PAYMENT_ENTRY_INACTIVE_ICON</td>
-	<td>//a[@data-type='payment-terms']/../../preceding-sibling::h4/strong[contains(@style,'orange')]</td>
+	<td>//a[@data-type='payment-terms']/../../preceding-sibling::div[contains(@class,'h4')]/strong[contains(@style,'orange')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/modules/apps/adaptive-media/adaptive-media-web/src/main/resources/META-INF/resources/adaptive_media/info_panel.jsp
+++ b/modules/apps/adaptive-media/adaptive-media-web/src/main/resources/META-INF/resources/adaptive_media/info_panel.jsp
@@ -26,9 +26,9 @@ if (ListUtil.isNotEmpty(selectedAMImageConfigurationEntries)) {
 		<c:when test="<%= selectedConfigurationEntriesSize == 1 %>">
 			<div class="autofit-row sidebar-section">
 				<div class="autofit-col autofit-col-expand">
-					<h4 class="component-title">
+					<div class="component-title">
 						<%= HtmlUtil.escape(amImageConfigurationEntry.getName()) %>
-					</h4>
+					</div>
 
 					<h5 class="component-subtitle">
 						<liferay-ui:message key="image-resolution" />
@@ -48,14 +48,14 @@ if (ListUtil.isNotEmpty(selectedAMImageConfigurationEntries)) {
 		<c:when test="<%= selectedConfigurationEntriesSize > 1 %>">
 			<div class="autofit-row sidebar-section">
 				<div class="autofit-col autofit-col-expand">
-					<h4 class="component-title"><liferay-ui:message arguments="<%= selectedConfigurationEntriesSize %>" key="x-items-are-selected" /></h4>
+					<div class="component-title"><liferay-ui:message arguments="<%= selectedConfigurationEntriesSize %>" key="x-items-are-selected" /></div>
 				</div>
 			</div>
 		</c:when>
 		<c:otherwise>
 			<div class="autofit-row sidebar-section">
 				<div class="autofit-col autofit-col-expand">
-					<h4 class="component-title"><liferay-ui:message key="adaptive-media" /></h4>
+					<div class="component-title"><liferay-ui:message key="adaptive-media" /></div>
 				</div>
 			</div>
 		</c:otherwise>

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_metadata/metadata_entry.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_metadata/metadata_entry.jsp
@@ -104,10 +104,10 @@ else if (metadataField.equals("view-count")) {
 			<div class="autofit-col autofit-col-expand">
 				<c:choose>
 					<c:when test="<%= assetRendererUser != null %>">
-						<h4 class="component-title mt-0"><%= HtmlUtil.escape(assetRendererUser.getFullName()) %></h4>
+						<div class="component-title mt-0"><%= HtmlUtil.escape(assetRendererUser.getFullName()) %></div>
 					</c:when>
 					<c:otherwise>
-						<h4 class="component-title mt-0"><liferay-ui:message key="anonymous"></liferay-ui:message></h4>
+						<div class="component-title mt-0"><liferay-ui:message key="anonymous"></liferay-ui:message></div>
 					</c:otherwise>
 				</c:choose>
 

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/input_asset_links/page.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/input_asset_links/page.jsp
@@ -58,9 +58,9 @@ List<DropdownItem> dropdownItems = inputAssetLinksDisplayContext.getActionDropdo
 		<liferay-ui:search-container-column-text
 			name="title"
 		>
-			<h4 class="list-group-title">
+			<div class="list-group-title">
 				<%= HtmlUtil.escape(assetLinkEntry.getTitle(locale)) %>
-			</h4>
+			</div>
 
 			<p class="list-group-subtitle">
 				<%= inputAssetLinksDisplayContext.getAssetType(assetLinkEntry) %>

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/js/InputAssetLinkDropdownDefaultPropsTransformer.js
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/js/InputAssetLinkDropdownDefaultPropsTransformer.js
@@ -54,9 +54,9 @@ export default function propsTransformer({
 									) {
 										const rowColumns = [];
 
-										rowColumns.push(`<h4 class="list-group-title">
+										rowColumns.push(`<div class="list-group-title">
 												${Liferay.Util.escapeHTML(assetEntry.title)}
-											</h4>
+											</div>
 											<p class="list-group-subtitle">
 												${Liferay.Util.escapeHTML(assetEntry.assetType)}
 											</p>

--- a/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/export/edit_batch_planner_plan.jsp
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/export/edit_batch_planner_plan.jsp
@@ -27,7 +27,7 @@ renderResponse.setTitle(editable ? LanguageUtil.get(request, "edit-template") : 
 		<input id="<portlet:namespace />containsHeaders" name="<portlet:namespace />containsHeaders" type="hidden" value="<%= true %>" />
 
 		<div class="card">
-			<h4 class="card-header"><liferay-ui:message key="export-settings" /></h4>
+			<div class="card-header"><liferay-ui:message key="export-settings" /></div>
 
 			<div class="card-body">
 				<liferay-frontend:edit-form-body>

--- a/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/import/edit_batch_planner_plan.jsp
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/import/edit_batch_planner_plan.jsp
@@ -30,7 +30,7 @@ renderResponse.setTitle(editable ? LanguageUtil.get(request, "edit-template") : 
 		<div class="row">
 			<div class="col-lg-6 d-flex flex-column">
 				<div class="card flex-fill">
-					<h4 class="card-header"><liferay-ui:message key="import-settings" /></h4>
+					<div class="card-header"><liferay-ui:message key="import-settings" /></div>
 
 					<div class="card-body">
 						<liferay-frontend:edit-form-body>
@@ -129,7 +129,7 @@ renderResponse.setTitle(editable ? LanguageUtil.get(request, "edit-template") : 
 
 			<div class="col-lg-6 d-flex flex-column">
 				<div class="card flex-fill">
-					<h4 class="card-header"><liferay-ui:message key="file-settings" /></h4>
+					<div class="card-header"><liferay-ui:message key="file-settings" /></div>
 
 					<div class="card-body">
 						<liferay-frontend:edit-form-body>

--- a/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/import/edit_batch_planner_plan.jsp
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/import/edit_batch_planner_plan.jsp
@@ -30,7 +30,7 @@ renderResponse.setTitle(editable ? LanguageUtil.get(request, "edit-template") : 
 		<div class="row">
 			<div class="col-lg-6 d-flex flex-column">
 				<div class="card flex-fill">
-					<div class="card-header"><liferay-ui:message key="import-settings" /></div>
+					<div class="card-header h4"><liferay-ui:message key="import-settings" /></div>
 
 					<div class="card-body">
 						<liferay-frontend:edit-form-body>
@@ -129,7 +129,7 @@ renderResponse.setTitle(editable ? LanguageUtil.get(request, "edit-template") : 
 
 			<div class="col-lg-6 d-flex flex-column">
 				<div class="card flex-fill">
-					<div class="card-header"><liferay-ui:message key="file-settings" /></div>
+					<div class="card-header h4"><liferay-ui:message key="file-settings" /></div>
 
 					<div class="card-body">
 						<liferay-frontend:edit-form-body>

--- a/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/js/FieldsTable.js
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/js/FieldsTable.js
@@ -116,9 +116,9 @@ function FieldsTable({portletNamespace}) {
 
 	return (
 		<div className="card d-flex flex-column">
-			<h4 className="card-header py-3">
+			<div className="card-header py-3">
 				{Liferay.Language.get('fields')}
-			</h4>
+			</div>
 
 			<ClayAlert
 				className="m-3"

--- a/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/js/FieldsTable.js
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/js/FieldsTable.js
@@ -116,7 +116,7 @@ function FieldsTable({portletNamespace}) {
 
 	return (
 		<div className="card d-flex flex-column">
-			<div className="card-header py-3">
+			<div className="card-header h4 py-3">
 				{Liferay.Language.get('fields')}
 			</div>
 

--- a/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/js/import/ImportForm.js
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/js/import/ImportForm.js
@@ -231,9 +231,9 @@ function ImportForm({
 		<>
 			{formIsVisible && (
 				<div className="card import-mapping-table">
-					<h4 className="card-header">
+					<div className="card-header">
 						{Liferay.Language.get('import-mappings')}
-					</h4>
+					</div>
 
 					<div className="card-body p-0">
 						<ClayTable borderless hover={false}>

--- a/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/js/import/ImportForm.js
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/js/import/ImportForm.js
@@ -231,7 +231,7 @@ function ImportForm({
 		<>
 			{formIsVisible && (
 				<div className="card import-mapping-table">
-					<div className="card-header">
+					<div className="card-header h4">
 						{Liferay.Language.get('import-mappings')}
 					</div>
 

--- a/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/view_batch_planner_plan.jsp
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/view_batch_planner_plan.jsp
@@ -15,7 +15,7 @@ BatchPlannerPlanDisplay batchPlannerPlanDisplay = (BatchPlannerPlanDisplay)reque
 
 <div class="container pt-4">
 	<div class="card">
-		<h4 class="card-header"><liferay-ui:message key="batch-engine-task-details" /></h4>
+		<div class="card-header"><liferay-ui:message key="batch-engine-task-details" /></div>
 
 		<div class="card-body">
 			<clay:content-row>

--- a/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/view_batch_planner_plan.jsp
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/view_batch_planner_plan.jsp
@@ -15,7 +15,7 @@ BatchPlannerPlanDisplay batchPlannerPlanDisplay = (BatchPlannerPlanDisplay)reque
 
 <div class="container pt-4">
 	<div class="card">
-		<div class="card-header"><liferay-ui:message key="batch-engine-task-details" /></div>
+		<div class="card-header h4"><liferay-ui:message key="batch-engine-task-details" /></div>
 
 		<div class="card-body">
 			<clay:content-row>

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/view_entry_content.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/view_entry_content.jsp
@@ -47,7 +47,7 @@ BlogsPortletInstanceConfiguration blogsPortletInstanceConfiguration = BlogsPortl
 					%>
 
 					<c:if test="<%= Objects.equals(blogsPortletInstanceConfiguration.displayStyle(), BlogsUtil.DISPLAY_STYLE_FULL_CONTENT) && Validator.isNotNull(subtitle) %>">
-						<h4 class="sub-title"><%= HtmlUtil.escape(subtitle) %></h4>
+						<div class="h4 sub-title"><%= HtmlUtil.escape(subtitle) %></div>
 					</c:if>
 				</clay:content-col>
 

--- a/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks/info_panel.jsp
+++ b/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks/info_panel.jsp
@@ -37,7 +37,7 @@ if (ListUtil.isEmpty(folders) && ListUtil.isEmpty(entries)) {
 		<div class="sidebar-header">
 			<div class="autofit-row sidebar-section">
 				<div class="autofit-col autofit-col-expand">
-					<h4 class="component-title"><%= (folder != null) ? HtmlUtil.escape(folder.getName()) : LanguageUtil.get(request, "home") %></h4>
+					<div class="component-title"><%= (folder != null) ? HtmlUtil.escape(folder.getName()) : LanguageUtil.get(request, "home") %></div>
 
 					<h5 class="component-subtitle">
 						<liferay-ui:message key="folder" />
@@ -111,7 +111,7 @@ if (ListUtil.isEmpty(folders) && ListUtil.isEmpty(entries)) {
 		<div class="sidebar-header">
 			<div class="autofit-row sidebar-section">
 				<div class="autofit-col autofit-col-expand">
-					<h4 class="component-title"><%= HtmlUtil.escape(entry.getName()) %></h4>
+					<div class="component-title"><%= HtmlUtil.escape(entry.getName()) %></div>
 
 					<h5>
 						<liferay-ui:message key="entry" />
@@ -227,7 +227,7 @@ if (ListUtil.isEmpty(folders) && ListUtil.isEmpty(entries)) {
 		<div class="sidebar-header">
 			<div class="autofit-row sidebar-section">
 				<div class="autofit-col autofit-col-expand">
-					<h4 class="component-title"><liferay-ui:message arguments="<%= folders.size() + entries.size() %>" key="x-items-are-selected" /></h4>
+					<div class="component-title"><liferay-ui:message arguments="<%= folders.size() + entries.size() %>" key="x-items-are-selected" /></div>
 				</div>
 			</div>
 		</div>

--- a/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks/move_entries.jsp
+++ b/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks/move_entries.jsp
@@ -86,7 +86,7 @@ if (portletTitleBasedNavigation) {
 				<aui:fieldset>
 					<c:if test="<%= !validMoveFolders.isEmpty() %>">
 						<div class="move-list-info">
-							<h4><liferay-ui:message arguments="<%= validMoveFolders.size() %>" key="x-folders-are-ready-to-be-moved" translateArguments="<%= false %>" /></h4>
+							<div class="h4"><liferay-ui:message arguments="<%= validMoveFolders.size() %>" key="x-folders-are-ready-to-be-moved" translateArguments="<%= false %>" /></div>
 						</div>
 
 						<div class="move-list">
@@ -120,7 +120,7 @@ if (portletTitleBasedNavigation) {
 
 					<c:if test="<%= !invalidMoveFolders.isEmpty() %>">
 						<div class="move-list-info">
-							<h4><liferay-ui:message arguments="<%= invalidMoveFolders.size() %>" key="x-folders-cannot-be-moved" translateArguments="<%= false %>" /></h4>
+							<div class="h4"><liferay-ui:message arguments="<%= invalidMoveFolders.size() %>" key="x-folders-cannot-be-moved" translateArguments="<%= false %>" /></div>
 						</div>
 
 						<div class="move-list">
@@ -159,7 +159,7 @@ if (portletTitleBasedNavigation) {
 
 					<c:if test="<%= !validMoveEntries.isEmpty() %>">
 						<div class="move-list-info">
-							<h4><liferay-ui:message arguments="<%= validMoveEntries.size() %>" key="x-entries-are-ready-to-be-moved" translateArguments="<%= false %>" /></h4>
+							<div class="h4"><liferay-ui:message arguments="<%= validMoveEntries.size() %>" key="x-entries-are-ready-to-be-moved" translateArguments="<%= false %>" /></div>
 						</div>
 
 						<div class="move-list">
@@ -193,7 +193,7 @@ if (portletTitleBasedNavigation) {
 
 					<c:if test="<%= !invalidMoveEntries.isEmpty() %>">
 						<div class="move-list-info">
-							<h4><liferay-ui:message arguments="<%= invalidMoveEntries.size() %>" key="x-entries-cannot-be-moved" translateArguments="<%= false %>" /></h4>
+							<div class="h4"><liferay-ui:message arguments="<%= invalidMoveEntries.size() %>" key="x-entries-cannot-be-moved" translateArguments="<%= false %>" /></div>
 						</div>
 
 						<div class="move-list">

--- a/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks/view_entry_descriptive.jsp
+++ b/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks/view_entry_descriptive.jsp
@@ -26,11 +26,11 @@ else {
 entry = entry.toEscapedModel();
 %>
 
-<h4>
+<div class="h4">
 	<aui:a href='<%= themeDisplay.getPathMain() + "/bookmarks/open_entry?entryId=" + entry.getEntryId() %>'>
 		<%= entry.getName() %>
 	</aui:a>
-</h4>
+</div>
 
 <h5 class="text-default">
 	<%= entry.getDescription() %>

--- a/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks/view_folder_descriptive.jsp
+++ b/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks/view_folder_descriptive.jsp
@@ -15,7 +15,7 @@ BookmarksFolder folder = (BookmarksFolder)row.getObject();
 folder = folder.toEscapedModel();
 %>
 
-<h4>
+<div class="h4">
 	<aui:a
 		href='<%=
 			PortletURLBuilder.createRenderURL(
@@ -31,7 +31,7 @@ folder = folder.toEscapedModel();
 	>
 		<%= folder.getName() %>
 	</aui:a>
-</h4>
+</div>
 
 <h5 class="text-default">
 	<%= folder.getDescription() %>

--- a/modules/apps/calendar/calendar-web-test/src/testFunctional/paths/CalendarExportImport.path
+++ b/modules/apps/calendar/calendar-web-test/src/testFunctional/paths/CalendarExportImport.path
@@ -22,7 +22,7 @@
 </tr>
 <tr>
 	<td>UPLOAD_ERROR_MESSAGE</td>
-	<td>//div[@class='upload-list']//h4[@class='upload-error-message']</td>
+	<td>//div[@class='upload-list']//[@class='upload-error-message']</td>
 	<td></td>
 </tr>
 </tbody>

--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/edit_calendar_notification_templates.jspf
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/edit_calendar_notification_templates.jspf
@@ -88,7 +88,7 @@ String notificationTemplateBody = BeanPropertiesUtil.getString(calendarNotificat
 	</aui:fieldset>
 
 	<div class="definition-of-terms">
-		<h4><liferay-ui:message key="definition-of-terms" /></h4>
+		<div class="h4"><liferay-ui:message key="definition-of-terms" /></div>
 
 		<dl>
 			<dt>

--- a/modules/apps/commerce/commerce-cart-content-web/src/main/resources/META-INF/resources/cart_mini/view.jsp
+++ b/modules/apps/commerce/commerce-cart-content-web/src/main/resources/META-INF/resources/cart_mini/view.jsp
@@ -61,9 +61,9 @@ request.setAttribute("view.jsp-portletURL", portletURL);
 	<ul class="commerce-order-items-header">
 		<li class="autofit-row">
 			<div class="autofit-col autofit-col-expand">
-				<h4 class="commerce-title">
+				<div class="commerce-title h4">
 					<liferay-ui:message arguments="<%= commerceCartContentMiniDisplayContext.getCommerceOrderItemsQuantity() %>" key="items-x" translateArguments="<%= false %>" />
-				</h4>
+				</div>
 			</div>
 
 			<div class="autofit-col">

--- a/modules/apps/commerce/commerce-cart-content-web/src/main/resources/META-INF/resources/cart_total/view.jsp
+++ b/modules/apps/commerce/commerce-cart-content-web/src/main/resources/META-INF/resources/cart_total/view.jsp
@@ -78,7 +78,7 @@ SearchContainer<CommerceOrderItem> commerceOrderItemSearchContainer = commerceCa
 			<div class="row">
 				<c:if test="<%= subtotalCommerceDiscountValue != null %>">
 					<div class="col-auto">
-						<h4><liferay-ui:message key="subtotal-discount" /></h4>
+						<div class="h4"><liferay-ui:message key="subtotal-discount" /></div>
 					</div>
 
 					<div class="col-auto">
@@ -112,7 +112,7 @@ SearchContainer<CommerceOrderItem> commerceOrderItemSearchContainer = commerceCa
 			<div class="row">
 				<c:if test="<%= totalCommerceDiscountValue != null %>">
 					<div class="col-auto">
-						<h4><liferay-ui:message key="total-discount" /></h4>
+						<div class="h4"><liferay-ui:message key="total-discount" /></div>
 					</div>
 
 					<div class="col-auto">

--- a/modules/apps/commerce/commerce-cart-content-web/src/main/resources/com/liferay/commerce/cart/content/web/internal/portlet/display/template/dependencies/cart_total/portlet_display_template_basic.ftl
+++ b/modules/apps/commerce/commerce-cart-content-web/src/main/resources/com/liferay/commerce/cart/content/web/internal/portlet/display/template/dependencies/cart_total/portlet_display_template_basic.ftl
@@ -5,7 +5,7 @@
 		commerceOrderTotal = commerceOrderPrice.getTotal()
 	/>
 
-	<h4>
+	<div class="h4">
 		<strong><@liferay_ui["message"] key="total" /> ${commerceOrderTotal.format(locale)}</strong>
-	</h4>
+	</div>
 </#if>

--- a/modules/apps/commerce/commerce-checkout-web/src/main/resources/META-INF/resources/address.jsp
+++ b/modules/apps/commerce/commerce-checkout-web/src/main/resources/META-INF/resources/address.jsp
@@ -11,7 +11,7 @@
 CommerceAddress commerceAddress = (CommerceAddress)request.getAttribute("address.jsp-commerceAddress");
 %>
 
-<h4><%= HtmlUtil.escape(commerceAddress.getName()) %></h4>
+<div class="h4"><%= HtmlUtil.escape(commerceAddress.getName()) %></div>
 <p><%= HtmlUtil.escape(commerceAddress.getStreet1()) %></p>
 
 <c:if test="<%= Validator.isNotNull(commerceAddress.getStreet2()) %>">

--- a/modules/apps/commerce/commerce-frontend-js/src/main/resources/META-INF/resources/components/item_finder/AddOrCreate.js
+++ b/modules/apps/commerce/commerce-frontend-js/src/main/resources/META-INF/resources/components/item_finder/AddOrCreate.js
@@ -92,9 +92,9 @@ class AddOrCreateBase extends Component {
 				}`}
 				onFocus={(event) => this.handleFocusIn(event)}
 			>
-				<h4 className="align-items-center card-header py-3">
+				<div className="align-items-center card-header h4 py-3">
 					{this.props.panelHeaderLabel}
-				</h4>
+				</div>
 
 				<div className="card-body">
 					<div className="input-group">

--- a/modules/apps/commerce/commerce-frontend-js/src/main/resources/META-INF/resources/components/summary/Summary.js
+++ b/modules/apps/commerce/commerce-frontend-js/src/main/resources/META-INF/resources/components/summary/Summary.js
@@ -42,10 +42,14 @@ function SummaryItemBigVariant(props) {
 	return (
 		<>
 			<div className="col-6 col-md-9">
-				<h4 className="my-2 summary-table-item-big">{props.label}</h4>
+				<div className="h4 my-2 summary-table-item-big">
+					{props.label}
+				</div>
 			</div>
 			<div className="col-6 col-md-3">
-				<h4 className="my-2 summary-table-item-big">{props.value}</h4>
+				<div className="h4 my-2 summary-table-item-big">
+					{props.value}
+				</div>
 			</div>
 		</>
 	);

--- a/modules/apps/commerce/commerce-frontend-taglib/src/main/resources/META-INF/resources/panel/start.jsp
+++ b/modules/apps/commerce/commerce-frontend-taglib/src/main/resources/META-INF/resources/panel/start.jsp
@@ -13,7 +13,7 @@ String collapseSwitchId = Validator.isNotNull(collapseSwitchName) ? collapseSwit
 
 <div class="card d-flex flex-column<%= Validator.isNotNull(elementClasses) ? StringPool.SPACE + elementClasses : StringPool.BLANK %>">
 	<c:if test="<%= Validator.isNotNull(actionLabel) || Validator.isNotNull(actionIcon) || Validator.isNotNull(title) %>">
-		<h4 class="align-items-center card-header d-flex justify-content-between py-3">
+		<div class="align-items-center card-header d-flex h4 justify-content-between py-3">
 			<%= HtmlUtil.escape(title) %>
 
 			<c:if test="<%= Validator.isNotNull(actionTargetId) %>">
@@ -116,7 +116,7 @@ String collapseSwitchId = Validator.isNotNull(collapseSwitchName) ? collapseSwit
 					</span>
 				</c:when>
 			</c:choose>
-		</h4>
+		</div>
 	</c:if>
 
 	<div class="collapse<%= collapsed ? StringPool.BLANK : " show" %>" id="<%= randomNamespace %>collapse">

--- a/modules/apps/commerce/commerce-order-content-web/src/main/resources/META-INF/resources/returns/view_commerce_return.jsp
+++ b/modules/apps/commerce/commerce-order-content-web/src/main/resources/META-INF/resources/returns/view_commerce_return.jsp
@@ -217,11 +217,11 @@ portletDisplay.setURLBack(String.valueOf(renderResponse.createRenderURL()));
 
 					<div class="row summary-table text-right">
 						<div class="col-6 col-md-9">
-							<h4 class="my-2 summary-table-item-big"><liferay-ui:message key="total-estimated-refund" /></h4>
+							<div class="h4 my-2 summary-table-item-big"><liferay-ui:message key="total-estimated-refund" /></div>
 						</div>
 
 						<div class="col-6 col-md-3">
-							<h4 class="my-2 summary-table-item-big"><%= commerceReturnContentDisplayContext.getTotalEstimatedRefund() %></h4>
+							<div class="h4 my-2 summary-table-item-big"><%= commerceReturnContentDisplayContext.getTotalEstimatedRefund() %></div>
 						</div>
 					</div>
 				</commerce-ui:panel>

--- a/modules/apps/commerce/commerce-order-web/src/main/resources/META-INF/resources/asset/full_content.jsp
+++ b/modules/apps/commerce/commerce-order-web/src/main/resources/META-INF/resources/asset/full_content.jsp
@@ -12,7 +12,7 @@ CommerceOrder commerceOrder = (CommerceOrder)request.getAttribute(CommerceOrderC
 %>
 
 <div class="container-fluid container-fluid-max-xl">
-	<h4><liferay-ui:message key="order-details" /></h4>
+	<div class="h4"><liferay-ui:message key="order-details" /></div>
 
 	<liferay-ui:search-container
 		id="commerceOrderItems"

--- a/modules/apps/commerce/commerce-order-web/src/main/resources/META-INF/resources/commerce_return/general.jsp
+++ b/modules/apps/commerce/commerce-order-web/src/main/resources/META-INF/resources/commerce_return/general.jsp
@@ -205,11 +205,11 @@ CommerceOrder commerceOrder = commerceReturnEditDisplayContext.getCommerceReturn
 				</div>
 
 				<div class="col-6 col-md-9">
-					<h4 class="my-2 summary-table-item-big"><liferay-ui:message key="total-estimated-refund" /></h4>
+					<div class="h4 my-2 summary-table-item-big"><liferay-ui:message key="total-estimated-refund" /></div>
 				</div>
 
 				<div class="col-6 col-md-3">
-					<h4 class="my-2 summary-table-item-big"><%= commerceReturnEditDisplayContext.getAmountFormatted(commerceReturn.getTotalAmount()) %></h4>
+					<div class="h4 my-2 summary-table-item-big"><%= commerceReturnEditDisplayContext.getAmountFormatted(commerceReturn.getTotalAmount()) %></div>
 				</div>
 			</div>
 		</commerce-ui:panel>

--- a/modules/apps/commerce/commerce-product-asset-categories-web/src/main/resources/META-INF/resources/display_layout/edit_asset_category_cp_display_layout.jsp
+++ b/modules/apps/commerce/commerce-product-asset-categories-web/src/main/resources/META-INF/resources/display_layout/edit_asset_category_cp_display_layout.jsp
@@ -43,7 +43,7 @@ String layoutBreadcrumb = categoryCPDisplayLayoutDisplayContext.getLayoutBreadcr
 				<aui:fieldset>
 					<liferay-asset:asset-categories-error />
 
-					<h4><liferay-ui:message key="select-categories" /></h4>
+					<div class="h4"><liferay-ui:message key="select-categories" /></div>
 
 					<div id="<portlet:namespace />categoriesContainer"></div>
 

--- a/modules/apps/commerce/commerce-product-content-web/src/main/resources/META-INF/resources/product_detail/render/view.jsp
+++ b/modules/apps/commerce/commerce-product-content-web/src/main/resources/META-INF/resources/product_detail/render/view.jsp
@@ -132,7 +132,7 @@ long cpDefinitionId = cpCatalogEntry.getCPDefinitionId();
 
 			<p class="mt-3 product-description"><%= HtmlUtil.escape(cpCatalogEntry.getShortDescription()) %></p>
 
-			<h4 class="commerce-subscription-info mt-3">
+			<div class="commerce-subscription-info h4 mt-3">
 				<c:if test="<%= cpSku != null %>">
 					<commerce-ui:product-subscription-info
 						CPInstanceId="<%= cpSku.getCPInstanceId() %>"
@@ -141,7 +141,7 @@ long cpDefinitionId = cpCatalogEntry.getCPDefinitionId();
 
 				<span class="d-block" data-text-cp-instance-subscription-info></span>
 				<span class="d-block" data-text-cp-instance-delivery-subscription-info></span>
-			</h4>
+			</div>
 
 			<div class="product-detail-options">
 				<commerce-ui:option-selector

--- a/modules/apps/commerce/commerce-product-options-web/src/main/resources/META-INF/resources/cp_option_category_info_panel.jsp
+++ b/modules/apps/commerce/commerce-product-options-web/src/main/resources/META-INF/resources/cp_option_category_info_panel.jsp
@@ -31,7 +31,7 @@ if (cpOptionCategories == null) {
 				<clay:content-col
 					expand="<%= true %>"
 				>
-					<h4 class="component-title"><%= HtmlUtil.escape(cpOptionCategory.getTitle(locale)) %></h4>
+					<div class="component-title"><%= HtmlUtil.escape(cpOptionCategory.getTitle(locale)) %></div>
 				</clay:content-col>
 
 				<clay:content-col>
@@ -62,7 +62,7 @@ if (cpOptionCategories == null) {
 				<clay:content-col
 					expand="<%= true %>"
 				>
-					<h4 class="component-title"><liferay-ui:message arguments="<%= cpOptionCategories.size() %>" key="x-items-are-selected" /></h4>
+					<div class="component-title"><liferay-ui:message arguments="<%= cpOptionCategories.size() %>" key="x-items-are-selected" /></div>
 				</clay:content-col>
 			</clay:content-row>
 		</div>

--- a/modules/apps/commerce/commerce-product-options-web/src/main/resources/META-INF/resources/cp_specification_option_info_panel.jsp
+++ b/modules/apps/commerce/commerce-product-options-web/src/main/resources/META-INF/resources/cp_specification_option_info_panel.jsp
@@ -31,7 +31,7 @@ if (cpSpecificationOptions == null) {
 				<clay:content-col
 					expand="<%= true %>"
 				>
-					<h4 class="component-title"><%= HtmlUtil.escape(cpSpecificationOption.getTitle(locale)) %></h4>
+					<div class="component-title"><%= HtmlUtil.escape(cpSpecificationOption.getTitle(locale)) %></div>
 				</clay:content-col>
 
 				<clay:content-col>
@@ -62,7 +62,7 @@ if (cpSpecificationOptions == null) {
 				<clay:content-col
 					expand="<%= true %>"
 				>
-					<h4 class="component-title"><liferay-ui:message arguments="<%= cpSpecificationOptions.size() %>" key="x-items-are-selected" /></h4>
+					<div class="component-title"><liferay-ui:message arguments="<%= cpSpecificationOptions.size() %>" key="x-items-are-selected" /></div>
 				</clay:content-col>
 			</clay:content-row>
 		</div>

--- a/modules/apps/commerce/commerce-product-test/src/testFunctional/paths/CommerceAccelerators.path
+++ b/modules/apps/commerce/commerce-product-test/src/testFunctional/paths/CommerceAccelerators.path
@@ -352,7 +352,7 @@
 </tr>
 <tr>
 	<td>PRODUCT_DETAILS_SUBSCRIPTION_INFO</td>
-	<td>//h4[contains(@class,'commerce-subscription-info')]/div/div[contains(.,'${key_subscriptionName} Subscription')]/..//span</td>
+	<td>//div[@contains(@class,'commerce-subscription-info')]/div/div[contains(.,'${key_subscriptionName} Subscription')]/..//span</td>
 	<td></td>
 </tr>
 <tr>
@@ -796,7 +796,7 @@
 </tr>
 <tr>
 	<td>MINI_CART_SUMMARY_TABLE_TOTAL</td>
-	<td>//div[contains(@class,'summary-table')]//*[contains(.,'Total')]/following::h4</td>
+	<td>//div[contains(@class,'summary-table')]//*[contains(.,'Total')]/following::div[contains(@class,'h4')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/modules/apps/commerce/commerce-product-test/src/testFunctional/paths/CommerceDiagrams.path
+++ b/modules/apps/commerce/commerce-product-test/src/testFunctional/paths/CommerceDiagrams.path
@@ -156,7 +156,7 @@
 
 <tr>
 	<td>DIAGRAM_PRODUCT_DETAIL_NAME</td>
-	<td>//div[contains(@class,'portlet-content')]//h4[contains(text(),'${key_productName}')]</td>
+	<td>//div[contains(@class,'portlet-content')]//div[contains(@class,'h4') and contains(text(),'${key_productName}')]</td>
 	<td></td>
 </tr>
 <tr>
@@ -184,7 +184,7 @@
 </tr>
 <tr>
 	<td>DIAGRAM_PRODUCT_TOOLTIP_LINKED_SKU</td>
-	<td>//div[contains(@class,'diagram-tooltip')]//h4//a[contains(text(),'${key_sku}')]</td>
+	<td>//div[contains(@class,'diagram-tooltip')]//div[contains(@class,'h4')]//a[contains(text(),'${key_sku}')]</td>
 	<td></td>
 </tr>
 <tr>
@@ -209,7 +209,7 @@
 </tr>
 <tr>
 	<td>DIAGRAM_PRODUCT_TOOLTIP_UNLINKED_PRODUCT_NAME</td>
-	<td>//div[contains(@class,'diagram-tooltip')]//h4[contains(text(),'${key_productName}')]</td>
+	<td>//div[contains(@class,'diagram-tooltip')]//div[contains(@class,'h4') and contains(text(),'${key_productName}')]</td>
 	<td></td>
 </tr>
 

--- a/modules/apps/commerce/commerce-product-test/src/testFunctional/paths/CommerceEntry.path
+++ b/modules/apps/commerce/commerce-product-test/src/testFunctional/paths/CommerceEntry.path
@@ -12,7 +12,7 @@
 <tbody>
 <tr>
 	<td>ACCOUNT_ORDER_DEFAULTS_ENTRY</td>
-	<td>//div[contains(.,'${key_defaultOption}')][@class='sheet-section']//div[@class='sheet-text']/following-sibling::span | //div[contains(.,'${key_defaultOption}')][@class='sheet-section']//div[@class='sheet-text']/following-sibling::h4</td>
+	<td>//div[contains(.,'${key_defaultOption}')][@class='sheet-section']//div[@class='sheet-text']/following-sibling::span | //div[contains(.,'${key_defaultOption}')][@class='sheet-section']//div[@class='sheet-text']/following-sibling::div[contains(@class,'h4')]</td>
 	<td></td>
 </tr>
 <tr>
@@ -367,7 +367,7 @@
 </tr>
 <tr>
 	<td>OVERRIDE_DEFAULT_DISPLAY_PAGE</td>
-	<td>//h4[contains(.,'Override Default')]//..//div[contains(@class,'dnd-tr')][contains(.,'${key_entryName}') and contains(.,'${key_layout}')]</td>
+	<td>//div[contains(@class,'h4') and contains(.,'Override Default')]//..//div[contains(@class,'dnd-tr')][contains(.,'${key_entryName}') and contains(.,'${key_layout}')]</td>
 	<td></td>
 </tr>
 <tr>
@@ -402,7 +402,7 @@
 </tr>
 <tr>
 	<td>ADD_BUTTON</td>
-	<td>//*[@data-qa-id='addButton'] | //a[contains(@class,'btn') and span[contains(@class,'icon-plus')]] | //button/span[contains(@class,'icon-plus')] | //button[@type='button']/*[contains(@class,'icon-plus')] | //h4[contains(@class,'section-header') and contains (.,'Options')]/button</td>
+	<td>//*[@data-qa-id='addButton'] | //a[contains(@class,'btn') and span[contains(@class,'icon-plus')]] | //button/span[contains(@class,'icon-plus')] | //button[@type='button']/*[contains(@class,'icon-plus')] | //div[contains(@class,'section-header') and contains (.,'Options')]/button</td>
 	<td></td>
 </tr>
 <tr>
@@ -837,12 +837,12 @@
 </tr>
 <tr>
 	<td>TABLE_ENTRY_DESCRIPTION</td>
-	<td>//h4[contains(.,'${key_table}')]//..//div/a[contains(.,'${key_entryName}')]/parent::div/parent::div/parent::div//div[@class='dnd-td'][2][contains(.,'${key_entryDescription}')]</td>
+	<td>//div[contains(@class,'h4') and contains(.,'${key_table}')]//..//div/a[contains(.,'${key_entryName}')]/parent::div/parent::div/parent::div//div[@class='dnd-td'][2][contains(.,'${key_entryDescription}')]</td>
 	<td></td>
 </tr>
 <tr>
 	<td>TABLE_ENTRY_NAME</td>
-	<td>//h4[contains(.,'${key_table}')]//..//div/a[contains(.,'${key_entryName}')]</td>
+	<td>//div[contains(@class,'h4') and contains(.,'${key_table}')]//..//div/a[contains(.,'${key_entryName}')]</td>
 	<td></td>
 </tr>
 <tr>
@@ -852,7 +852,7 @@
 </tr>
 <tr>
 	<td>ELIGIBILITY_CARD_TITLE</td>
-	<td>//div/h4[contains(.,'${key_eligibilityCardTitle}')]</td>
+	<td>//div/div[contains(@class,'h4') and contains(.,'${key_eligibilityCardTitle}')]</td>
 	<td></td>
 </tr>
 <tr>
@@ -862,7 +862,7 @@
 </tr>
 <tr>
 	<td>ELIGIBILITY_RELATION_FIELD_CLEAR_BUTTON</td>
-	<td>//div[h4[contains(.,'${key_eligibilityCardTitle}')]]//input[@type='text']/..//span[contains(@class,'input-group-inset-item')]//button[contains(@class,'btn')]</td>
+	<td>//div[div[contains(@class,'h4') and contains(.,'${key_eligibilityCardTitle}')]]//input[@type='text']/..//span[contains(@class,'input-group-inset-item')]//button[contains(@class,'btn')]</td>
 	<td></td>
 </tr>
 <tr>
@@ -892,12 +892,12 @@
 </tr>
 <tr>
 	<td>TABLE_ENTRY_STATUS</td>
-	<td>//h4[contains(.,'${key_table}')]//..//div/a[contains(.,'${key_entryName}')]/parent::div/parent::div/parent::div//div[@class='dnd-td']/span[contains(@class,'label')][contains(.,'${key_entryStatus}')]</td>
+	<td>//div[contains(@class,'h4') and contains(.,'${key_table}')]//..//div/a[contains(.,'${key_entryName}')]/parent::div/parent::div/parent::div//div[@class='dnd-td']/span[contains(@class,'label')][contains(.,'${key_entryStatus}')]</td>
 	<td></td>
 </tr>
 <tr>
 	<td>TABLE_ENTRY_NAME_NOT_CONTAINS</td>
-	<td>//h4[contains(.,'${key_table}')]//..//div/a[(text()='${key_entryName}')]</td>
+	<td>//div[contains(@class,'h4') and contains(.,'${key_table}')]//..//div/a[(text()='${key_entryName}')]</td>
 	<td></td>
 </tr>
 <tr>
@@ -907,7 +907,7 @@
 </tr>
 <tr>
 	<td>TABLE_ELIGIBILITY_ENTRY</td>
-	<td>//h4[contains(.,'${key_table}')]//..//div[@class='dnd-td'][contains(.,'${key_entryName}')]</td>
+	<td>//div[contains(@class,'h4') and contains(.,'${key_table}')]//..//div[@class='dnd-td'][contains(.,'${key_entryName}')]</td>
 	<td></td>
 </tr>
 <tr>
@@ -922,12 +922,12 @@
 </tr>
 <tr>
 	<td>TABLE_ENTRY_DELETE_BUTTON</td>
-	<td>//h4[contains(.,'${key_table}')]//..//div/a[contains(.,'${key_entryName}')]//..//..//../div/*[contains(.,'Delete')] | //div[contains(.,'${key_table}')]//div[@class='dnd-tr'][contains(.,'${key_entryName}')]//*[contains(text(),'Delete')]</td>
+	<td>//div[contains(@class,'h4') and contains(.,'${key_table}')]//..//div/a[contains(.,'${key_entryName}')]//..//..//../div/*[contains(.,'Delete')] | //div[contains(.,'${key_table}')]//div[@class='dnd-tr'][contains(.,'${key_entryName}')]//*[contains(text(),'Delete')]</td>
 	<td></td>
 </tr>
 <tr>
 	<td>TABLE_ENTRY_EDIT_BUTTON</td>
-	<td>//h4[contains(.,'${key_table}')]//..//div/a[text()='${key_entryName}']//..//..//../div/*[contains(.,'Edit')] | //div[contains(.,'${key_table}')]//div[@class='dnd-tr']//*[text()='${key_entryName}']/..//*[contains(text(),'Edit')]</td>
+	<td>//div[contains(@class,'h4') and contains(.,'${key_table}')]//..//div/a[text()='${key_entryName}']//..//..//../div/*[contains(.,'Edit')] | //div[contains(.,'${key_table}')]//div[@class='dnd-tr']//*[text()='${key_entryName}']/..//*[contains(text(),'Edit')]</td>
 	<td></td>
 </tr>
 <tr>
@@ -1094,7 +1094,7 @@
 
 <tr>
 	<td>ADD_RELATION_FIELD</td>
-	<td>//div[h4[contains(.,'${key_title}')]]//input[@type='text']</td>
+	<td>//div[div[contains(@class,'h4') and contains(.,'${key_title}')]]//input[@type='text']</td>
 	<td></td>
 </tr>
 <tr>
@@ -1109,7 +1109,7 @@
 </tr>
 <tr>
 	<td>ADD_RELATION_FIELD_SELECT</td>
-	<td>//div[h4[contains(.,'${key_title}')]]//td[p[text()='${key_entryName}']]/..//button[contains(.,'Select')]</td>
+	<td>//div[div[contains(@class,'h4') and contains(.,'${key_title}')]]//td[p[text()='${key_entryName}']]/..//button[contains(.,'Select')]</td>
 	<td></td>
 </tr>
 <tr>
@@ -1124,7 +1124,7 @@
 </tr>
 <tr>
 	<td>ADD_RELATION_CLEAN_INPUT_BUTTON</td>
-	<td>//div[h4[contains(.,'${key_title}')]]//span</td>
+	<td>//div[div[contains(@class,'h4') and contains(.,'${key_title}')]]//span</td>
 	<td></td>
 </tr>
 <tr>
@@ -1178,7 +1178,7 @@
 
 <tr>
 	<td>IMAGES_PLUS_BUTTON</td>
-	<td>//h4[contains(.,'Images')]//..//button[contains(@class,'btn-primary')]</td>
+	<td>//div[contains(@class,'h4') and contains(.,'Images')]//..//button[contains(@class,'btn-primary')]</td>
 	<td></td>
 </tr>
 <tr>
@@ -1206,7 +1206,7 @@
 
 <tr>
 	<td>ATTACHMENT_PLUS_BUTTON</td>
-	<td>//h4[contains(.,'Attachments')]//..//button[contains(@class,'btn-primary')]</td>
+	<td>//div[contains(@class,'h4') and contains(.,'Attachments')]//..//button[contains(@class,'btn-primary')]</td>
 	<td></td>
 </tr>
 
@@ -1254,12 +1254,12 @@
 </tr>
 <tr>
 	<td>ORDER_PAYMENT_STATUS</td>
-	<td>//h4[contains(.,'Payment Status')]//..//div//span[contains(@class,'label')]//*[contains(.,'${paymentStatus}')]</td>
+	<td>//div[contains(@class,'h4') and contains(.,'Payment Status')]//..//div//span[contains(@class,'label')]//*[contains(.,'${paymentStatus}')]</td>
 	<td></td>
 </tr>
 <tr>
 	<td>ORDER_PAYMENT_METHOD</td>
-	<td>//h4[contains(.,'Payment Method')]//..//div//span[contains(@class,'payment-name') and contains(.,'${paymentMethod}')]</td>
+	<td>//div[contains(@class,'h4') and contains(.,'Payment Method')]//..//div//span[contains(@class,'payment-name') and contains(.,'${paymentMethod}')]</td>
 	<td></td>
 </tr>
 
@@ -1267,7 +1267,7 @@
 
 <tr>
 	<td>SEARCH_TABLES_CHANNELS</td>
-	<td>//h4[contains(text(),'${key_nameTableChannels}')]</td>
+	<td>//div[contains(@class,'h4') and contains(text(),'${key_nameTableChannels}')]</td>
 	<td></td>
 </tr>
 <tr>
@@ -1300,7 +1300,7 @@
 </tr>
 <tr>
 	<td>PRODUCT_DETAIL_VIEW_OPTION</td>
-	<td>//div[contains(@class,'card d-flex')]//h4[contains(.,'Option')]/..//a</td>
+	<td>//div[contains(@class,'card d-flex')]//div[contains(@class,'h4') and contains(.,'Option')]/..//a</td>
 	<td></td>
 </tr>
 <tr>
@@ -1310,7 +1310,7 @@
 </tr>
 <tr>
 	<td>PRODUCT_DETAIL_CARD_HEADER</td>
-	<td>//div[contains(@class,'card d-flex')]//h4[contains(.,'${key_cardName}')]</td>
+	<td>//div[contains(@class,'card d-flex')]//div[contains(@class,'h4') and contains(.,'${key_cardName}')]</td>
 	<td></td>
 </tr>
 <tr>
@@ -1320,37 +1320,37 @@
 </tr>
 <tr>
 	<td>PAYMENT_SUBSCRIPTION_TOGGLE</td>
-	<td>//h4[contains(text(), 'Payment Subscription')]//following-sibling::span[contains(@class,'toggle-switch-handle')]</td>
+	<td>//div[contains(@class,'h4') and contains(text(), 'Payment Subscription')]//following-sibling::span[contains(@class,'toggle-switch-handle')]</td>
 	<td></td>
 </tr>
 <tr>
 	<td>PAYMENT_SUBSCRIPTION_TOGGLE_ACTIVE</td>
-	<td>//h4[contains(text(), 'Payment Subscription')]//following-sibling::span[contains(@class,'toggle-switch-handle')]//following::div[contains(@class,'collapse show')]</td>
+	<td>//div[contains(@class,'h4') and contains(text(), 'Payment Subscription')]//following-sibling::span[contains(@class,'toggle-switch-handle')]//following::div[contains(@class,'collapse show')]</td>
 	<td></td>
 </tr>
 <tr>
 	<td>DELIVERY_SUBSCRIPTION_TOGGLE</td>
-	<td>//h4[contains(text(), 'Delivery Subscription')]//following-sibling::span[contains(@class,'toggle-switch-handle')]</td>
+	<td>//div[contains(@class,'h4') and contains(text(), 'Delivery Subscription')]//following-sibling::span[contains(@class,'toggle-switch-handle')]</td>
 	<td></td>
 </tr>
 <tr>
 	<td>SUBSCRIPTION_TOGGLE</td>
-	<td>//h4[contains(text(), '${key_subscriptionName}')]//following-sibling::span[contains(@class,'toggle-switch-handle')]</td>
+	<td>//div[contains(@class,'h4') and contains(text(), '${key_subscriptionName}')]//following-sibling::span[contains(@class,'toggle-switch-handle')]</td>
 	<td></td>
 </tr>
 <tr>
 	<td>SUBSCRIPTION_FIELD_LABEL</td>
-	<td>//h4[contains(text(), '${key_subscriptionName}')]/..//label[contains(.,'${key_subscriptionFieldLabel}')]/..//select</td>
+	<td>//div[contains(@class,'h4') and contains(text(), '${key_subscriptionName}')]/..//label[contains(.,'${key_subscriptionFieldLabel}')]/..//select</td>
 	<td></td>
 </tr>
 <tr>
 	<td>SUBSCRIPTION_FIELD_LABEL_N</td>
-	<td>xpath=(//h4[contains(text(), '${key_subscriptionName}')]/..//label[contains(.,'${key_subscriptionFieldLabel}')]/..//select)[${key_indexNumber}]</td>
+	<td>xpath=(//div[contains(@class,'h4') and contains(text(), '${key_subscriptionName}')]/..//label[contains(.,'${key_subscriptionFieldLabel}')]/..//select)[${key_indexNumber}]</td>
 	<td></td>
 </tr>
 <tr>
 	<td>SUBSCRIPTION_TYPE_IN_LENGTH</td>
-	<td>//h4[contains(text(), '${key_subscriptionName}')]/..//label[contains(.,'${key_subscriptionFieldLabel}')]/..//span</td>
+	<td>//div[contains(@class,'h4') and contains(text(), '${key_subscriptionName}')]/..//label[contains(.,'${key_subscriptionFieldLabel}')]/..//span</td>
 	<td></td>
 </tr>
 <tr>
@@ -1423,7 +1423,7 @@
 
 <tr>
 	<td>DELETE_OPTION_BUTTON</td>
-	<td>//h4[contains(.,'Option')]//..//button[contains(.,'Delete')]</td>
+	<td>//div[contains(@class,'h4') and contains(.,'Option')]//..//button[contains(.,'Delete')]</td>
 	<td></td>
 </tr>
 <tr>
@@ -1538,7 +1538,7 @@
 </tr>
 <tr>
 	<td>ENTRY_SUBSCRIPTIONS</td>
-	<td>//h4[contains(text(),'${key_entryName}')]</td>
+	<td>//div[contains(@class,'h4') and contains(text(),'${key_entryName}')]</td>
 	<td></td>
 </tr>
 <tr>
@@ -1617,7 +1617,7 @@
 
 <tr>
 	<td>CHECK_SPECIFIC_TOGGLE_SWITCH</td>
-	<td>//h4[contains(.,"${key_name}")]//span[contains(@id,'toggle-switch')]//..//..//..//div[contains(@class,'collapse show')]</td>
+	<td>//div[contains(@class,'h4') and contains(.,"${key_name}")]//span[contains(@id,'toggle-switch')]//..//..//..//div[contains(@class,'collapse show')]</td>
 	<td></td>
 </tr>
 

--- a/modules/apps/commerce/commerce-product-test/src/testFunctional/paths/CommerceFrontStore.path
+++ b/modules/apps/commerce/commerce-product-test/src/testFunctional/paths/CommerceFrontStore.path
@@ -277,7 +277,7 @@
 </tr>
 <tr>
 	<td>PRODUCT_DETAILS_REPLACEMENTS_SKU</td>
-	<td>//h4[contains(text(),'Replacements')]/..//div[contains(@class,'content-wrapper')]//a[text()='${key_productSku}']</td>
+	<td>//div[contains(@class,'h4') and contains(text(),'Replacements')]/..//div[contains(@class,'content-wrapper')]//a[text()='${key_productSku}']</td>
 	<td></td>
 </tr>
 <tr>

--- a/modules/apps/commerce/commerce-product-test/src/testFunctional/paths/CommerceNavigation.path
+++ b/modules/apps/commerce/commerce-product-test/src/testFunctional/paths/CommerceNavigation.path
@@ -62,7 +62,7 @@
 </tr>
 <tr>
 	<td>DATASET_SEARCH_FIELD_BY_LABEL</td>
-	<td>//h4[normalize-space(text())='${key_label}']//following::input[@aria-label='Search']</td>
+	<td>//div[contains(@class,'h4') and normalize-space(text())='${key_label}']//following::input[@aria-label='Search']</td>
 	<td></td>
 </tr>
 <tr>

--- a/modules/apps/commerce/commerce-product-test/src/testFunctional/paths/CommerceOrders.path
+++ b/modules/apps/commerce/commerce-product-test/src/testFunctional/paths/CommerceOrders.path
@@ -22,7 +22,7 @@
 </tr>
 <tr>
 	<td>ORDER_DETAILS_EDIT_BUTTON</td>
-	<td>//h4[contains(text(),'${key_titleName}')]/a[contains(text(),'Edit')]</td>
+	<td>//div[contains(@class,'h4') and contains(text(),'${key_titleName}')]/a[contains(text(),'Edit')]</td>
 	<td></td>
 </tr>
 <tr>
@@ -32,7 +32,7 @@
 </tr>
 <tr>
 	<td>ORDER_DETAILS_PAYMENT_EDIT_BUTTON</td>
-	<td>//h4[contains(.,'${key_table}')]//a[contains(.,'${key_title}')]</td>
+	<td>//div[contains(@class,'h4') and contains(.,'${key_table}')]//a[contains(.,'${key_title}')]</td>
 	<td></td>
 </tr>
 <tr>
@@ -365,7 +365,7 @@
 </tr>
 <tr>
 	<td>ORDER_VIEW_SUMMARY_FIELDS_TOTAL</td>
-	<td>//div[contains(@class,'summary-table')]//*[contains(text(),'${key_label}')]/..//following-sibling::div[1]//h4</td>
+	<td>//div[contains(@class,'summary-table')]//*[contains(text(),'${key_label}')]/..//following-sibling::div[1]//div[contains(@class,'h4')]</td>
 	<td></td>
 </tr>
 </tbody>

--- a/modules/apps/commerce/commerce-product-type-grouped-web/src/main/resources/META-INF/resources/cp_definition_grouped_entry_info_panel.jsp
+++ b/modules/apps/commerce/commerce-product-type-grouped-web/src/main/resources/META-INF/resources/cp_definition_grouped_entry_info_panel.jsp
@@ -31,7 +31,7 @@ if (cpDefinitionGroupedEntries == null) {
 		<div class="sidebar-header">
 			<div class="autofit-row sidebar-section">
 				<div class="autofit-col autofit-col-expand">
-					<h4 class="component-title"><%= HtmlUtil.escape(cProductCPDefinition.getName(themeDisplay.getLanguageId())) %></h4>
+					<div class="component-title"><%= HtmlUtil.escape(cProductCPDefinition.getName(themeDisplay.getLanguageId())) %></div>
 				</div>
 
 				<div class="autofit-col">
@@ -59,7 +59,7 @@ if (cpDefinitionGroupedEntries == null) {
 		<div class="sidebar-header">
 			<div class="autofit-row sidebar-section">
 				<div class="autofit-col autofit-col-expand">
-					<h4 class="component-title"><liferay-ui:message arguments="<%= cpDefinitionGroupedEntries.size() %>" key="x-items-are-selected" /></h4>
+					<div class="component-title"><liferay-ui:message arguments="<%= cpDefinitionGroupedEntries.size() %>" key="x-items-are-selected" /></div>
 				</div>
 			</div>
 		</div>

--- a/modules/apps/commerce/commerce-product-type-virtual-web/src/main/resources/META-INF/resources/sample.jspf
+++ b/modules/apps/commerce/commerce-product-type-virtual-web/src/main/resources/META-INF/resources/sample.jspf
@@ -21,7 +21,7 @@
 </aui:fieldset>
 
 <div class="col-md-3">
-	<h4 class="text-default"><liferay-ui:message key="select-existing-content-or-add-the-url-below" /></h4>
+	<div class="h4 text-default"><liferay-ui:message key="select-existing-content-or-add-the-url-below" /></div>
 </div>
 
 <div class="col-md-9">
@@ -52,7 +52,7 @@
 
 		<aui:button name="selectSampleFile" value="select" />
 
-		<h4 class="<%= textCssClass %>" id="lfr-definition-virtual-sample-button-row-message"><liferay-ui:message key="or" /></h4>
+		<div class="h4 <%= textCssClass %>" id="lfr-definition-virtual-sample-button-row-message"><liferay-ui:message key="or" /></div>
 
 		<aui:input label="sample-file-url" name="sampleURL" />
 	</aui:fieldset>

--- a/modules/apps/commerce/commerce-product-type-virtual-web/src/main/resources/META-INF/resources/terms_of_use.jspf
+++ b/modules/apps/commerce/commerce-product-type-virtual-web/src/main/resources/META-INF/resources/terms_of_use.jspf
@@ -22,7 +22,7 @@
 
 <div class="row" id="<portlet:namespace />termsOfUseSettings">
 	<div class="col-md-3">
-		<h4 class="text-default"><liferay-ui:message key="select-existing-content-or-add-terms-of-use-in-the-space-below" /></h4>
+		<div class="h4 text-default"><liferay-ui:message key="select-existing-content-or-add-terms-of-use-in-the-space-below" /></div>
 	</div>
 
 	<div class="col-md-9">
@@ -52,7 +52,7 @@
 			<aui:button name="selectArticle" value="select-web-content" />
 
 			<aui:field-wrapper cssClass="lfr-definition-virtual-setting-content">
-				<h4 class="text-default"><liferay-ui:message key="or" /></h4>
+				<div class="h4 text-default"><liferay-ui:message key="or" /></div>
 
 				<div class="entry-content form-group">
 					<liferay-ui:input-localized

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/js/components/rules/editor/Actions.es.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/js/components/rules/editor/Actions.es.js
@@ -67,7 +67,9 @@ const ActionContentCalculate = ({
 const ActionCalculate = ({children}) => (
 	<>
 		<Timeline.FormGroupItem className="form-group-item-label form-group-item-shrink">
-			<h4>{Liferay.Language.get('choose-a-field-to-show-the-result')}</h4>
+			<div className="h4">
+				{Liferay.Language.get('choose-a-field-to-show-the-result')}
+			</div>
 		</Timeline.FormGroupItem>
 		{children}
 	</>

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/js/components/rules/editor/Conditions.es.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/js/components/rules/editor/Conditions.es.js
@@ -414,11 +414,11 @@ export function Conditions({
 								openModal({
 									payload: {
 										body: (
-											<h4>
+											<div className="h4">
 												{Liferay.Language.get(
 													'are-you-sure-you-want-to-delete-this-condition'
 												)}
-											</h4>
+											</div>
 										),
 										footer: [
 											null,

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/js/components/rules/editor/Timeline.es.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/js/components/rules/editor/Timeline.es.js
@@ -49,11 +49,11 @@ const Panel = ({bottomContent, children, expression}) => (
 		<ClayPanel.Body>
 			<div className="form-group-autofit">
 				<FormGroupItem className="form-group-item-label form-group-item-shrink">
-					<h4>
+					<div className="h4">
 						<span className="text-truncate-inline">
 							<span className="text-truncate">{expression}</span>
 						</span>
-					</h4>
+					</div>
 				</FormGroupItem>
 
 				{children}

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/view_record_history.jsp
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/view_record_history.jsp
@@ -23,9 +23,9 @@ for (DDLRecordVersion recordVersion : DDLRecordVersionServiceUtil.getRecordVersi
 			<clay:content-col
 				expand="<%= true %>"
 			>
-				<h4 class="list-group-title">
+				<div class="list-group-title">
 					<liferay-ui:message arguments="<%= recordVersion.getVersion() %>" key="version-x" />
-				</h4>
+				</div>
 
 				<p class="list-group-subtitle">
 					<liferay-ui:message key="author" />: <%= HtmlUtil.escape(recordVersion.getUserName()) %>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-web/src/main/resources/META-INF/resources/css/main.scss
@@ -26,7 +26,11 @@
 	}
 
 	td.lfr-name-column,
-	.lfr-search-container-wrapper .list-group .list-group-item .autofit-col h4 {
+	.lfr-search-container-wrapper
+		.list-group
+		.list-group-item
+		.autofit-col
+		.h4 {
 		font-weight: 600;
 	}
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-web/src/main/resources/META-INF/resources/data_provider_descriptive.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-web/src/main/resources/META-INF/resources/data_provider_descriptive.jsp
@@ -14,11 +14,11 @@ DDMDataProviderInstance ddmDataProviderInstance = (DDMDataProviderInstance)row.g
 %>
 
 <div class="clamp-container">
-	<h4 class="text-truncate">
+	<div class="h4 text-truncate">
 		<aui:a href="<%= (String)request.getAttribute(WebKeys.SEARCH_ENTRY_HREF) %>">
 			<%= HtmlUtil.escape(ddmDataProviderInstance.getName(locale)) %>
 		</aui:a>
-	</h4>
+	</div>
 
 	<h5 class="text-default">
 		<div class="text-truncate">

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/DocumentLibrary/DocumentLibrary.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/DocumentLibrary/DocumentLibrary.es.js
@@ -24,9 +24,9 @@ const CardItem = ({fileEntryTitle, fileEntryURL}) => {
 		<ClayCard horizontal>
 			<ClayCard.Body>
 				<div className="card-col-content card-col-gutters">
-					<h4 className="text-truncate" title={fileEntryTitle}>
+					<div className="h4 text-truncate" title={fileEntryTitle}>
 						{fileEntryTitle}
-					</h4>
+					</div>
 				</div>
 
 				<div className="card-col-field">

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/css/_general.scss
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/css/_general.scss
@@ -302,6 +302,7 @@ div.lfr-de__partial-results--background {
 	}
 
 	.ddm-form-basic-info {
+		.h4,
 		h1,
 		h2,
 		h3,

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/view_element_set_descriptive.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/view_element_set_descriptive.jsp
@@ -18,11 +18,11 @@ dateSearchEntry.setDate(ddmStructure.getModifiedDate());
 %>
 
 <div class="clamp-container">
-	<h4 class="text-truncate">
+	<div class="h4 text-truncate">
 		<aui:a cssClass="form-instance-name" href="<%= (String)request.getAttribute(WebKeys.SEARCH_ENTRY_HREF) %>">
 			<%= HtmlUtil.escape(ddmStructure.getName(locale)) %>
 		</aui:a>
-	</h4>
+	</div>
 
 	<h5 class="text-default">
 		<div class="form-instance-description text-truncate">

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/js/pages/RuleEditor.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/js/pages/RuleEditor.es.js
@@ -30,11 +30,11 @@ export function RuleEditor({onCancel, onSave, rule, ...otherProps}) {
 			<div className="form-rule-builder-header">
 				<h2 className="text-default">{Liferay.Language.get('rule')}</h2>
 
-				<h4 className="text-default">
+				<div className="h4 text-default">
 					{Liferay.Language.get(
 						'define-condition-and-action-to-change-fields-and-elements-on-the-form'
 					)}
-				</h4>
+				</div>
 			</div>
 
 			<DataEngineRuleEditor

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/js/pages/RuleEditor.scss
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/js/pages/RuleEditor.scss
@@ -9,6 +9,7 @@
 			padding-top: 40px;
 		}
 
+		.h4,
 		h2,
 		h4 {
 			font-weight: normal;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/META-INF/resources/notification/form_entry_add_body.ftl
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/META-INF/resources/notification/form_entry_add_body.ftl
@@ -42,7 +42,7 @@
 			text-align: center;
 		}
 
-		h4 {
+		.h4 {
 			color: #9aa2a6;
 			font-size: 21px;
 			font-weight: 500;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/META-INF/resources/notification/form_entry_add_body.ftl
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/META-INF/resources/notification/form_entry_add_body.ftl
@@ -107,7 +107,7 @@
 
 						<#foreach page in pages>
 							<div class="introduction">
-								<h4>${page.title}</h4>
+								<div class="h4">${page.title}</div>
 
 								<#foreach field in page.fields>
 

--- a/modules/apps/export-import/export-import-service/src/main/resources/com/liferay/exportimport/internal/background/task/display/dependencies/export_import_background_task_details.ftl
+++ b/modules/apps/export-import/export-import-service/src/main/resources/com/liferay/exportimport/internal/background/task/display/dependencies/export_import_background_task_details.ftl
@@ -1,11 +1,11 @@
 <div class="alert alert-danger publish-error">
-	<h4 class="upload-error-message">
+	<div class="h4 upload-error-message">
 		<#if exported && !validated>
 			<@liferay.language key="the-publication-process-did-not-start-due-to-validation-errors" />
 		<#else>
 			<@liferay.language key="an-unexpected-error-occurred-with-the-publication-process.-please-check-your-portal-and-publishing-configuration" />
 		</#if>
-	</h4>
+	</div>
 
 	<span class="error-message">${htmlUtil.escape(statusMessageJSONObject.getString("message"))}</span>
 

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/publish_process_message_task_details.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/publish_process_message_task_details.jsp
@@ -37,10 +37,10 @@ catch (Exception e) {
 
 			<c:choose>
 				<c:when test="<%= exported && !validated %>">
-					<h4 class="upload-error-message"><liferay-ui:message key="the-publish-process-did-not-start-due-to-validation-errors" /></h4>
+					<div class="h4 upload-error-message"><liferay-ui:message key="the-publish-process-did-not-start-due-to-validation-errors" /></div>
 				</c:when>
 				<c:otherwise>
-					<h4 class="upload-error-message"><liferay-ui:message key="an-unexpected-error-occurred-with-the-publish-process.-please-check-your-portal-and-publishing-configuration" /></h4>
+					<div class="h4 upload-error-message"><liferay-ui:message key="an-unexpected-error-occurred-with-the-publish-process.-please-check-your-portal-and-publishing-configuration" /></div>
 				</c:otherwise>
 			</c:choose>
 

--- a/modules/apps/frontend-css/frontend-css-cadmin-web/src/main/resources/META-INF/resources/clay_admin.scss
+++ b/modules/apps/frontend-css/frontend-css-cadmin-web/src/main/resources/META-INF/resources/clay_admin.scss
@@ -621,10 +621,13 @@ html#{$cadmin-selector} {
 				position: relative;
 				text-align: center;
 
-				h4 span {
-					display: block;
-					margin: 5px 0;
-					text-transform: lowercase;
+				.h4,
+				h4 {
+					span {
+						display: block;
+						margin: 5px 0;
+						text-transform: lowercase;
+					}
 				}
 
 				.or-text {
@@ -694,6 +697,7 @@ html#{$cadmin-selector} {
 			.upload-list-info {
 				margin: 1em 0 0.5em;
 
+				.h4,
 				h4 {
 					font-size: 1.3em;
 				}

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/timeline/Timeline.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/timeline/Timeline.js
@@ -19,7 +19,7 @@ function TimelineEntry({date, description, title}) {
 				<div className="panel-body">
 					<div className="mb-2 row">
 						<div className="col">
-							<h4 className="mb-0">{title}</h4>
+							<div className="h4 mb-0">{title}</div>
 						</div>
 
 						<div className="col-auto">{description}</div>

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/upload.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/upload.js
@@ -85,7 +85,7 @@ AUI.add(
 
 			'<tpl if="values.error && !this.multipleFiles">',
 			'<li class="alert alert-danger upload-error" data-fileId="{id}" id="{id}">',
-			'<h4 class="upload-error-message">{[ Lang.sub(this.strings.fileCannotBeSavedText, [LString.escapeHTML(values.name)]) ]}</h4>',
+			'<div class="h4 upload-error-message">{[ Lang.sub(this.strings.fileCannotBeSavedText, [LString.escapeHTML(values.name)]) ]}</div>',
 
 			'<span class="error-message" title="{[ LString.escapeHTML(values.error) ]}">{[ LString.escapeHTML(values.error) ]}</span>',
 
@@ -135,7 +135,7 @@ AUI.add(
 			'</div>',
 
 			'<div class="hide upload-list-info" id="{$ns}listInfo">',
-			'<h4>{[ this.strings.uploadsCompleteText ]}</h4>',
+			'<div class="h4">{[ this.strings.uploadsCompleteText ]}</div>',
 			'</div>',
 
 			'<div class="alert alert-warning hide pending-files-info" role="alert">',

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/upload.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/upload.js
@@ -654,7 +654,7 @@ AUI.add(
 					const removeOnComplete = instance.get('removeOnComplete');
 
 					if (removeOnComplete) {
-						instance._listInfo.one('h4').hide();
+						instance._listInfo.one('.h4').hide();
 
 						instance._allRowIdsCheckbox.hide();
 					}
@@ -1167,7 +1167,7 @@ AUI.add(
 
 					const strings = instance.get(STRINGS);
 
-					const infoTitle = instance._listInfo.one('h4');
+					const infoTitle = instance._listInfo.one('.h4');
 
 					if (!instance.get('multipleFiles')) {
 						infoTitle.html('');

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/cards.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/cards.jsp
@@ -49,7 +49,7 @@ ClaySampleImageCard claySampleImageCard = new ClaySampleImageCard();
 	</clay:col>
 </clay:row>
 
-<h4>Image Card with Sticker</h4>
+<div class="h4">Image Card with Sticker</div>
 
 <clay:row>
 	<clay:col
@@ -93,7 +93,7 @@ ClaySampleImageCard claySampleImageCard = new ClaySampleImageCard();
 	</clay:col>
 </clay:row>
 
-<h4>Image Card with Sticker Shape</h4>
+<div class="h4">Image Card with Sticker Shape</div>
 
 <clay:row>
 	<clay:col
@@ -142,7 +142,7 @@ ClaySampleImageCard claySampleImageCard = new ClaySampleImageCard();
 	</clay:col>
 </clay:row>
 
-<h4>Image Card with Labels</h4>
+<div class="h4">Image Card with Labels</div>
 
 <clay:row>
 	<clay:col
@@ -189,7 +189,7 @@ ClaySampleImageCard claySampleImageCard = new ClaySampleImageCard();
 	</clay:col>
 </clay:row>
 
-<h4>Selectable Image Card</h4>
+<div class="h4">Selectable Image Card</div>
 
 <clay:row>
 	<clay:col
@@ -244,7 +244,7 @@ ClaySampleImageCard claySampleImageCard = new ClaySampleImageCard();
 	</clay:col>
 </clay:row>
 
-<h4>Image Card Using Model</h4>
+<div class="h4">Image Card Using Model</div>
 
 <clay:row>
 	<clay:col
@@ -280,7 +280,7 @@ ClaySampleImageCard claySampleImageCard = new ClaySampleImageCard();
 	</clay:col>
 </clay:row>
 
-<h4>File Cards</h4>
+<div class="h4">File Cards</div>
 
 <%
 ClaySampleFileCard claySampleFileCard = new ClaySampleFileCard();
@@ -333,7 +333,7 @@ ClaySampleFileCard claySampleFileCard = new ClaySampleFileCard();
 	</clay:col>
 </clay:row>
 
-<h4>File Cards Using Model</h4>
+<div class="h4">File Cards Using Model</div>
 
 <clay:row>
 	<clay:col
@@ -374,7 +374,7 @@ ClaySampleFileCard claySampleFileCard = new ClaySampleFileCard();
 	</clay:col>
 </clay:row>
 
-<h4>User Cards</h4>
+<div class="h4">User Cards</div>
 
 <%
 ClaySampleUserCard claySampleUserCard = new ClaySampleUserCard();
@@ -423,7 +423,7 @@ ClaySampleUserCard claySampleUserCard = new ClaySampleUserCard();
 	</clay:col>
 </clay:row>
 
-<h4>Selectable User Cards</h4>
+<div class="h4">Selectable User Cards</div>
 
 <clay:row>
 	<clay:col
@@ -466,7 +466,7 @@ ClaySampleUserCard claySampleUserCard = new ClaySampleUserCard();
 	</clay:col>
 </clay:row>
 
-<h4>User Cards Using Model</h4>
+<div class="h4">User Cards Using Model</div>
 
 <clay:row>
 	<clay:col
@@ -515,7 +515,7 @@ ClaySampleUserCard claySampleUserCard = new ClaySampleUserCard();
 	</clay:col>
 </clay:row>
 
-<h4>Selectable User Cards Using Display Context</h4>
+<div class="h4">Selectable User Cards Using Display Context</div>
 
 <clay:row>
 	<clay:col
@@ -567,7 +567,7 @@ ClaySampleUserCard claySampleUserCard = new ClaySampleUserCard();
 	</clay:col>
 </clay:row>
 
-<h4>Horizontal Cards</h4>
+<div class="h4">Horizontal Cards</div>
 
 <clay:row>
 	<clay:col
@@ -621,7 +621,7 @@ ClaySampleUserCard claySampleUserCard = new ClaySampleUserCard();
 	</clay:col>
 </clay:row>
 
-<h4>Vertical Cards</h4>
+<div class="h4">Vertical Cards</div>
 
 <%
 ClaySampleVerticalCard claySampleVerticalCard = new ClaySampleVerticalCard();
@@ -661,7 +661,7 @@ ClaySampleVerticalCard claySampleVerticalCard = new ClaySampleVerticalCard();
 	</clay:col>
 </clay:row>
 
-<h4>Vertical Cards Using Model</h4>
+<div class="h4">Vertical Cards Using Model</div>
 
 <clay:row>
 	<clay:col
@@ -703,7 +703,7 @@ ClaySampleVerticalCard claySampleVerticalCard = new ClaySampleVerticalCard();
 	</clay:col>
 </clay:row>
 
-<h4>Navigation Cards</h4>
+<div class="h4">Navigation Cards</div>
 
 <clay:row>
 	<clay:col

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/js/translation_manager/components/DeleteLocaleModal.js
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/js/translation_manager/components/DeleteLocaleModal.js
@@ -11,11 +11,11 @@ export default function DeleteLocaleModal({observer, onCancel, onConfirm}) {
 	return (
 		<ClayModal observer={observer} size="sm">
 			<ClayModal.Body>
-				<h4>
+				<div className="h4">
 					{Liferay.Language.get(
 						'are-you-sure-you-want-to-deactivate-this-language'
 					)}
-				</h4>
+				</div>
 			</ClayModal.Body>
 
 			<ClayModal.Footer

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/translation_manager/components/DeleteLocaleModal.js
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/translation_manager/components/DeleteLocaleModal.js
@@ -11,11 +11,11 @@ export default function DeleteLocaleModal({observer, onCancel, onConfirm}) {
 	return (
 		<ClayModal observer={observer} size="sm">
 			<ClayModal.Body>
-				<h4>
+				<div className="h4">
 					{Liferay.Language.get(
 						'are-you-sure-you-want-to-deactivate-this-language'
 					)}
-				</h4>
+				</div>
 			</ClayModal.Body>
 
 			<ClayModal.Footer

--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portal/_uploader.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portal/_uploader.scss
@@ -84,6 +84,7 @@
 	.upload-list-info {
 		margin: 1em 0 0.5em;
 
+		.h4,
 		h4 {
 			font-size: 1.3em;
 		}

--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/taglib/_search_container.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/taglib/_search_container.scss
@@ -129,6 +129,7 @@ $table-responsive-margin-left-md: 375px !default;
 		}
 
 		.list-group-item {
+			.h4,
 			h4 {
 				font-size: $font-size-sm;
 				line-height: 1.5;

--- a/modules/apps/headless/headless-discovery/headless-discovery-web/src/css/main.css
+++ b/modules/apps/headless/headless-discovery/headless-discovery-web/src/css/main.css
@@ -9,8 +9,11 @@ body {
 	padding-left: 30px;
 }
 
-h4 span {
-	font-size: 14px;
+.h4,
+h4 {
+	span {
+		font-size: 14px;
+	}
 }
 
 .swagger-ui .responses-table {

--- a/modules/apps/headless/headless-discovery/headless-discovery-web/src/css/main.css
+++ b/modules/apps/headless/headless-discovery/headless-discovery-web/src/css/main.css
@@ -9,11 +9,9 @@ body {
 	padding-left: 30px;
 }
 
-.h4,
-h4 {
-	span {
-		font-size: 14px;
-	}
+.h4 span,
+h4 span {
+	font-size: 14px;
 }
 
 .swagger-ui .responses-table {

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/move_articles_and_folders.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/move_articles_and_folders.jsp
@@ -43,7 +43,7 @@ JournalMoveEntriesDisplayContext journalMoveEntriesDisplayContext = new JournalM
 			%>
 
 			<c:if test="<%= !validMoveFolders.isEmpty() %>">
-				<h4><liferay-ui:message arguments="<%= validMoveFolders.size() %>" key="x-folders-are-ready-to-be-moved" translateArguments="<%= false %>" /></h4>
+				<div class="h4"><liferay-ui:message arguments="<%= validMoveFolders.size() %>" key="x-folders-are-ready-to-be-moved" translateArguments="<%= false %>" /></div>
 
 				<ul class="list-unstyled">
 
@@ -69,7 +69,7 @@ JournalMoveEntriesDisplayContext journalMoveEntriesDisplayContext = new JournalM
 			%>
 
 			<c:if test="<%= !invalidMoveFolders.isEmpty() %>">
-				<h4><liferay-ui:message arguments="<%= invalidMoveFolders.size() %>" key="x-folders-cannot-be-moved" translateArguments="<%= false %>" /></h4>
+				<div class="h4"><liferay-ui:message arguments="<%= invalidMoveFolders.size() %>" key="x-folders-cannot-be-moved" translateArguments="<%= false %>" /></div>
 
 				<ul class="list-unstyled">
 
@@ -100,7 +100,7 @@ JournalMoveEntriesDisplayContext journalMoveEntriesDisplayContext = new JournalM
 			%>
 
 			<c:if test="<%= !validMoveArticles.isEmpty() %>">
-				<h4><liferay-ui:message arguments="<%= validMoveArticles.size() %>" key="x-web-content-instances-are-ready-to-be-moved" translateArguments="<%= false %>" /></h4>
+				<div class="h4"><liferay-ui:message arguments="<%= validMoveArticles.size() %>" key="x-web-content-instances-are-ready-to-be-moved" translateArguments="<%= false %>" /></div>
 
 				<ul class="list-unstyled">
 
@@ -126,7 +126,7 @@ JournalMoveEntriesDisplayContext journalMoveEntriesDisplayContext = new JournalM
 			%>
 
 			<c:if test="<%= !invalidMoveArticles.isEmpty() %>">
-				<h4><liferay-ui:message arguments="<%= invalidMoveArticles.size() %>" key="x-web-content-instances-cannot-be-moved" translateArguments="<%= false %>" /></h4>
+				<div class="h4"><liferay-ui:message arguments="<%= invalidMoveArticles.size() %>" key="x-web-content-instances-cannot-be-moved" translateArguments="<%= false %>" /></div>
 
 				<ul class="list-unstyled">
 

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/attachments.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/attachments.jsp
@@ -33,7 +33,7 @@ if (kbArticle != null) {
 	<div class="hide selected" id="<portlet:namespace />selectedFileNameMetadataContainer"></div>
 
 	<c:if test="<%= !attachmentsFileEntries.isEmpty() %>">
-		<h4><liferay-ui:message key="saved-attachments" /></h4>
+		<div class="h4"><liferay-ui:message key="saved-attachments" /></div>
 
 		<div id="<portlet:namespace />existingAttachmentsContainer">
 

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/view_kb_suggestion.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/view_kb_suggestion.jsp
@@ -36,9 +36,9 @@ renderResponse.setTitle(viewKBSuggestionDisplayContext.getKBCommentTitle());
 						<%= HtmlUtil.escape(viewKBSuggestionDisplayContext.getModifiedDateLabel()) %>
 					</h5>
 
-					<h4>
+					<div class="h4">
 						<%= HtmlUtil.escape(viewKBSuggestionDisplayContext.getKBCommentTitle()) %>
-					</h4>
+					</div>
 
 					<h5>
 						<span class="kb-comment-status text-default">

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/info_panel.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/info_panel.jsp
@@ -48,7 +48,7 @@ if (ListUtil.isEmpty(kbFolders) && ListUtil.isEmpty(kbArticles)) {
 		<div class="sidebar-header">
 			<div class="autofit-row sidebar-section">
 				<div class="autofit-col autofit-col-expand">
-					<h4 class="component-title"><%= (kbFolder != null) ? HtmlUtil.escape(kbFolder.getName()) : LanguageUtil.get(request, "home") %></h4>
+					<div class="component-title"><%= (kbFolder != null) ? HtmlUtil.escape(kbFolder.getName()) : LanguageUtil.get(request, "home") %></div>
 
 					<h5 class="component-subtitle">
 						<liferay-ui:message key="folder" />
@@ -157,7 +157,7 @@ if (ListUtil.isEmpty(kbFolders) && ListUtil.isEmpty(kbArticles)) {
 					expand="<%= true %>"
 				>
 					<clay:content-section>
-						<h4 class="component-title"><%= HtmlUtil.escape(kbArticle.getTitle()) %></h4>
+						<div class="component-title"><%= HtmlUtil.escape(kbArticle.getTitle()) %></div>
 
 						<clay:label
 							displayType="info"
@@ -288,7 +288,7 @@ if (ListUtil.isEmpty(kbFolders) && ListUtil.isEmpty(kbArticles)) {
 		<div class="sidebar-header">
 			<div class="autofit-row sidebar-section">
 				<div class="autofit-col autofit-col-expand">
-					<h4 class="component-title"><liferay-ui:message arguments="<%= kbFolders.size() + kbArticles.size() %>" key="x-items-are-selected" /></h4>
+					<div class="component-title"><liferay-ui:message arguments="<%= kbFolders.size() + kbArticles.size() %>" key="x-items-are-selected" /></div>
 				</div>
 			</div>
 		</div>

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/search/configuration.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/search/configuration.jsp
@@ -57,9 +57,9 @@ kbSearchPortletInstanceConfiguration = ParameterMapUtil.setParameterMap(KBSearch
 
 					<aui:input label="enable-print" name="preferences--enableKBArticlePrint--" type="checkbox" value="<%= kbSearchPortletInstanceConfiguration.enableKBArticlePrint() %>" />
 
-					<h4 class="section-header">
+					<div class="h4 section-header">
 						<liferay-ui:message key="social-bookmarks" />
-					</h4>
+					</div>
 
 					<liferay-social-bookmarks:bookmarks-settings
 						displayStyle="<%= kbSearchPortletInstanceConfiguration.socialBookmarksDisplayStyle() %>"

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/section/configuration.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/section/configuration.jsp
@@ -80,9 +80,9 @@ kbSectionPortletInstanceConfiguration = ParameterMapUtil.setParameterMap(KBSecti
 
 					<aui:input label="enable-print" name="preferences--enableKBArticlePrint--" type="checkbox" value="<%= kbSectionPortletInstanceConfiguration.enableKBArticlePrint() %>" />
 
-					<h4 class="section-header">
+					<div class="h4 section-header">
 						<liferay-ui:message key="social-bookmarks" />
-					</h4>
+					</div>
 
 					<liferay-social-bookmarks:bookmarks-settings
 						displayStyle="<%= kbSectionPortletInstanceConfiguration.socialBookmarksDisplayStyle() %>"

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/look_and_feel_theme_details.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/look_and_feel_theme_details.jsp
@@ -174,7 +174,7 @@ String styleBookWarningMessage = layoutsAdminDisplayContext.getStyleBookWarningM
 </clay:row>
 
 <c:if test="<%= (selPluginPackage != null) && Validator.isNotNull(selPluginPackage.getShortDescription()) %>">
-	<h4><liferay-ui:message key="description" /></h4>
+	<div class="h4"><liferay-ui:message key="description" /></div>
 
 	<p class="text-default">
 		<%= HtmlUtil.escape(selPluginPackage.getShortDescription()) %>

--- a/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/site_settings/open_graph.jsp
+++ b/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/site_settings/open_graph.jsp
@@ -22,9 +22,9 @@ OpenGraphSettingsDisplayContext openGraphSettingsDisplayContext = (OpenGraphSett
 </aui:field-wrapper>
 
 <div class="open-graph-settings <%= openGraphSettingsDisplayContext.isOpenGraphEnabled() ? "" : "disabled" %>" id="<portlet:namespace />openGraphSettings">
-	<h4 class="sheet-subtitle">
+	<div class="sheet-subtitle">
 		<liferay-ui:message key="open-graph-image" />
-	</h4>
+	</div>
 
 	<p class="small text-secondary">
 		<liferay-ui:message key="open-graph-image-description" />

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/css/main.scss
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/css/main.scss
@@ -207,9 +207,12 @@
 		clear: both;
 	}
 
-	.list-group .list-group-item h4,
-	.list-group .list-group-item h2 {
-		font-weight: 400;
+	.list-group .list-group-item {
+		.h4,
+		h2,
+		h4 {
+			font-weight: 400;
+		}
 	}
 
 	.taglib-custom-attributes-list {

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/edit_message_quick_resource.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/edit_message_quick_resource.jsp
@@ -85,7 +85,7 @@ String redirect = ParamUtil.getString(request, "redirect");
 				<%= userDisplayText %>
 			</span>
 
-			<h4 title="<%= HtmlUtil.escape(message.getSubject()) %>">
+			<div class="h4" title="<%= HtmlUtil.escape(message.getSubject()) %>">
 				<c:choose>
 					<c:when test='<%= GetterUtil.getBoolean(request.getAttribute("edit-message.jsp-showPermanentLink")) %>'>
 						<a href="#<portlet:namespace />message_<%= message.getMessageId() %>" title="<liferay-ui:message key="permanent-link-to-this-item" />">
@@ -96,7 +96,7 @@ String redirect = ParamUtil.getString(request, "redirect");
 						<%= HtmlUtil.escape(message.getSubject()) %>
 					</c:otherwise>
 				</c:choose>
-			</h4>
+			</div>
 
 			<%
 			String[] ranks = MBStatsUserLocalServiceUtil.getUserRank(themeDisplay.getSiteGroupId(), themeDisplay.getLanguageId(), message.getUserId());

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_thread_message.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_thread_message.jsp
@@ -62,7 +62,7 @@ User messageUser = UserLocalServiceUtil.fetchUser(message.getUserId());
 					<%= HtmlUtil.escape(userDisplayText) %>
 				</span>
 
-				<h4 title="<%= HtmlUtil.escape(message.getSubject()) %>">
+				<div class="h4" title="<%= HtmlUtil.escape(message.getSubject()) %>">
 					<c:choose>
 						<c:when test="<%= showPermanentLink %>">
 							<a href="#<portlet:namespace />message_<%= message.getMessageId() %>" title="<liferay-ui:message key="permanent-link-to-this-item" />">
@@ -77,7 +77,7 @@ User messageUser = UserLocalServiceUtil.fetchUser(message.getUserId());
 					<c:if test="<%= message.isAnswer() %>">
 						(<liferay-ui:message key="answer[noun]" />)
 					</c:if>
-				</h4>
+				</div>
 
 				<%
 				int messageCount = 0;

--- a/modules/apps/nested-portlets/nested-portlets-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/nested-portlets/nested-portlets-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -24,7 +24,7 @@
 		<liferay-frontend:fieldset
 			cssClass="display-style-icon"
 		>
-			<h4><liferay-ui:message key="layout-template" /></h4>
+			<div class="h4"><liferay-ui:message key="layout-template" /></div>
 
 			<clay:row>
 

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/assign_scopes_tab1.jspf
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/assign_scopes_tab1.jspf
@@ -82,7 +82,7 @@
 								</div>
 
 								<div class="autofit-col autofit-col-expand">
-									<h4 class="list-group-title text-truncate">
+									<div class="list-group-title text-truncate">
 
 										<%
 										AssignableScopes assignableScopes = applicationAssignableScopesRelationsEntry.getKey();
@@ -145,7 +145,7 @@
 												</label>
 											</c:otherwise>
 										</c:choose>
-									</h4>
+									</div>
 
 									<c:if test="<%= !globalScopeAliases.isEmpty() %>">
 										<c:choose>

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/assign_scopes_tab2.jspf
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/assign_scopes_tab2.jspf
@@ -106,7 +106,7 @@
 								</div>
 
 								<div class="autofit-col autofit-col-expand">
-									<h4 class="list-group-title text-truncate"><%= HtmlUtil.escape(assignScopesDisplayContext.getApplicationDescription(applicationName)) %></h4>
+									<div class="list-group-title text-truncate"><%= HtmlUtil.escape(assignScopesDisplayContext.getApplicationDescription(applicationName)) %></div>
 
 									<p class="list-group-subtitle text-truncate">
 										<c:choose>

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/connected_applications/view.jsp
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/connected_applications/view.jsp
@@ -59,9 +59,9 @@ if (Validator.isNotNull(backURL)) {
 				<liferay-ui:search-container-column-text
 					colspan="<%= 2 %>"
 				>
-					<h4>
+					<div class="h4">
 						<aui:a href="<%= viewURL.toString() %>"><%= HtmlUtil.escape(oAuth2Application.getName()) %></aui:a>
-					</h4>
+					</div>
 
 					<h5 class="text-default">
 						<span><liferay-ui:message key="authorization" /></span>:

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/connected_applications/view_application.jsp
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/connected_applications/view_application.jsp
@@ -65,9 +65,9 @@ renderResponse.setTitle(oAuth2Application.getName());
 						</p>
 					</c:if>
 
-					<h4 class="permissions">
+					<div class="h4 permissions">
 						<liferay-ui:message key="permissions" />
-					</h4>
+					</div>
 
 					<ul class="list-group">
 
@@ -85,7 +85,7 @@ renderResponse.setTitle(oAuth2Application.getName());
 								<clay:content-col
 									expand="<%= true %>"
 								>
-									<h4 class="list-group-title text-truncate"><%= HtmlUtil.escape(assignableScopes.getApplicationDescription(applicationName)) %></h4>
+									<div class="list-group-title text-truncate"><%= HtmlUtil.escape(assignableScopes.getApplicationDescription(applicationName)) %></div>
 
 									<p class="list-group-subtitle text-truncate"><%= StringUtil.merge(assignableScopes.getApplicationScopeDescription(themeDisplay.getCompanyId(), applicationName), ", ") %></p>
 								</clay:content-col>
@@ -97,9 +97,9 @@ renderResponse.setTitle(oAuth2Application.getName());
 
 					</ul>
 
-					<h4 class="activity">
+					<div class="activity h4">
 						<liferay-ui:message key="activity" />
-					</h4>
+					</div>
 
 					<p class="last-access text-truncate">
 						<span><liferay-ui:message key="last-access" /></span>:

--- a/modules/apps/object/object-test/src/testFunctional/paths/CreateObject.path
+++ b/modules/apps/object/object-test/src/testFunctional/paths/CreateObject.path
@@ -82,7 +82,7 @@
 	</tr>
 	<tr>
 		<td>DISABLED_TAB_TYPE_RELATIONSHIPS</td>
-		<td>//div[@class = 'layout-tab__tab-types disabled']//h4[@class = 'layout-tab__tab-types__title' and contains(text(),'Relationships')]</td>
+		<td>//div[@class = 'layout-tab__tab-types disabled']//div[contains(@class,'layout-tab__tab-types__title') and contains(text(),'Relationships')]</td>
 		<td></td>
 	</tr>
 	<tr>

--- a/modules/apps/object/object-test/src/testFunctional/paths/ObjectAdmin.path
+++ b/modules/apps/object/object-test/src/testFunctional/paths/ObjectAdmin.path
@@ -372,7 +372,7 @@
 	</tr>
 	<tr>
 		<td>TAB_TYPE</td>
-		<td>//div[@class = 'form-group']//h4[@class = 'layout-tab__tab-types__title' and contains(text(),'${key_type}')]</td>
+		<td>//div[@class = 'form-group']//div[contains(@class,'layout-tab__tab-types__title') and contains(text(),'${key_type}')]</td>
 		<td></td>
 	</tr>
 	<tr>

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/Layout/LayoutScreen/ModalAddObjectLayoutTab.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/Layout/LayoutScreen/ModalAddObjectLayoutTab.tsx
@@ -107,7 +107,7 @@ function TabType({
 				onClick={() => onChangeType(type)}
 				{...(disabled && tabProps)}
 			>
-				<h4 className="layout-tab__tab-types__title">{label}</h4>
+				<div className="h4 layout-tab__tab-types__title">{label}</div>
 
 				<span className="tab__tab-types__description">
 					{description}

--- a/modules/apps/portal-remote/portal-remote-json-web-service-web/src/main/resources/META-INF/resources/action.jsp
+++ b/modules/apps/portal-remote/portal-remote-json-web-service-web/src/main/resources/META-INF/resources/action.jsp
@@ -23,9 +23,9 @@ String signature = ParamUtil.getString(request, "signature");
 				<h2 class="mb-0"><%= jsonWebServiceActionMapping.getPath() %></h2>
 
 				<dl class="align-items-center d-flex lfr-api-http-method mb-0">
-					<h4 class="mb-0 text-secondary">
+					<div class="h4 mb-0 text-secondary">
 						<liferay-ui:message key="http-method" />
-					</h4>
+					</div>
 
 					<span class="label label-inverse-success label-lg ml-3">
 						<span class="label-item label-item-expand">

--- a/modules/apps/portal-search/portal-search-admin-web/src/main/resources/META-INF/resources/connections.jsp
+++ b/modules/apps/portal-search/portal-search-admin-web/src/main/resources/META-INF/resources/connections.jsp
@@ -85,7 +85,7 @@ SearchEngineDisplayContext searchEngineDisplayContext = (SearchEngineDisplayCont
 								>
 									<div class="connection-info-item-header">
 										<div class="connection-info-item-header-block">
-											<h4 class="connection-id">
+											<div class="connection-id h4">
 												<%= connectionInformation.getConnectionId() %>
 
 												<%
@@ -100,7 +100,7 @@ SearchEngineDisplayContext searchEngineDisplayContext = (SearchEngineDisplayCont
 												}
 												%>
 
-											</h4>
+											</div>
 
 											<c:if test="<%= Validator.isNotNull(connectionInformation.getClusterName()) %>">
 												<span class="connection-cluster-name text-secondary"><%= connectionInformation.getClusterName() %></span>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/view_content.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/view_content.jsp
@@ -44,7 +44,7 @@ SearchResultContentDisplayContext searchResultContentDisplayContext = searchResu
 
 <c:if test="<%= searchResultContentDisplayContext.isVisible() %>">
 	<div class="mb-2">
-		<h4 class="component-title">
+		<div class="component-title">
 			<span class="asset-title d-inline">
 				<%= HtmlUtil.escape(searchResultContentDisplayContext.getHeaderTitle()) %>
 			</span>
@@ -62,7 +62,7 @@ SearchResultContentDisplayContext searchResultContentDisplayContext = searchResu
 					/>
 				</span>
 			</c:if>
-		</h4>
+		</div>
 	</div>
 
 	<liferay-asset:asset-display

--- a/modules/apps/portal-settings/portal-settings-authentication-ldap-web/src/main/resources/META-INF/resources/com.liferay.portal.settings.web/edit_ldap_server.jsp
+++ b/modules/apps/portal-settings/portal-settings-authentication-ldap-web/src/main/resources/META-INF/resources/com.liferay.portal.settings.web/edit_ldap_server.jsp
@@ -196,7 +196,7 @@ renderResponse.setTitle((ldapServerId == 0) ? LanguageUtil.get(resourceBundle, "
 
 				<aui:input cssClass="lfr-input-text-container" helpMessage="ignore-user-search-filter-for-auth-help" label="ignore-user-search-filter-for-auth" name='<%= "ldap--" + LDAPConstants.INGORE_USER_SEARCH_FILTER_FOR_AUTH + "--" %>' type="checkbox" value="<%= ignoreUserAuthFilterForAuth %>" />
 
-				<h4><liferay-ui:message key="user-mapping" /></h4>
+				<div class="h4"><liferay-ui:message key="user-mapping" /></div>
 
 				<aui:input cssClass="lfr-input-text-container" label="uuid" name="userMappingUuid" type="text" value="<%= userMappingUuid %>" />
 
@@ -241,7 +241,7 @@ renderResponse.setTitle((ldapServerId == 0) ? LanguageUtil.get(resourceBundle, "
 
 				<aui:input cssClass="lfr-input-text-container" label="import-search-filter" name='<%= "ldap--" + LDAPConstants.GROUP_SEARCH_FILTER + "--" %>' type="text" value="<%= ldapGroupSearchFilter %>" />
 
-				<h4><liferay-ui:message key="group-mapping" /></h4>
+				<div class="h4"><liferay-ui:message key="group-mapping" /></div>
 
 				<aui:input cssClass="lfr-input-text-container" label="group-name" name="groupMappingGroupName" type="text" value="<%= groupMappingGroupName %>" />
 

--- a/modules/apps/portal-settings/portal-settings-web/src/main/resources/META-INF/resources/general.jsp
+++ b/modules/apps/portal-settings/portal-settings-web/src/main/resources/META-INF/resources/general.jsp
@@ -19,7 +19,7 @@ catch (Exception e) {
 
 <aui:input name="<%= Constants.CMD %>" type="hidden" value="<%= Constants.UPDATE %>" />
 
-<h4><liferay-ui:message key="main-configuration" /></h4>
+<div class="h4"><liferay-ui:message key="main-configuration" /></div>
 
 <aui:model-context bean="<%= company %>" model="<%= Company.class %>" />
 
@@ -51,7 +51,7 @@ catch (Exception e) {
 	</clay:col>
 </clay:row>
 
-<h4><liferay-ui:message key="navigation" /></h4>
+<div class="h4"><liferay-ui:message key="navigation" /></div>
 
 <clay:row>
 	<clay:col
@@ -69,7 +69,7 @@ catch (Exception e) {
 	</clay:col>
 </clay:row>
 
-<h4><liferay-ui:message key="additional-information" /></h4>
+<div class="h4"><liferay-ui:message key="additional-information" /></div>
 
 <clay:row>
 	<clay:col

--- a/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/view.jsp
@@ -94,12 +94,12 @@ else {
 							<liferay-ui:message key="last-activity-date" />, <%= dateSearchEntry.getName(request) %>
 						</h5>
 
-						<h4>
+						<div class="h4">
 							<clay:link
 								href="<%= rowURL %>"
 								label="<%= HtmlUtil.escape(workflowTaskDisplayContext.getAssetTitle(workflowTask)) %>"
 							/>
-						</h4>
+						</div>
 
 						<h5 class="text-default">
 							<span class="asset-type">

--- a/modules/apps/portal-workflow/portal-workflow-test/src/testFunctional/paths/MyWorkflowTasks.path
+++ b/modules/apps/portal-workflow/portal-workflow-test/src/testFunctional/paths/MyWorkflowTasks.path
@@ -248,7 +248,7 @@
 </tr>
 <tr>
 	<td>NAME_AUTHOR</td>
-	<td>//h4[(@class= 'component-title mt-0') and contains(., '${key_nameAuthor}')]</td>
+	<td>//div[contains(@class,'component-title') and contains(., '${key_nameAuthor}')]</td>
 	<td></td>
 </tr>
 </tbody>

--- a/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/definition/edit_workflow_definition.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/definition/edit_workflow_definition.jsp
@@ -123,11 +123,11 @@ renderResponse.setTitle((workflowDefinition == null) ? LanguageUtil.get(request,
 						<clay:content-col
 							expand="<%= true %>"
 						>
-							<h4 class="component-title">
+							<div class="component-title">
 								<span class="text-truncate-inline">
 									<span class="text-truncate"><%= HtmlUtil.escape(workflowDefinition.getTitle(LanguageUtil.getLanguageId(request))) %></span>
 								</span>
-							</h4>
+							</div>
 						</clay:content-col>
 					</clay:content-row>
 				</div>

--- a/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/instance/edit_workflow_instance.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/instance/edit_workflow_instance.jsp
@@ -111,9 +111,9 @@ renderResponse.setTitle(workflowInstanceEditDisplayContext.getHeaderTitle());
 							/>
 
 							<c:if test="<%= assetEntry != null %>">
-								<h4 class="task-content-author">
+								<div class="h4 task-content-author">
 									<liferay-ui:message key="author" />
-								</h4>
+								</div>
 
 								<liferay-asset:asset-metadata
 									className="<%= assetEntry.getClassName() %>"

--- a/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/instance/view.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/instance/view.jsp
@@ -53,12 +53,12 @@
 							<liferay-ui:message key="last-activity-date" />, <%= dateSearchEntry.getName(request) %>
 						</h5>
 
-						<h4>
+						<div class="h4">
 							<clay:link
 								href="<%= rowURL %>"
 								label="<%= workflowInstanceViewDisplayContext.getAssetTitle(workflowInstance) %>"
 							/>
-						</h4>
+						</div>
 
 						<h5 class="text-default">
 							<span class="asset-type">

--- a/modules/apps/portal/portal-cluster-multiple-sample-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/portal/portal-cluster-multiple-sample-web/src/main/resources/META-INF/resources/view.jsp
@@ -17,7 +17,7 @@
 ClusterSampleData clusterSampleData = new ClusterSampleData();
 %>
 
-<h4>Server Data:</h4>
+<div class="h4">Server Data:</div>
 
 <p>Following data is from the server that generated this response:</p>
 
@@ -33,7 +33,7 @@ ClusterSampleData clusterSampleData = new ClusterSampleData();
 	</li>
 </ul>
 
-<h4>Session Data:</h4>
+<div class="h4">Session Data:</div>
 
 <%
 ClusterSampleData portletSessionClusterSampleData = (ClusterSampleData)portletSession.getAttribute(ClusterSampleData.class.getName());

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/css/main.scss
@@ -199,6 +199,7 @@ html#{$cadmin-selector} {
 			}
 
 			.list-group-heading {
+				.h4,
 				h1,
 				h2,
 				h3,

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/UserPopover.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/UserPopover.es.js
@@ -24,9 +24,9 @@ export default function UserPopover({creator, statistics}) {
 					/>
 
 					<div className="c-ml-2">
-						<h4 className="font-weight-light h6 text-secondary">
+						<div className="font-weight-light h6 text-secondary">
 							{statistics?.rank}
-						</h4>
+						</div>
 
 						<h3 className="h5">
 							{creator?.name ||

--- a/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/edit_role_permissions_form.jsp
+++ b/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/edit_role_permissions_form.jsp
@@ -75,7 +75,17 @@ if (Validator.isNotNull(portletResource)) {
 
 		<clay:sheet-section>
 			<c:if test="<%= Validator.isNotNull(applicationPermissionsLabel) %>">
-				<h4 class="sheet-subtitle"><liferay-ui:message key="<%= applicationPermissionsLabel %>" /> <liferay-ui:icon-help message='<%= applicationPermissionsLabel + "-help" %>' /></h4>
+				<div class="sheet-subtitle">
+					<liferay-ui:message key="<%= applicationPermissionsLabel %>" />
+
+					<clay:icon
+						aria-label='<%= LanguageUtil.get(request, applicationPermissionsLabel + "-help") %>'
+						cssClass="lfr-portal-tooltip"
+						data-title='<%= LanguageUtil.get(request, applicationPermissionsLabel + "-help") %>'
+						symbol="question-circle-full"
+						tabindex="0"
+					/>
+				</div>
 			</c:if>
 
 			<liferay-util:include page="/edit_role_permissions_resource.jsp" servletContext="<%= application %>" />
@@ -83,7 +93,17 @@ if (Validator.isNotNull(portletResource)) {
 
 		<c:if test="<%= (modelResources != null) && !modelResources.isEmpty() %>">
 			<clay:sheet-section>
-				<h4 class="sheet-subtitle"><liferay-ui:message key="resource-permissions" /> <liferay-ui:icon-help message="resource-permissions-help" /></h4>
+				<div class="sheet-subtitle">
+					<liferay-ui:message key="resource-permissions" />
+
+					<clay:icon
+						aria-label='<%= LanguageUtil.get(request, "resource-permissions-help") %>'
+						cssClass="lfr-portal-tooltip"
+						data-title='<%= LanguageUtil.get(request, "resource-permissions-help") %>'
+						symbol="question-circle-full"
+						tabindex="0"
+					/>
+				</div>
 
 				<div class="permission-group">
 
@@ -115,7 +135,7 @@ if (Validator.isNotNull(portletResource)) {
 
 		<c:if test="<%= portletResource.equals(PortletKeys.PORTLET_DISPLAY_TEMPLATE) || portletResource.equals(TemplatePortletKeys.TEMPLATE) %>">
 			<clay:sheet-section>
-				<h4 class="sheet-subtitle"><liferay-ui:message key="related-application-permissions" /></h4>
+				<div class="sheet-subtitle"><liferay-ui:message key="related-application-permissions" /></div>
 
 				<div class="related-permissions">
 

--- a/modules/apps/sharing/sharing-web/src/main/resources/META-INF/resources/js/sharing/Sharing.js
+++ b/modules/apps/sharing/sharing-web/src/main/resources/META-INF/resources/js/sharing/Sharing.js
@@ -338,9 +338,9 @@ const Sharing = ({
 					/>
 				</ClayForm.Group>
 
-				<h4 className="sheet-tertiary-title">
+				<div className="sheet-tertiary-title">
 					{Liferay.Language.get('sharing-permissions')}
-				</h4>
+				</div>
 
 				<ClayForm.Group>
 					<ClayRadioGroup

--- a/modules/apps/site-initializer/site-initializer-raylife-d2c/extra/remote-app/src/common/components/product-comparison/index.js
+++ b/modules/apps/site-initializer/site-initializer-raylife-d2c/extra/remote-app/src/common/components/product-comparison/index.js
@@ -141,9 +141,9 @@ const ProductComparison = ({
 
 			<div className="d-flex flex-column justify-content-between pb-5 pt-4 px-4 quote-content">
 				<div className="quote-header text-center">
-					<h4 className="font-weight-bolder text-brand-primary text-capitalize">
+					<div className="font-weight-bolder h4 text-brand-primary text-capitalize">
 						{category}
-					</h4>
+					</div>
 
 					<div className="d-flex display-3 flex-row font-weight-bolder justify-content-center text-neutral-10 value">
 						<span>

--- a/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/paths/Raylife.path
+++ b/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/paths/Raylife.path
@@ -137,7 +137,7 @@
 </tr>
 <tr>
 	<td>APPLICATION_ID</td>
-	<td>//h4[@id='content-agent-text-your-application']</td>
+	<td>//div[@id='content-agent-text-your-application']</td>
 	<td></td>
 </tr>
 <tr>

--- a/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/paths/RaylifeQuoteComparison.path
+++ b/modules/apps/site-initializer/site-initializer-raylife-d2c/site-initializer-raylife-d2c-test/src/testFunctional/paths/RaylifeQuoteComparison.path
@@ -12,7 +12,7 @@
 <tbody>
 <tr>
 	<td>BUTTON_PURCHASE_THIS_POLICY</td>
-	<td>//h4[contains(text(),'${policy}')]//..//..//button[contains(text(),'PURCHASE THIS POLICY')]</td>
+	<td>//div[contains(@class,'h4') and contains(text(),'${policy}')]//..//..//button[contains(text(),'PURCHASE THIS POLICY')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/modules/apps/site-initializer/site-initializer-raylife-d2c/src/main/resources/site-initializer/ddm-templates/tip-card/ddm-template.ftl
+++ b/modules/apps/site-initializer/site-initializer-raylife-d2c/src/main/resources/site-initializer/ddm-templates/tip-card/ddm-template.ftl
@@ -114,7 +114,7 @@
 
 <div class="bg-neutral-1 p-4 rounded" id="tip">
 	<#if (title.getData())??>
-		<h4 class="title font-weight-bolder">${title.getData()}</h4>
+		<div class="font-weight-bolder h4 title">${title.getData()}</div>
 	</#if>
 
 	<#if (subtitle.getData())??>

--- a/modules/apps/site-initializer/site-initializer-raylife-d2c/src/main/resources/site-initializer/fragments/group/raylife/fragments/congrats/index.css
+++ b/modules/apps/site-initializer/site-initializer-raylife-d2c/src/main/resources/site-initializer/fragments/group/raylife/fragments/congrats/index.css
@@ -17,6 +17,7 @@
 	line-height: 32px;
 }
 
+.congrats .h4,
 .congrats h4 {
 	color: var(--color-neutral-9);
 	font-size: 16px;

--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/site_settings/categorization.jsp
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/site_settings/categorization.jsp
@@ -17,7 +17,7 @@ Group liveGroup = (Group)request.getAttribute("site.liveGroup");
 
 <liferay-asset:asset-tags-error />
 
-<h4 class="sheet-subtitle"><liferay-ui:message key="categories" /></h4>
+<div class="sheet-subtitle"><liferay-ui:message key="categories" /></div>
 
 <liferay-asset:asset-categories-selector
 	className="<%= Group.class.getName() %>"
@@ -25,7 +25,7 @@ Group liveGroup = (Group)request.getAttribute("site.liveGroup");
 	visibilityTypes="<%= AssetVocabularyConstants.VISIBILITY_TYPES %>"
 />
 
-<h4 class="sheet-subtitle"><liferay-ui:message key="tags" /></h4>
+<div class="sheet-subtitle"><liferay-ui:message key="tags" /></div>
 
 <liferay-asset:asset-tags-selector
 	className="<%= Group.class.getName() %>"

--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/site_settings/pages.jsp
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/site_settings/pages.jsp
@@ -44,7 +44,7 @@ if (!LanguageUtil.isInheritLocales(siteGroup.getGroupId()) && !siteAdminConfigur
 boolean hasUnlinkLayoutSetPrototypePermission = PortalPermissionUtil.contains(permissionChecker, ActionKeys.UNLINK_LAYOUT_SET_PROTOTYPE);
 %>
 
-<h4 class="sheet-subtitle"><liferay-ui:message key="pages" /></h4>
+<div class="sheet-subtitle"><liferay-ui:message key="pages" /></div>
 
 <aui:field-wrapper cssClass="form-group">
 	<c:choose>

--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/site_settings/public_private_pages.jsp
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/site_settings/public_private_pages.jsp
@@ -59,7 +59,7 @@ if (!LanguageUtil.isInheritLocales(siteGroup.getGroupId()) && !siteAdminConfigur
 boolean hasUnlinkLayoutSetPrototypePermission = PortalPermissionUtil.contains(permissionChecker, ActionKeys.UNLINK_LAYOUT_SET_PROTOTYPE);
 %>
 
-<h4 class="sheet-subtitle"><liferay-ui:message key="public-pages" /></h4>
+<div class="sheet-subtitle"><liferay-ui:message key="public-pages" /></div>
 
 <aui:field-wrapper cssClass="form-group">
 	<c:choose>
@@ -152,7 +152,7 @@ boolean hasUnlinkLayoutSetPrototypePermission = PortalPermissionUtil.contains(pe
 	</c:choose>
 </aui:field-wrapper>
 
-<h4 class="sheet-subtitle"><liferay-ui:message key="private-pages" /></h4>
+<div class="sheet-subtitle"><liferay-ui:message key="private-pages" /></div>
 
 <aui:field-wrapper cssClass="form-group">
 	<c:choose>

--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/site_settings/public_private_site_url.jsp
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/site_settings/public_private_site_url.jsp
@@ -131,7 +131,7 @@ if (privateVirtualHostnames.isEmpty()) {
 	</p>
 
 	<div class="mb-5" id="<portlet:namespace />publicVirtualHostFields">
-		<h4 class="sheet-subtitle"><liferay-ui:message key="public-pages" /></h4>
+		<div class="sheet-subtitle"><liferay-ui:message key="public-pages" /></div>
 
 		<%
 		for (Map.Entry<String, String> entry : publicVirtualHostnames.entrySet()) {
@@ -171,7 +171,7 @@ if (privateVirtualHostnames.isEmpty()) {
 	</div>
 
 	<div id="<portlet:namespace />privateVirtualHostFields">
-		<h4 class="sheet-subtitle"><liferay-ui:message key="private-pages" /></h4>
+		<div class="sheet-subtitle"><liferay-ui:message key="private-pages" /></div>
 
 		<%
 		for (Map.Entry<String, String> entry : privateVirtualHostnames.entrySet()) {

--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/site_settings/ratings.jsp
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/site_settings/ratings.jsp
@@ -30,9 +30,9 @@ CompanyPortletRatingsDefinitionDisplayContext companyPortletRatingsDefinitionDis
 		Portlet portlet = PortletLocalServiceUtil.getPortletById(portletId);
 	%>
 
-		<h4 class="text-default">
+		<div class="h4 text-default">
 			<%= PortalUtil.getPortletTitle(portlet, application, locale) %>
-		</h4>
+		</div>
 
 		<%
 		Map<String, RatingsType> ratingsTypeMap = entry.getValue();

--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/site_settings/site_url.jsp
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/site_settings/site_url.jsp
@@ -122,7 +122,7 @@ if (publicVirtualHostnames.isEmpty()) {
 	</p>
 
 	<div class="mb-5" id="<portlet:namespace />publicVirtualHostFields">
-		<h4 class="sheet-subtitle"><liferay-ui:message key="pages" /></h4>
+		<div class="sheet-subtitle"><liferay-ui:message key="pages" /></div>
 
 		<%
 		for (Map.Entry<String, String> entry : publicVirtualHostnames.entrySet()) {

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/organization_info_panel.jsp
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/organization_info_panel.jsp
@@ -14,7 +14,7 @@ List<Organization> organizations = (List<Organization>)request.getAttribute(Site
 <c:choose>
 	<c:when test="<%= ListUtil.isEmpty(organizations) %>">
 		<div class="sidebar-header">
-			<h4><liferay-ui:message key="organizations" /></h4>
+			<div class="h4"><liferay-ui:message key="organizations" /></div>
 		</div>
 
 		<div class="sheet-row">
@@ -47,9 +47,9 @@ List<Organization> organizations = (List<Organization>)request.getAttribute(Site
 		%>
 
 		<div class="sidebar-header">
-			<h4>
+			<div class="h4">
 				<%= organization.getName() %>
-			</h4>
+			</div>
 
 			<div class="h6">
 				<liferay-ui:message key="<%= organization.getType() %>" />
@@ -124,7 +124,7 @@ List<Organization> organizations = (List<Organization>)request.getAttribute(Site
 	</c:when>
 	<c:when test="<%= ListUtil.isNotEmpty(organizations) && (organizations.size() > 1) %>">
 		<div class="sidebar-header">
-			<h4><liferay-ui:message arguments="<%= organizations.size() %>" key="x-items-are-selected" /></h4>
+			<div class="h4"><liferay-ui:message arguments="<%= organizations.size() %>" key="x-items-are-selected" /></div>
 		</div>
 
 		<div class="sheet-row">

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/preview_membership_request.jsp
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/preview_membership_request.jsp
@@ -35,9 +35,9 @@ renderResponse.setTitle(userName);
 	<div class="sheet">
 		<div class="panel-group panel-group-flush">
 			<aui:fieldset>
-				<h4 class="text-default">
+				<div class="h4 text-default">
 					<liferay-ui:message arguments="<%= userName %>" key="requested-by-x" />
-				</h4>
+				</div>
 
 				<div class="nameplate">
 					<div class="nameplate-field">
@@ -77,9 +77,9 @@ renderResponse.setTitle(userName);
 				}
 				%>
 
-				<h4 class="text-default">
+				<div class="h4 text-default">
 					<liferay-ui:message arguments="<%= replier %>" key="replied-by-x" />
-				</h4>
+				</div>
 
 				<div class="nameplate">
 					<c:if test="<%= membershipRequestReplierUser != null %>">
@@ -101,9 +101,9 @@ renderResponse.setTitle(userName);
 					</div>
 				</div>
 
-				<h4 class="text-default">
+				<div class="h4 text-default">
 					<strong><liferay-ui:message key="status" /></strong>
-				</h4>
+				</div>
 
 				<c:choose>
 					<c:when test="<%= membershipRequest.getStatusId() == MembershipRequestConstants.STATUS_APPROVED %>">

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/reply_membership_request.jsp
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/reply_membership_request.jsp
@@ -60,7 +60,7 @@ renderResponse.setTitle(LanguageUtil.format(request, "reply-membership-request-f
 				%>
 
 				<c:if test="<%= Validator.isNotNull(group.getDescription()) %>">
-					<h4 class="text-default"><liferay-ui:message key="description" /></h4>
+					<div class="h4 text-default"><liferay-ui:message key="description" /></div>
 
 					<p class="text-default">
 						<%= HtmlUtil.escape(group.getDescription(locale)) %>

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/user_info_panel.jsp
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/user_info_panel.jsp
@@ -16,7 +16,7 @@ Group group = siteMembershipsDisplayContext.getGroup();
 <c:choose>
 	<c:when test="<%= ListUtil.isEmpty(users) %>">
 		<div class="sidebar-header">
-			<h4>
+			<div class="h4">
 				<liferay-ui:message key="membership-type" />: <liferay-ui:message key="<%= GroupConstants.getTypeLabel(group.getType()) %>" />
 
 				<%
@@ -35,7 +35,7 @@ Group group = siteMembershipsDisplayContext.getGroup();
 
 					<aui:a cssClass="badge badge-primary badge-sm" href="<%= viewMembershipRequestsURL %>" label="<%= String.valueOf(pendingRequests) %>" title='<%= LanguageUtil.format(request, "there-are-x-membership-requests-pending", String.valueOf(pendingRequests), false) %>' />
 				</c:if>
-			</h4>
+			</div>
 
 			<div class="h6 text-secondary">
 				<liferay-ui:message arguments="<%= GroupUtil.getGroupTypeLabel(group, locale) %>" key='<%= "membership-type-" + GroupConstants.getTypeLabel(group.getType()) + "-help" %>' translateArguments="<%= false %>" />
@@ -71,9 +71,9 @@ Group group = siteMembershipsDisplayContext.getGroup();
 		%>
 
 		<div class="sidebar-header">
-			<h4>
+			<div class="h4">
 				<%= HtmlUtil.escape(curUser.getFullName()) %>
-			</h4>
+			</div>
 
 			<div class="h6">
 				<%= curUser.getScreenName() %>
@@ -140,7 +140,7 @@ Group group = siteMembershipsDisplayContext.getGroup();
 	</c:when>
 	<c:when test="<%= ListUtil.isNotEmpty(users) && (users.size() > 1) %>">
 		<div class="sidebar-header">
-			<h4><liferay-ui:message arguments="<%= users.size() %>" key="x-items-are-selected" /></h4>
+			<div class="h4"><liferay-ui:message arguments="<%= users.size() %>" key="x-items-are-selected" /></div>
 		</div>
 
 		<div class="sheet-row">

--- a/modules/apps/staging/staging-configuration-web/src/main/resources/META-INF/resources/publish_process_message_task_details.jsp
+++ b/modules/apps/staging/staging-configuration-web/src/main/resources/META-INF/resources/publish_process_message_task_details.jsp
@@ -37,10 +37,10 @@ catch (Exception e) {
 
 			<c:choose>
 				<c:when test="<%= exported && !validated %>">
-					<h4 class="upload-error-message"><liferay-ui:message key="the-publish-process-did-not-start-due-to-validation-errors" /></h4>
+					<div class="h4 upload-error-message"><liferay-ui:message key="the-publish-process-did-not-start-due-to-validation-errors" /></div>
 				</c:when>
 				<c:otherwise>
-					<h4 class="upload-error-message"><liferay-ui:message key="an-unexpected-error-occurred-with-the-publish-process.-please-check-your-portal-and-publishing-configuration" /></h4>
+					<div class="h4 upload-error-message"><liferay-ui:message key="an-unexpected-error-occurred-with-the-publish-process.-please-check-your-portal-and-publishing-configuration" /></div>
 				</c:otherwise>
 			</c:choose>
 

--- a/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/process_message_task_details/page.jsp
+++ b/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/process_message_task_details/page.jsp
@@ -42,10 +42,10 @@
 
 					<c:choose>
 						<c:when test="<%= exported && !validated %>">
-							<h4 class="upload-error-message"><liferay-ui:message key="the-publish-process-did-not-start-due-to-validation-errors" /></h4>
+							<div class="h4 upload-error-message"><liferay-ui:message key="the-publish-process-did-not-start-due-to-validation-errors" /></div>
 						</c:when>
 						<c:otherwise>
-							<h4 class="upload-error-message"><liferay-ui:message key="an-unexpected-error-occurred-with-the-publish-process.-please-check-your-portal-and-publishing-configuration" /></h4>
+							<div class="h4 upload-error-message"><liferay-ui:message key="an-unexpected-error-occurred-with-the-publish-process.-please-check-your-portal-and-publishing-configuration" /></div>
 						</c:otherwise>
 					</c:choose>
 

--- a/modules/apps/style-book/style-book-web/src/main/resources/META-INF/resources/css/FragmentCollectionPreview.scss
+++ b/modules/apps/style-book/style-book-web/src/main/resources/META-INF/resources/css/FragmentCollectionPreview.scss
@@ -36,9 +36,12 @@ body.page-maximized {
 }
 
 html#{$cadmin-selector} {
-	.cadmin h4 {
-		font-size: 0.875rem;
-		font-weight: 600;
+	.cadmin {
+		.h4,
+		h4 {
+			font-size: 0.875rem;
+			font-weight: 600;
+		}
 	}
 }
 

--- a/modules/apps/style-book/style-book-web/src/main/resources/META-INF/resources/js/fragment-collection-preview/VariationPreview.js
+++ b/modules/apps/style-book/style-book-web/src/main/resources/META-INF/resources/js/fragment-collection-preview/VariationPreview.js
@@ -89,13 +89,13 @@ export function VariationPreview({
 	return (
 		<article className="d-flex flex-column-reverse">
 			<div className="cadmin">
-				<h4
-					className={classNames('mb-0 mt-2 text-secondary', {
+				<div
+					className={classNames('h4 mb-0 mt-2 text-secondary', {
 						'sr-only': !showLabel,
 					})}
 				>
 					{label}
-				</h4>
+				</div>
 			</div>
 
 			<div

--- a/modules/apps/subscription/subscription-web/src/main/resources/META-INF/resources/unsubscribe/unsubscribed.jsp
+++ b/modules/apps/subscription/subscription-web/src/main/resources/META-INF/resources/unsubscribe/unsubscribed.jsp
@@ -49,9 +49,9 @@ if (manageSubscriptionsURL != null) {
 
 	<c:if test="<%= manageSubscriptionsURL != null %>">
 		<p class="help">
-			<h4>
+			<div class="h4">
 				<liferay-ui:message key="did-you-unsubscribe-by-accident" />
-			</h4>
+			</div>
 
 			<a href="<%= manageSubscriptionsURL.toString() %>">
 				<liferay-ui:message key="manage-your-subscriptions" />

--- a/modules/apps/trash/trash-web/src/main/resources/META-INF/resources/info_panel.jsp
+++ b/modules/apps/trash/trash-web/src/main/resources/META-INF/resources/info_panel.jsp
@@ -31,7 +31,7 @@ List<TrashEntry> trashEntries = (List<TrashEntry>)request.getAttribute(TrashWebK
 						<clay:content-col
 							expand="<%= true %>"
 						>
-							<h4 class="component-title"><%= HtmlUtil.escape(trashRenderer.getTitle(locale)) %></h4>
+							<div class="component-title"><%= HtmlUtil.escape(trashRenderer.getTitle(locale)) %></div>
 
 							<p class="component-subtitle">
 								<%= ResourceActionsUtil.getModelResource(locale, trashEntry.getClassName()) %>
@@ -100,7 +100,7 @@ List<TrashEntry> trashEntries = (List<TrashEntry>)request.getAttribute(TrashWebK
 						<clay:content-col
 							expand="<%= true %>"
 						>
-							<h4 class="component-title"><liferay-ui:message arguments="<%= trashEntries.size() %>" key="x-items-are-selected" /></h4>
+							<div class="component-title"><liferay-ui:message arguments="<%= trashEntries.size() %>" key="x-items-are-selected" /></div>
 						</clay:content-col>
 
 						<clay:content-col>

--- a/modules/apps/trash/trash-web/src/main/resources/META-INF/resources/view_content_info_panel.jsp
+++ b/modules/apps/trash/trash-web/src/main/resources/META-INF/resources/view_content_info_panel.jsp
@@ -23,7 +23,7 @@ TrashHandler trashHandler = trashDisplayContext.getTrashHandler();
 			<clay:content-col
 				expand="<%= true %>"
 			>
-				<h4 class="component-title"><%= HtmlUtil.escape(trashRenderer.getTitle(locale)) %></h4>
+				<div class="component-title"><%= HtmlUtil.escape(trashRenderer.getTitle(locale)) %></div>
 			</clay:content-col>
 
 			<clay:content-col>

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/sites.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/sites.jsp
@@ -272,7 +272,7 @@ currentURLObj.setParameter("historyKey", liferayPortletResponse.getNamespace() +
 </c:if>
 
 <c:if test="<%= !inheritedSiteGroups.isEmpty() %>">
-	<h4 class="sheet-tertiary-title"><liferay-ui:message key="inherited-sites" /></h4>
+	<div class="sheet-tertiary-title"><liferay-ui:message key="inherited-sites" /></div>
 
 	<liferay-ui:search-container
 		cssClass="lfr-search-container-inherited-sites"

--- a/modules/apps/wiki/wiki-engine-creole/src/main/java/com/liferay/wiki/engine/creole/internal/antlrwiki/translator/XhtmlTranslator.java
+++ b/modules/apps/wiki/wiki-engine-creole/src/main/java/com/liferay/wiki/engine/creole/internal/antlrwiki/translator/XhtmlTranslator.java
@@ -169,7 +169,7 @@ public class XhtmlTranslator extends XhtmlTranslationVisitor {
 
 		append("<div class=\"toc\">");
 		append("<div class=\"collapsebox\">");
-		append("<h4>");
+		append("<div class=\"h4\">");
 
 		String title = tableOfContentsNode.getTitle();
 
@@ -185,7 +185,7 @@ public class XhtmlTranslator extends XhtmlTranslationVisitor {
 
 		append(StringPool.NBSP);
 		append("<a class=\"toc-trigger\" href=\"javascript:void(0);\">[-]");
-		append("</a></h4>");
+		append("</a></div>");
 		append("<div class=\"toc-index\">");
 
 		_appendTableOfContents(tableOfContents, 1);

--- a/modules/apps/wiki/wiki-engine-creole/src/main/resources/META-INF/resources/help_page.jsp
+++ b/modules/apps/wiki/wiki-engine-creole/src/main/resources/META-INF/resources/help_page.jsp
@@ -8,18 +8,18 @@
 <%@ include file="/init.jsp" %>
 
 <clay:container-fluid>
-	<h4>
+	<div class="h4">
 		<liferay-ui:message key="text-styles" />
-	</h4>
+	</div>
 
 	<pre>
 	//italics//
 	**bold**
 	</pre>
 
-	<h4>
+	<div class="h4">
 		<liferay-ui:message key="headers" />
-	</h4>
+	</div>
 
 	<pre>
 	== Large heading ==
@@ -27,18 +27,18 @@
 	==== Small heading ====
 	</pre>
 
-	<h4>
+	<div class="h4">
 		<liferay-ui:message key="links" />
-	</h4>
+	</div>
 
 	<pre>
 	[[Link to a page]]
 	[[http://www.liferay.com|Link to website]]
 	</pre>
 
-	<h4>
+	<div class="h4">
 		<liferay-ui:message key="lists" />
-	</h4>
+	</div>
 
 	<pre>
 	* Item
@@ -47,18 +47,18 @@
 	## Ordered Subitem
 	</pre>
 
-	<h4>
+	<div class="h4">
 		<liferay-ui:message key="images" />
-	</h4>
+	</div>
 
 	<pre>
 	{{attached-image.png}}
 	{{Page Name/other-image.jpg|label}}
 	</pre>
 
-	<h4>
+	<div class="h4">
 		<liferay-ui:message key="other" />
-	</h4>
+	</div>
 
 	<pre>
 	&lt;&lt;TableOfContents&gt;&gt;

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/item/selector/wiki_pages.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/item/selector/wiki_pages.jsp
@@ -85,11 +85,11 @@ String searchURL = HttpComponentsUtil.removeParameter(
 				WikiPageItemSelectorReturnTypeResolver wikiPageItemSelectorReturnTypeResolver = wikiPageItemSelectorViewDisplayContext.getWikiPageItemSelectorReturnTypeResolver();
 				%>
 
-				<h4>
+				<div class="h4">
 					<a class="wiki-page" data-title="<%= wikiPageItemSelectorReturnTypeResolver.getTitle(curPage, themeDisplay) %>" data-value="<%= wikiPageItemSelectorReturnTypeResolver.getValue(curPage, themeDisplay) %>" href="javascript:void(0);">
 						<%= curPage.getTitle() %>
 					</a>
-				</h4>
+				</div>
 
 				<h5 class="text-default">
 					<aui:workflow-status markupView="lexicon" showIcon="<%= false %>" showLabel="<%= false %>" status="<%= curPage.getStatus() %>" />

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/css/main.scss
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/css/main.scss
@@ -54,6 +54,7 @@
 		border: 1px solid #aaa;
 		padding: 0 1em;
 
+		.h4,
 		h4 {
 			margin-bottom: 0.7em;
 		}
@@ -102,6 +103,7 @@
 			text-decoration: none;
 		}
 
+		.h4,
 		h2,
 		h3,
 		h4 {
@@ -285,6 +287,7 @@
 	}
 
 	.syntax-help {
+		.h4,
 		h4 {
 			margin-bottom: 0.5em;
 		}

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/help/classic_wiki.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/help/classic_wiki.jsp
@@ -7,9 +7,9 @@
 
 <%@ include file="/wiki/init.jsp" %>
 
-<h4>
+<div class="h4">
 	<liferay-ui:message key="text-styles" />
-</h4>
+</div>
 
 <pre>
 'quoted'
@@ -18,9 +18,9 @@
 monospaced
 </pre>
 
-<h4>
+<div class="h4">
 	<liferay-ui:message key="headers" />
-</h4>
+</div>
 
 <pre>
 = Header 1 =
@@ -28,18 +28,18 @@ monospaced
 === Header 3 ===
 </pre>
 
-<h4>
+<div class="h4">
 	<liferay-ui:message key="links" />
-</h4>
+</div>
 
 <pre>
 CamelCaseWordsAreLinksToPages
 [http://www.liferay.com Liferay's Website]
 </pre>
 
-<h4>
+<div class="h4">
 	<liferay-ui:message key="lists" />
-</h4>
+</div>
 
 <pre>
 <i class="icon-long-arrow-right"></i>* Item

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/help/creole.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/help/creole.jsp
@@ -7,18 +7,18 @@
 
 <%@ include file="/wiki/init.jsp" %>
 
-<h4>
+<div class="h4">
 	<liferay-ui:message key="text-styles" />
-</h4>
+</div>
 
 <pre>
 //italics//
 **bold**
 </pre>
 
-<h4>
+<div class="h4">
 	<liferay-ui:message key="headers" />
-</h4>
+</div>
 
 <pre>
 == Large heading ==
@@ -26,18 +26,18 @@
 ==== Small heading ====
 </pre>
 
-<h4>
+<div class="h4">
 	<liferay-ui:message key="links" />
-</h4>
+</div>
 
 <pre>
 [[Link to a page]]
 [[http://www.liferay.com|Link to website]]
 </pre>
 
-<h4>
+<div class="h4">
 	<liferay-ui:message key="lists" />
-</h4>
+</div>
 
 <pre>
 * Item
@@ -46,18 +46,18 @@
 ## Ordered Subitem
 </pre>
 
-<h4>
+<div class="h4">
 	<liferay-ui:message key="images" />
-</h4>
+</div>
 
 <pre>
 {{attached-image.png}}
 {{Page Name/other-image.jpg|label}}
 </pre>
 
-<h4>
+<div class="h4">
 	<liferay-ui:message key="other" />
-</h4>
+</div>
 
 <pre>
 &lt;&lt;TableOfContents&gt;&gt;

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/page_links.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/page_links.jsp
@@ -39,7 +39,7 @@ boolean hasOutgoingLinkPages = ListUtil.isNotEmpty(outgoingLinkPages);
 									%>
 
 										<dt class="h5">
-											<h4>
+											<div class="h4">
 												<a
 													class="text-default" href="<%=
 	PortletURLBuilder.createRenderURL(
@@ -54,7 +54,7 @@ boolean hasOutgoingLinkPages = ListUtil.isNotEmpty(outgoingLinkPages);
 											"title", incomingLinkPage.getTitle()
 										).buildString() %>"><%= incomingLinkPage.getTitle() %></a
 												>
-											</h4>
+											</div>
 										</dt>
 										<dd>
 											<small>
@@ -97,9 +97,9 @@ boolean hasOutgoingLinkPages = ListUtil.isNotEmpty(outgoingLinkPages);
 										<c:choose>
 											<c:when test="<%= outgoingLinkPage.isNew() %>">
 												<dt class="h5">
-													<h4 class="text-truncate">
+													<div class="h4 text-truncate">
 														<a class="text-default" href="<%= outgoingLinkPage.getTitle() %>"><%= outgoingLinkPage.getTitle() %></a>
-													</h4>
+													</div>
 												</dt>
 											</c:when>
 											<c:otherwise>
@@ -109,7 +109,7 @@ boolean hasOutgoingLinkPages = ListUtil.isNotEmpty(outgoingLinkPages);
 												%>
 
 												<dt class="h5">
-													<h4 class="text-truncate">
+													<div class="h4 text-truncate">
 														<a
 															class="text-default" href="<%=
 	PortletURLBuilder.createRenderURL(
@@ -124,7 +124,7 @@ boolean hasOutgoingLinkPages = ListUtil.isNotEmpty(outgoingLinkPages);
 													"title", outgoingLinkPage.getTitle()
 												).buildString() %>"><%= outgoingLinkPage.getTitle() %></a
 														>
-													</h4>
+													</div>
 												</dt>
 												<dd>
 													<small>

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/view.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/view.jsp
@@ -470,9 +470,9 @@ if (portletTitleBasedNavigation) {
 		</div>
 
 		<c:if test="<%= Validator.isNotNull(formattedContent) && (followRedirect || (redirectPage == null)) && !childPages.isEmpty() %>">
-			<h4 class="text-default">
+			<div class="h4 text-default">
 				<liferay-ui:message arguments="<%= childPages.size() %>" key="child-pages-x" translateArguments="<%= false %>" />
-			</h4>
+			</div>
 
 			<div>
 				<ul class="list-group">

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki_admin/node_info_panel.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki_admin/node_info_panel.jsp
@@ -21,9 +21,9 @@ WikiNodeInfoPanelDisplayContext wikiNodeInfoPanelDisplayContext = new WikiNodeIn
 
 			<div class="autofit-row sidebar-section">
 				<div class="autofit-col autofit-col-expand">
-					<h4 class="component-title">
+					<div class="component-title">
 						<%= HtmlUtil.escape(node.getName()) %>
-					</h4>
+					</div>
 
 					<h5 class="component-subtitle">
 						<liferay-ui:message key="wiki" />
@@ -50,14 +50,14 @@ WikiNodeInfoPanelDisplayContext wikiNodeInfoPanelDisplayContext = new WikiNodeIn
 		<c:when test="<%= wikiNodeInfoPanelDisplayContext.isMultipleNodeSelection() %>">
 			<div class="autofit-row sidebar-section">
 				<div class="autofit-col autofit-col-expand">
-					<h4 class="component-title"><liferay-ui:message arguments="<%= wikiNodeInfoPanelDisplayContext.getSelectedNodesCount() %>" key="x-items-are-selected" /></h4>
+					<div class="component-title"><liferay-ui:message arguments="<%= wikiNodeInfoPanelDisplayContext.getSelectedNodesCount() %>" key="x-items-are-selected" /></div>
 				</div>
 			</div>
 		</c:when>
 		<c:otherwise>
 			<div class="autofit-row sidebar-section">
 				<div class="autofit-col autofit-col-expand">
-					<h4 class="component-title"><liferay-ui:message key="wikis" /></h4>
+					<div class="component-title"><liferay-ui:message key="wikis" /></div>
 				</div>
 			</div>
 		</c:otherwise>

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki_admin/page_info_panel.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki_admin/page_info_panel.jsp
@@ -27,9 +27,9 @@ request.setAttribute("page_info_panel.jsp-wikiPage", wikiPageInfoPanelDisplayCon
 							WikiPage wikiPage = wikiPageInfoPanelDisplayContext.getFirstPage();
 							%>
 
-							<h4 class="component-title">
+							<div class="component-title">
 								<%= HtmlUtil.escape(wikiPage.getTitle()) %>
-							</h4>
+							</div>
 
 							<h5 class="component-subtitle">
 								<liferay-ui:message key="page" />
@@ -51,14 +51,14 @@ request.setAttribute("page_info_panel.jsp-wikiPage", wikiPageInfoPanelDisplayCon
 				<c:when test="<%= wikiPageInfoPanelDisplayContext.isMultiplePageSelection() %>">
 					<div class="autofit-row sidebar-section">
 						<div class="autofit-col autofit-col-expand">
-							<h4 class="component-title"><liferay-ui:message arguments="<%= wikiPageInfoPanelDisplayContext.getSelectedPagesCount() %>" key="x-items-are-selected" /></h4>
+							<div class="component-title"><liferay-ui:message arguments="<%= wikiPageInfoPanelDisplayContext.getSelectedPagesCount() %>" key="x-items-are-selected" /></div>
 						</div>
 					</div>
 				</c:when>
 				<c:otherwise>
 					<div class="autofit-row sidebar-section">
 						<div class="autofit-col autofit-col-expand">
-							<h4 class="component-title"><liferay-ui:message key="pages" /></h4>
+							<div class="component-title"><liferay-ui:message key="pages" /></div>
 						</div>
 					</div>
 				</c:otherwise>
@@ -74,9 +74,9 @@ request.setAttribute("page_info_panel.jsp-wikiPage", wikiPageInfoPanelDisplayCon
 
 			<div class="autofit-row sidebar-section">
 				<div class="autofit-col autofit-col-expand">
-					<h4 class="component-title">
+					<div class="component-title">
 						<%= HtmlUtil.escape(wikiPage.getTitle()) %>
-					</h4>
+					</div>
 				</div>
 			</div>
 		</div>

--- a/modules/dxp/apps/akismet/akismet-web/src/main/resources/META-INF/resources/view_thread_message.jsp
+++ b/modules/dxp/apps/akismet/akismet-web/src/main/resources/META-INF/resources/view_thread_message.jsp
@@ -70,13 +70,13 @@ if (messageId > 0) {
 						<%= HtmlUtil.escape(userDisplayText) %>
 					</h5>
 
-					<h4 title="<%= HtmlUtil.escape(message.getSubject()) %>">
+					<div class="h4" title="<%= HtmlUtil.escape(message.getSubject()) %>">
 						<%= HtmlUtil.escape(message.getSubject()) %>
 
 						<c:if test="<%= message.isAnswer() %>">
 							(<liferay-ui:message key="answer[noun]" />)
 						</c:if>
-					</h4>
+					</div>
 
 					<%
 					User messageUser = UserLocalServiceUtil.fetchUser(message.getUserId());

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/ConnectToAC.tsx
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/ConnectToAC.tsx
@@ -43,9 +43,9 @@ export default function ConnectToAC({
 
 			{isAnalyticsConnected ? (
 				<>
-					<h4 className="font-weight-semi-bold h5 mt-3">
+					<div className="font-weight-semi-bold h5 mt-3">
 						{Liferay.Language.get('sync-to-analytics-cloud')}
-					</h4>
+					</div>
 
 					<p className="text-secondary">
 						{Liferay.Language.get(
@@ -68,11 +68,11 @@ export default function ConnectToAC({
 				</>
 			) : (
 				<>
-					<h4 className="font-weight-semi-bold h5 mt-3">
+					<div className="font-weight-semi-bold h5 mt-3">
 						{Liferay.Language.get(
 							'connect-to-liferay-analytics-cloud'
 						)}
-					</h4>
+					</div>
 
 					<p className="text-secondary">
 						{Liferay.Language.get(

--- a/modules/dxp/apps/commerce/commerce-shop-by-diagram-web/src/main/resources/META-INF/resources/js/components/StorefrontTooltipContent.js
+++ b/modules/dxp/apps/commerce/commerce-shop-by-diagram-web/src/main/resources/META-INF/resources/js/components/StorefrontTooltipContent.js
@@ -110,9 +110,9 @@ function SkuContent({
 					</ClayLabel>
 				</div>
 
-				<h4 className="component-title mb-1">
+				<div className="component-title mb-1">
 					<a href={productURL}>{product.sku}</a>
-				</h4>
+				</div>
 
 				<p className="component-subtitle mb-1">
 					<a href={productURL}>{productName}</a>
@@ -183,9 +183,9 @@ function DiagramContent({product, productBaseURL}) {
 			)}
 
 			<div className="col">
-				<h4 className="component-title">
+				<div className="component-title">
 					<a href={productURL}>{productName}</a>
-				</h4>
+				</div>
 			</div>
 
 			<div className="col-auto">
@@ -200,7 +200,7 @@ function DiagramContent({product, productBaseURL}) {
 function ExternalContent({product}) {
 	return (
 		<>
-			<h4 className="mb-1">{product.sku || product.name}</h4>
+			<div className="h4 mb-1">{product.sku || product.name}</div>
 
 			{!!product.quantity && (
 				<p className="mb-0">

--- a/modules/dxp/apps/commerce/commerce-shop-by-diagram-web/src/main/resources/META-INF/resources/render/view.jsp
+++ b/modules/dxp/apps/commerce/commerce-shop-by-diagram-web/src/main/resources/META-INF/resources/render/view.jsp
@@ -20,9 +20,9 @@ CSDiagramSetting csDiagramSetting = csDiagramCPTypeHelper.getCSDiagramSetting(co
 %>
 
 <div class="col my-4 p-0">
-	<h4 class="component-title mb-4 text-7">
+	<div class="component-title mb-4 text-7">
 		<%= cpCatalogEntry.getName() %>
-	</h4>
+	</div>
 
 	<p class="text-3">
 		<%= cpCatalogEntry.getShortDescription() %>

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-admin-web/src/main/resources/META-INF/resources/info_panel.jsp
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-admin-web/src/main/resources/META-INF/resources/info_panel.jsp
@@ -39,7 +39,7 @@ request.removeAttribute(WebKeys.SEARCH_CONTAINER_RESULT_ROW);
 		%>
 
 		<div class="sidebar-header">
-			<h4><%= HtmlUtil.escape(faroProjectAdminDisplay.getName()) %></h4>
+			<div class="h4"><%= HtmlUtil.escape(faroProjectAdminDisplay.getName()) %></div>
 		</div>
 
 		<clay:navigation-bar
@@ -106,14 +106,14 @@ request.removeAttribute(WebKeys.SEARCH_CONTAINER_RESULT_ROW);
 			</c:when>
 			<c:otherwise>
 				<div class="sidebar-header">
-					<h4><liferay-ui:message arguments="<%= faroProjectAdminDisplays.size() %>" key="x-items-are-selected" /></h4>
+					<div class="h4"><liferay-ui:message arguments="<%= faroProjectAdminDisplays.size() %>" key="x-items-are-selected" /></div>
 				</div>
 			</c:otherwise>
 		</c:choose>
 	</c:when>
 	<c:otherwise>
 		<div class="sidebar-header">
-			<h4><liferay-ui:message arguments="<%= (int)request.getAttribute(FaroAdminWebKeys.FARO_PROJECT_ENTRIES_COUNT) %>" key="x-items-are-selected" /></h4>
+			<div class="h4"><liferay-ui:message arguments="<%= (int)request.getAttribute(FaroAdminWebKeys.FARO_PROJECT_ENTRIES_COUNT) %>" key="x-items-are-selected" /></div>
 		</div>
 	</c:otherwise>
 </c:choose>

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/css/_activities_chart_timeline.scss
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/css/_activities_chart_timeline.scss
@@ -14,6 +14,7 @@
 			padding: 0;
 		}
 
+		.h4,
 		h4 {
 			line-height: 32px;
 		}

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/css/_base_field_mapping_view.scss
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/css/_base_field_mapping_view.scss
@@ -4,6 +4,7 @@
 			display: flex;
 		}
 
+		> .h4,
 		> h4 {
 			font-weight: $fontWeightBold;
 		}

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/css/_data_source_base_tabs.scss
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/css/_data_source_base_tabs.scss
@@ -25,6 +25,7 @@
 				background-color: $lightBackground;
 			}
 
+			.h4,
 			h4 {
 				font-size: $fontSizeSmall;
 				margin-bottom: 0;

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/css/_individual_profile_card.scss
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/css/_individual_profile_card.scss
@@ -20,6 +20,7 @@
 			padding: 0;
 		}
 
+		.h4,
 		h4 {
 			line-height: 32px;
 		}

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/css/_segment_growth.scss
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/css/_segment_growth.scss
@@ -26,6 +26,7 @@
 			padding: 0;
 		}
 
+		.h4,
 		h4 {
 			color: $mainLighten28;
 			line-height: 24px;

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/components/ActivitiesChartTimeline.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/components/ActivitiesChartTimeline.tsx
@@ -153,8 +153,8 @@ const ActivitiesChartTimeline: React.FC<IActivitiesChartTimelineProps> = ({
 
 			{!!history.length && (
 				<div className='selected-info'>
-					<div className='d-flex align-items-baseline'>
-						<div className='h4'>{sub(activitiesLabel, [date])}</div>
+				<div className='d-flex align-items-baseline'>
+						<div className="h4">{sub(activitiesLabel, [date])}</div>
 
 						{hasSelectedPoint && (
 							<ClayButton

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/BaseInterestDetails.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/BaseInterestDetails.tsx
@@ -223,7 +223,7 @@ const BaseInterestDetails: React.FC<IBaseInterestDetailsProps> = ({
 						{navigationItems.map(({active, href, label}) => (
 							<ClayNavigationBar.Item active={active} key={label}>
 								<ClayLink href={href}>
-									<div className='h4'>{label}</div>
+									<div className="h4">{label}</div>
 								</ClayLink>
 							</ClayNavigationBar.Item>
 						))}

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/experiments/components/summary-card/SummaryDraftCard.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/experiments/components/summary-card/SummaryDraftCard.tsx
@@ -117,7 +117,7 @@ export const SummaryDraftCard = ({
 										)}
 									>
 										<Card.Body>
-											<div className='h4'>{title}</div>
+											<div className="h4">{title}</div>
 
 											<Description className='analytics-summary-card-step-content-description' />
 										</Card.Body>

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/profile/components/ProfileCard.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/profile/components/ProfileCard.tsx
@@ -272,7 +272,7 @@ const ProfileCard: React.FC<IProfileCardProps> = ({
 
 					<div className='selected-info'>
 						<div className='activities-date d-flex align-items-baseline'>
-							<div className='h4'>
+							<div className="h4">
 								{activityHistory?.length
 									? sub(
 											Liferay.Language.get(

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/components/Growth.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/components/Growth.tsx
@@ -544,7 +544,7 @@ export const SegmentGrowthChart: React.FC<ISegmentGrowthChartProps> = ({
 
 export const SelectedPointInfo: React.FC = () => (
 	<div className='selected-point-info'>
-		<div className='h4'>{Liferay.Language.get('known-members')}</div>
+		<div className="h4">{Liferay.Language.get('known-members')}</div>
 	</div>
 );
 

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/apis/components/GenerateTokenCard.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/apis/components/GenerateTokenCard.tsx
@@ -45,9 +45,7 @@ const GenerateTokenCard: React.FC<IGenerateTokenCardProps> = ({
 	return (
 		<Card>
 			<Card.Body>
-				<div className='h4'>
-					{Liferay.Language.get('create-new-access-token')}
-				</div>
+				<div className="h4">{Liferay.Language.get('create-new-access-token')}</div>
 				<div className='col-md-5 mt-2 pl-0'>
 					<Form.Group>
 						<label htmlFor='picker' id='picker-label'>

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/SelectDataSource.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/SelectDataSource.tsx
@@ -25,7 +25,7 @@ const SelectDataSource: React.FC<ISelectDataSourceProps> = ({
 	<div className={getCN('select-data-source-root', className)}>
 		{sections.map(({dataSources, title}) => (
 			<section key={title}>
-				<div className='h4 text-uppercase section-title'>{title}</div>
+				<div className='h4 section-title text-uppercase'>{title}</div>
 
 				<div className='section-items'>
 					{dataSources.map(
@@ -47,7 +47,7 @@ const SelectDataSource: React.FC<ISelectDataSourceProps> = ({
 
 									<div className='details'>
 										<div className='title'>
-											<div className='h4'>{name}</div>
+											<div className="h4">{name}</div>
 										</div>
 
 										<div className='subtitle'>
@@ -71,7 +71,7 @@ const SelectDataSource: React.FC<ISelectDataSourceProps> = ({
 
 									<div className='details'>
 										<div className='title'>
-											<div className='h4'>{name}</div>
+											<div className="h4">{name}</div>
 										</div>
 
 										<div className='subtitle'>

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/data-privacy/pages/Overview.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/data-privacy/pages/Overview.tsx
@@ -176,7 +176,7 @@ export const Overview: React.FC<IOverviewProps> = ({close, groupId, open}) => {
 							<div className='container'>
 								<div className='row justify-content-between'>
 									<div className='col-lg-8'>
-										<div className='h4'>
+										<div className="h4">
 											{Liferay.Language.get(
 												'retention-period'
 											)}
@@ -259,7 +259,7 @@ export const Overview: React.FC<IOverviewProps> = ({close, groupId, open}) => {
 
 								<div className='row mt-3 justify-content-between'>
 									<div className='col-lg-8'>
-										<div className='h4'>
+										<div className="h4">
 											{Liferay.Language.get(
 												'suppressed-users'
 											)}

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/definitions/pages/InterestTopics.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/definitions/pages/InterestTopics.tsx
@@ -304,9 +304,7 @@ const InterestTopics: React.FC<IInterestTopicsProps> = ({
 				)}
 			</p>
 
-			<div className='h4'>
-				{Liferay.Language.get('keywords-blocklist')}
-			</div>
+			<div className="h4">{Liferay.Language.get('keywords-blocklist')}</div>
 			<p>
 				{Liferay.Language.get(
 					'keywords-can-be-excluded-by-adding-them-to-a-blocklist-manage-the-keywords-that-you-dont-want-listed-in-liferay-analytics-cloud-and-dont-want-them-to-be-used-to-generate-content-recommendation-in-liferay-dxp'

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/modal/Header.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/modal/Header.tsx
@@ -20,7 +20,7 @@ const Header: React.FC<IHeaderProps> = ({
 }) => (
 	<div className={getCN('modal-header', className, {border})}>
 		{title && (
-			<div className='h4 modal-title'>
+			<div className='modal-title'>
 				{iconSymbol && (
 					<ClayIcon
 						className='icon-root modal-title-indicator'

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/modals/ExportLogModal.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/modals/ExportLogModal.tsx
@@ -46,9 +46,7 @@ const ExportLogModal: React.FC<IExportLogModalProps> = ({
 			<Modal.Body>
 				<p className='text-secondary'>{description}</p>
 
-				<div className='h4'>
-					{Liferay.Language.get('request-date-range')}
-				</div>
+				<div className="h4">{Liferay.Language.get('request-date-range')}</div>
 
 				<div className='d-flex'>
 					<DateRangeInput

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/modals/NewRequestModal.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/modals/NewRequestModal.tsx
@@ -210,9 +210,7 @@ const NewRequestModal: React.FC<INewRequestModalProps> = ({
 							</p>
 
 							<Form.Group>
-								<div className='h4'>
-									{Liferay.Language.get('job-type')}
-								</div>
+								<div className="h4">{Liferay.Language.get('job-type')}</div>
 
 								<Form.GroupItem>
 									<Form.Checkbox
@@ -260,7 +258,11 @@ const NewRequestModal: React.FC<INewRequestModalProps> = ({
 							</Form.Group>
 
 							<Form.Group>
+<<<<<<< HEAD
 								<div className='h4'>
+=======
+								<div className="h4">
+>>>>>>> parent of 129241d096498 (Revert "LPD-4680 Convert h4 elements to use div.h4")
 									{Liferay.Language.get('data-subject-id')}
 								</div>
 

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/modals/TestModal.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/modals/TestModal.tsx
@@ -11,7 +11,7 @@ const TestModal: React.FC<{onClose: () => void; title: string}> = ({
 		<Modal.Header onClose={() => onClose} title={title} />
 
 		<Modal.Body inlineScroller>
-			<div className='h4'>{'Modal Body'}</div>
+			<div className="h4">{'Modal Body'}</div>
 		</Modal.Body>
 
 		<Modal.Footer>

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/modals/onboarding-modal/InvitePeople.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/modals/onboarding-modal/InvitePeople.tsx
@@ -82,7 +82,7 @@ const InvitePeople: React.FC<IInvitePeopleProps> = ({
 
 				{sent ? (
 					<div className='description text-center'>
-						<div className='h4'>
+						<div className="h4">
 							{Liferay.Language.get(
 								'you-can-see-the-new-members-invitation-status-and-role-permissions-under-user-management-in-settings'
 							)}

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/modals/onboarding-modal/ReadyToGo.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/modals/onboarding-modal/ReadyToGo.tsx
@@ -28,7 +28,7 @@ const ReadyToGo: React.FC<IReadyToGoProps> = ({onClose}) => (
 					)}
 				</div>
 
-				<div className='h4'>
+				<div className="h4">
 					{Liferay.Language.get(
 						'make-sure-to-set-your-time-period-to-last-24-hours-to-see-if-your-data-is-coming-in-correctly'
 					)}

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/table/Cell.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/table/Cell.tsx
@@ -9,7 +9,7 @@ interface ICellProps {
 const Cell: React.FC<ICellProps> = ({children, className, title}) => (
 	<td className={className}>
 		{title ? (
-			<div className='h4 table-title text-truncate'>{children}</div>
+			<div className='table-title text-truncate'>{children}</div>
 		) : (
 			children
 		)}

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/routes/customer-portal/components/ActivationStatus/AnalyticsCloud/AnalyticsCloudStatusModal.tsx
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/routes/customer-portal/components/ActivationStatus/AnalyticsCloud/AnalyticsCloudStatusModal.tsx
@@ -23,9 +23,9 @@ const AnalyticsCloudStatusModal: React.FC<AnalyticsCloudStatusModalProps> = ({
 	<ClayModal center observer={observer}>
 		<div className="bg-neutral-1 cp-analytics-cloud-status-modal">
 			<div className="d-flex justify-content-between">
-				<h4 className="ml-4 mt-4 text-brand-primary text-paragraph">
+				<div className="h4 ml-4 mt-4 text-brand-primary text-paragraph">
 					{i18n.translate('analytics-cloud-setup').toUpperCase()}
-				</h4>
+				</div>
 
 				<div className="mr-4 mt-3">
 					<Button

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/routes/customer-portal/styles/components/_card-incident-contact.scss
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/extra/remote-app/src/routes/customer-portal/styles/components/_card-incident-contact.scss
@@ -10,6 +10,7 @@
 	order: 1;
 	padding: 1.5rem;
 
+	.h4,
 	p,
 	h1,
 	h3,
@@ -47,6 +48,7 @@
 		line-height: 1.25rem;
 	}
 
+	.h4,
 	h4 {
 		color: var(--color-neutral-9);
 		font-size: 0.813rem;

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/osb-site-initializer-customer-portal-test/src/testFunctional/paths/CustomerPortalSite.path
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/osb-site-initializer-customer-portal-test/src/testFunctional/paths/CustomerPortalSite.path
@@ -207,7 +207,7 @@
 </tr>
 <tr>
 	<td>PROJECT_TABLE_NAME</td>
-	<td>//div[contains(@class,'card-body')]//h4[contains(@title,'${key_projectName}')]</td>
+	<td>//div[contains(@class,'card-body')]//div[contains(@title,'${key_projectName}')]</td>
 	<td></td>
 </tr>
 <tr>
@@ -242,7 +242,7 @@
 </tr>
 <tr>
 	<td>PROJECT_TITLE_MAIN_PAGE</td>
-	<td>//div[contains(@class, 'card-body')]//h4[contains(@class, 'text-truncate')]</td>
+	<td>//div[contains(@class, 'card-body')]//div[contains(@class,'h4') and contains(@class, 'text-truncate')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/src/main/resources/site-initializer/ddm-templates/release-notes-breaking-change/ddm-template.ftl
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/src/main/resources/site-initializer/ddm-templates/release-notes-breaking-change/ddm-template.ftl
@@ -52,33 +52,33 @@
 </#list>
 
 <@clay.panel displayTitle="${name}">
-	<h4>
+	<div class="h4">
 		What Changed?
-	</h4>
+	</div>
 
 	<p>
 		${whatChanged}
 	</p>
 
-	<h4>
+	<div class="h4">
 		Who is affected?
-	</h4>
+	</div>
 
 	<p>
 		${whoIsAffected}
 	</p>
 
-	<h4>
+	<div class="h4">
 		What do I need to do?
-	</h4>
+	</div>
 
 	<p>
 		${whatDoINeedToDo}
 	</p>
 
-	<h4>
+	<div class="h4">
 		Why was the change made?
-	</h4>
+	</div>
 
 	<p>
 		${whyWasTheChangeMade}

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-evp/osb-site-initializer-evp-test/src/testFunctional/paths/EVPRequest.path
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-evp/osb-site-initializer-evp-test/src/testFunctional/paths/EVPRequest.path
@@ -22,7 +22,7 @@
 </tr>
 <tr>
 	<td>DETAIL_FIELD_NAME</td>
-	<td>//div[contains(@class,'dialect-text')]//h4[contains(text(), '${key_name}')]</td>
+	<td>//div[contains(@class,'dialect-text')]//div[contains(@class,'h4') and contains(text(), '${key_name}')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/edit_kaleo_definition_version.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/edit_kaleo_definition_version.jsp
@@ -154,11 +154,11 @@ String randomNamespace = StringUtil.randomId() + StringPool.UNDERLINE;
 
 				<div class="sidebar-header">
 					<div class="sidebar-section">
-						<h4 class="component-title">
+						<div class="component-title">
 							<span class="text-truncate-inline">
 								<span class="text-truncate"><%= HtmlUtil.escape(kaleoDefinitionVersion.getTitle(locale)) %></span>
 							</span>
-						</h4>
+						</div>
 					</div>
 				</div>
 			</div>

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testFunctional/paths/WorkflowAllItems.path
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testFunctional/paths/WorkflowAllItems.path
@@ -107,7 +107,7 @@
 </tr>
 <tr>
 	<td>DETAIL_PAGE_SLA_STATUS_TITLE</td>
-	<td>//h4[text()='Due Date by SLA']/following-sibling::h5[contains(text(), '${key_slaStatusTitle}')]</td>
+	<td>//div[contains(@class,'h4') and text()='Due Date by SLA']/following-sibling::h5[contains(text(), '${key_slaStatusTitle}')]</td>
 	<td></td>
 </tr>
 <tr>
@@ -172,7 +172,7 @@
 </tr>
 <tr>
 	<td>DETAIL_PAGE_PROCESS_STATUS</td>
-	<td>//h4[contains(.,'Process Details')]//following-sibling::p[1][contains(.,'Process Status')]//following-sibling::span[1]</td>
+	<td>//div[contains(@class,'h4') and contains(.,'Process Details')]//following-sibling::p[1][contains(.,'Process Status')]//following-sibling::span[1]</td>
 	<td></td>
 </tr>
 <tr>
@@ -182,7 +182,7 @@
 </tr>
 <tr>
 	<td>DETAIL_PAGE_SLA_MESSAGE</td>
-	<td>//div[contains(@class,'modal-body')]/h4[contains(.,'Due Date by SLA')]//following-sibling::p/span</td>
+	<td>//div[contains(@class,'modal-body')]/div[contains(@class,'h4') and contains(.,'Due Date by SLA')]//following-sibling::p/span</td>
 	<td></td>
 </tr>
 <tr>
@@ -422,7 +422,7 @@
 </tr>
 <tr>
 	<td>DETAIL_SLA_STATUS</td>
-	<td>//h4[contains(.,'Due Date by SLA')]/..//div[contains(@class,'sla-result')]//*[contains(@class,'lexicon-icon-${key_status}')] | //div[contains(@class,'workflow-metrics')]//*[contains(@class,'lexicon-icon-${key_status}')]</td>
+	<td>//div[contains(@class,'h4') and contains(.,'Due Date by SLA')]/..//div[contains(@class,'sla-result')]//*[contains(@class,'lexicon-icon-${key_status}')] | //div[contains(@class,'workflow-metrics')]//*[contains(@class,'lexicon-icon-${key_status}')]</td>
 	<td></td>
 </tr>
 <tr>
@@ -442,7 +442,7 @@
 </tr>
 <tr>
 	<td>WORKFLOW_SLA_STATUS_BEFORE_TITLE</td>
-	<td>//div[contains(@class,'modal-header')]/h1[contains(@class,'modal-title')]/../..//div[contains(@class,'modal-body')]/h4[contains(.,'Due Date by SLA')]</td>
+	<td>//div[contains(@class,'modal-header')]/h1[contains(@class,'modal-title')]/../..//div[contains(@class,'modal-body')]/div[contains(@class,'h4') and contains(.,'Due Date by SLA')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testFunctional/paths/WorkflowTransitionModal.path
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-test/src/testFunctional/paths/WorkflowTransitionModal.path
@@ -12,7 +12,7 @@
 <tbody>
 <tr>
 	<td>TASK_PANEL</td>
-	<td>//div[@class='panel']//h4[text()='${key_taskName}']</td>
+	<td>//div[@class='panel']//div[contains(@class,'h4') and text()='${key_taskName}']</td>
 	<td></td>
 </tr>
 <tr>
@@ -22,12 +22,12 @@
 </tr>
 <tr>
 	<td>TRANSITION_TO_BUTTON</td>
-	<td>//h4[text()='${key_taskName}']/parent::div/following-sibling::div[1]//select</td>
+	<td>//div[contains(@class,'h4') and text()='${key_taskName}']/parent::div/following-sibling::div[1]//select</td>
 	<td></td>
 </tr>
 <tr>
 	<td>TRANSITION_TO_OPTION</td>
-	<td>//h4[text()='${key_taskName}']/parent::div/following-sibling::div[1]//select//option[@value='${key_transitionOption}']</td>
+	<td>//div[contains(@class,'h4') and text()='${key_taskName}']/parent::div/following-sibling::div[1]//select//option[@value='${key_transitionOption}']</td>
 	<td></td>
 </tr>
 <tr>

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/css/_process_tabs.scss
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/css/_process_tabs.scss
@@ -158,6 +158,7 @@ $c: '.workflow-process-tabs';
 	.custom-range-form {
 		padding: 1rem 1.5rem 0.5rem;
 
+		.h4,
 		h4 {
 			margin-bottom: 2rem;
 		}

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/filter/CustomTimeRangeForm.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/filter/CustomTimeRangeForm.es.js
@@ -90,7 +90,9 @@ export default function CustomTimeRangeForm({
 	return (
 		<div className="custom-range-wrapper" ref={wrapperRef}>
 			<ClayForm className="custom-range-form">
-				<h4 className="mb-2">{Liferay.Language.get('custom-range')}</h4>
+				<div className="h4 mb-2">
+					{Liferay.Language.get('custom-range')}
+				</div>
 
 				<span className="form-text mb-3 text-semi-bold">
 					{sub(Liferay.Language.get('default-date-format-is-x'), [

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/instance-list-page/modal/instance-details/InstanceDetailsModalBody.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/instance-list-page/modal/instance-details/InstanceDetailsModalBody.es.js
@@ -250,9 +250,9 @@ function Body({
 }
 
 function SectionTitle({children, className = ''}) {
-	const classNames = `${className} font-weight-medium mb-4`;
+	const classNames = `${className} font-weight-medium mb-4 h4`;
 
-	return <h4 className={classNames}>{children}</h4>;
+	return <div className={classNames}>{children}</div>;
 }
 
 function SectionSubTitle({children}) {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/instance-list-page/modal/instance-details/InstanceDetailsModalBody.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/instance-list-page/modal/instance-details/InstanceDetailsModalBody.es.js
@@ -250,7 +250,7 @@ function Body({
 }
 
 function SectionTitle({children, className = ''}) {
-	const classNames = `${className} font-weight-medium mb-4 h4`;
+	const classNames = `${className} font-weight-medium h4 mb-4`;
 
 	return <div className={classNames}>{children}</div>;
 }

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/instance-list-page/modal/transition/bulk/select-transition-step/SelectTransitionStepBody.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/components/instance-list-page/modal/transition/bulk/select-transition-step/SelectTransitionStepBody.es.js
@@ -91,9 +91,9 @@ function Body({data, setRetry, tasks}) {
 					versionedCard.map(([taskLabel, tasks], cardIndex) => (
 						<ClayPanel key={`${versionIndex}_${cardIndex}`}>
 							<ClayPanel.Header>
-								<h4 className="mt-2">
+								<div className="h4 mt-2">
 									{capitalize(taskLabel)}
-								</h4>
+								</div>
 							</ClayPanel.Header>
 
 							<Body.Card

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/preview_sidebar/index.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/preview_sidebar/index.js
@@ -222,13 +222,13 @@ function PreviewSidebar({
 			data-testid={TEST_IDS.PREVIEW_SIDEBAR}
 		>
 			<div className="sidebar-header">
-				<h4 className="component-title">
+				<div className="component-title">
 					<span className="text-truncate-inline">
 						<span className="text-truncate">
 							{Liferay.Language.get('preview')}
 						</span>
 					</span>
-				</h4>
+				</div>
 
 				<span>
 					<PreviewAttributesModal

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_element/EditSXPElementForm.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_element/EditSXPElementForm.js
@@ -629,7 +629,7 @@ function EditSXPElementForm({
 				{!readOnly && (
 					<>
 						<div className="sidebar-header">
-							<h4 className="component-title">
+							<div className="component-title">
 								<span className="text-truncate-inline">
 									<span className="text-truncate">
 										{Liferay.Language.get(
@@ -637,7 +637,7 @@ function EditSXPElementForm({
 										)}
 									</span>
 								</span>
-							</h4>
+							</div>
 						</div>
 
 						<div className="container-fluid">

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/Sidebar.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/shared/Sidebar.js
@@ -16,11 +16,11 @@ function Sidebar({children, className, onClose, title, visible}) {
 			})}
 		>
 			<div className="sidebar-header">
-				<h4 className="component-title">
+				<div className="component-title">
 					<span className="text-truncate-inline">
 						<span className="text-truncate">{title}</span>
 					</span>
-				</h4>
+				</div>
 
 				<span>
 					<ClayButton

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/ClickGoalPicker/ClickGoalPicker.es.js
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/ClickGoalPicker/ClickGoalPicker.es.js
@@ -184,7 +184,7 @@ function ClickGoalPicker({allowEdit = true, onSelectClickGoalTarget, target}) {
 	return (
 		<DispatchContext.Provider value={dispatch}>
 			<StateContext.Provider value={state}>
-				<h4 className="mb-3 mt-4 sheet-subtitle">
+				<div className="mb-3 mt-4 sheet-subtitle">
 					{Liferay.Language.get('click-goal')}
 
 					{allowEdit && (
@@ -194,7 +194,7 @@ function ClickGoalPicker({allowEdit = true, onSelectClickGoalTarget, target}) {
 							symbol="asterisk"
 						/>
 					)}
-				</h4>
+				</div>
 
 				{allowEdit && (
 					<div className="c-mb-2 text-secondary">

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/ConnectToAC.es.js
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/ConnectToAC.es.js
@@ -31,9 +31,9 @@ export default function ConnectToAC({
 
 			{isAnalyticsConnected ? (
 				<>
-					<h4 className="font-weight-semi-bold h5 mt-3">
+					<div className="font-weight-semi-bold h5 mt-3">
 						{Liferay.Language.get('sync-to-analytics-cloud')}
-					</h4>
+					</div>
 
 					<p className="text-secondary">
 						{Liferay.Language.get(
@@ -56,11 +56,11 @@ export default function ConnectToAC({
 				</>
 			) : (
 				<>
-					<h4 className="font-weight-semi-bold h5 mt-3">
+					<div className="font-weight-semi-bold h5 mt-3">
 						{Liferay.Language.get(
 							'connect-to-liferay-analytics-cloud'
 						)}
-					</h4>
+					</div>
 
 					<p className="text-secondary">
 						{Liferay.Language.get(

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/SegmentsExperiments.es.js
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/SegmentsExperiments.es.js
@@ -82,9 +82,9 @@ function Experiments({
 			{experiment && (
 				<>
 					<div className="align-items-center d-flex justify-content-between">
-						<h4 className="mb-0 text-dark text-truncate">
+						<div className="h4 mb-0 text-dark text-truncate">
 							{experiment.name}
-						</h4>
+						</div>
 
 						{experiment.editable && (
 							<ClayDropDown
@@ -226,11 +226,11 @@ function Experiments({
 						width="185"
 					/>
 
-					<h4 className="text-dark">
+					<div className="h4 text-dark">
 						{Liferay.Language.get(
 							'no-active-tests-were-found-for-the-selected-experience'
 						)}
-					</h4>
+					</div>
 
 					<p>{Liferay.Language.get('create-test-help-message')}</p>
 

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/SegmentsExperimentsDetails.es.js
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/SegmentsExperimentsDetails.es.js
@@ -21,9 +21,9 @@ function SegmentsExperimentsDetails({segmentsExperiment}) {
 
 	return (
 		<>
-			<h4 className="mb-3 mt-4 sheet-subtitle">
+			<div className="mb-3 mt-4 sheet-subtitle">
 				{Liferay.Language.get('details')}
-			</h4>
+			</div>
 
 			<dl className="pl-0 segments-experiment-details">
 				{description && (

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/UnsupportedSegmentsExperiments.es.js
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/UnsupportedSegmentsExperiments.es.js
@@ -12,11 +12,11 @@ export default function UnsupportedSegmentsExperiments() {
 		<div className="align-items-center d-flex flex-column p-3">
 			<FlaskIllustration />
 
-			<h4 className="text-center text-dark">
+			<div className="h4 text-center text-dark">
 				{Liferay.Language.get(
 					'ab-test-is-available-only-for-content-pages'
 				)}
-			</h4>
+			</div>
 		</div>
 	);
 }

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/Variants/Variants.es.js
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/Variants/Variants.es.js
@@ -47,7 +47,7 @@ function Variants({selectedSegmentsExperienceId}) {
 
 	return (
 		<>
-			<h4 className="mb-3 mt-4 sheet-subtitle">
+			<div className="h4 mb-3 mt-4 sheet-subtitle">
 				{Liferay.Language.get('variants')}
 
 				{experiment.status.value === STATUS_DRAFT && (
@@ -57,7 +57,7 @@ function Variants({selectedSegmentsExperienceId}) {
 						symbol="asterisk"
 					/>
 				)}
-			</h4>
+			</div>
 
 			{variants.length === 1 && (
 				<>

--- a/portal-web/docroot/html/portal/saml/slo.jsp
+++ b/portal-web/docroot/html/portal/saml/slo.jsp
@@ -43,9 +43,9 @@ JSONArray samlSloRequestInfosJSONArray = samlSloContextJSONObject.getJSONArray("
 	<liferay-ui:message key="signing-out-from-services" />
 </h3>
 
-<h4>
+<div class="h4">
 	<liferay-ui:icon image="activate" /> <liferay-ui:message key="please-do-not-leave-this-page-in-order-to-avoid-inconsistencies" />
-</h4>
+</div>
 
 <div id="samlSloResults"></div>
 

--- a/portal-web/docroot/html/portal/setup_wizard.jsp
+++ b/portal-web/docroot/html/portal/setup_wizard.jsp
@@ -115,9 +115,9 @@
 											<liferay-ui:message key="this-database-is-useful-for-development-and-demo'ing-purposes" />
 										</c:when>
 										<c:otherwise>
-											<h4>
+											<div class="h4">
 												<liferay-ui:message key="configured-database" />
-											</h4>
+											</div>
 
 											<dl class="database-values dl-horizontal">
 												<c:choose>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/analyticscloud/ACAssets.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/analyticscloud/ACAssets.path
@@ -35,7 +35,7 @@
 </tr>
 <tr>
 	<td>NO_RESULTS_CONTENT_MESSAGE</td>
-	<td>//*//div[contains(@class,'no-results-content')]//h4[text()='${key_noResultMessage}']</td>
+	<td>//*//div[contains(@class,'no-results-content')]//div[contains(@class,'h4') and text()='${key_noResultMessage}']</td>
 	<td></td>
 </tr>
 

--- a/portal-web/test/functional/com/liferay/portalweb/paths/analyticscloud/ACCards.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/analyticscloud/ACCards.path
@@ -80,7 +80,7 @@
 </tr>
 <tr>
 	<td>NO_RESULTS_TITLE</td>
-	<td>//h4[@class='no-results-title' and contains(.,'${key_cardTitle}')]</td>
+	<td>//div[contains(@class,'no-results-title') and contains(.,'${key_cardTitle}')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/analyticscloud/ACDataControlAndPrivacy.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/analyticscloud/ACDataControlAndPrivacy.path
@@ -12,7 +12,7 @@
 <tbody>
 <tr>
 	<td>REQUEST_SUPPRESSED_OPTIONS</td>
-	<td>//h4[contains(.,'${key_optionName}')]/../..//*[contains(@class,'button-root') and contains(.,'${key_optionValue}')]</td>
+	<td>//div[contains(@class,'h4') and contains(.,'${key_optionName}')]/../..//*[contains(@class,'button-root') and contains(.,'${key_optionValue}')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/analyticscloud/ACIndividualsDashboard.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/analyticscloud/ACIndividualsDashboard.path
@@ -93,7 +93,7 @@
 </tr>
 <tr>
 	<td>INDIVIDUALS_EVENTS_DATE</td>
-	<td>//div[contains(@class,'activities-date')]//h4</td>
+	<td>//div[contains(@class,'activities-date')]//div[contains(@class,'h4')]</td>
 	<td></td>
 </tr>
 <tr>
@@ -136,7 +136,7 @@
 </tr>
 <tr>
 	<td>INDIVIDUAL_DETAILS_CARD_FULL_NAME</td>
-	<td>//div[contains(@class,'individual-details-card')]//div[contains(@class,'card-body')]//h4[normalize-space(text())='${fullName}']</td>
+	<td>//div[contains(@class,'individual-details-card')]//div[contains(@class,'card-body')]//div[contains(@class,'h4') and normalize-space(text())='${fullName}']</td>
 	<td></td>
 </tr>
 

--- a/portal-web/test/functional/com/liferay/portalweb/paths/analyticscloud/ACInterests.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/analyticscloud/ACInterests.path
@@ -27,7 +27,7 @@
 </tr>
 <tr>
 	<td>NO_INTEREST_TITLE</td>
-	<td>//h4[@class='no-results-title']</td>
+	<td>//div[contains(@class,'no-results-title')]</td>
 	<td></td>
 </tr>
 
@@ -68,7 +68,7 @@
 </tr>
 <tr>
 	<td>INTEREST_ACTIVE_MEMBERS_PERCENTAGE</td>
-	<td>//tr[contains(.,'${key_interestTopic}')]/td[@class='table-column-text-end']/h4</td>
+	<td>//tr[contains(.,'${key_interestTopic}')]/td[@class='table-column-text-end']/div[contains(@class,'h4')]</td>
 	<td></td>
 </tr>
 <tr>
@@ -96,7 +96,7 @@
 </tr>
 <tr>
 	<td>TAB_NAME</td>
-	<td>//ul[contains(@class,'nav-root')]//h4[text()='${key_tabName}']</td>
+	<td>//ul[contains(@class,'nav-root')]//div[contains(@class,'h4') and text()='${key_tabName}']</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/analyticscloud/ACSegments.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/analyticscloud/ACSegments.path
@@ -250,7 +250,7 @@
 </tr>
 <tr>
 	<td>SEGMENT_BREAKDOWN_CARD</td>
-	<td>//div[contains(@class,'distribution-card')]//*[@class='description']/h4</td>
+	<td>//div[contains(@class,'distribution-card')]//*[@class='description']/div[contains(@class,'h4')]</td>
 	<td></td>
 </tr>
 <tr>
@@ -383,7 +383,7 @@
 </tr>
 <tr>
 	<td>NO_MEMBER_TITLE</td>
-	<td>//h4[@class='no-results-title']</td>
+	<td>//div[contains(@class,'no-results-title')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/analyticscloud/ACSettings.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/analyticscloud/ACSettings.path
@@ -79,7 +79,7 @@
 </tr>
 <tr>
 	<td>KEYWORD_CHECKBOX</td>
-	<td>//h4[text()='${key_keywordName}']/parent::td/preceding-sibling::td//input</td>
+	<td>//div[contains(@class,'h4') and text()='${key_keywordName}']/parent::td/preceding-sibling::td//input</td>
 	<td></td>
 </tr>
 <tr>
@@ -89,7 +89,7 @@
 </tr>
 <tr>
 	<td>KEYWORD_DELETE_ICON</td>
-	<td>//h4[text()='${key_keywordName}']/parent::td/following-sibling::td[contains(@class,'row-inline-actions')]/span/button</td>
+	<td>//div[contains(@class,'h4') and text()='${key_keywordName}']/parent::td/following-sibling::td[contains(@class,'row-inline-actions')]/span/button</td>
 	<td></td>
 </tr>
 <tr>
@@ -150,7 +150,7 @@
 </tr>
 <tr>
 	<td>DXP_DATA_SOURCE_CHOOSE_OPTION</td>
-	<td>//h4[contains(@class,'section-title') and contains(.,'Choose Source')]/..//*[contains(@class,'data-source-item') and contains(.,'${key_sourceType}')]</td>
+	<td>//div[contains(@class,'section-title') and contains(.,'Choose Source')]/..//*[contains(@class,'data-source-item') and contains(.,'${key_sourceType}')]</td>
 	<td></td>
 </tr>
 <tr>
@@ -355,12 +355,12 @@
 </tr>
 <tr>
 	<td>USER_LIST</td>
-	<td>//h4[contains(@class,'table')]</td>
+	<td>//div[contains(@class,'table')]</td>
 	<td></td>
 </tr>
 <tr>
 	<td>USER_LIST_EMAIL</td>
-	<td>//h4[contains(@class,'table')]/parent::td/following-sibling::td</td>
+	<td>//div[contains(@class,'table')]/parent::td/following-sibling::td</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/analyticscloud/ACSites.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/analyticscloud/ACSites.path
@@ -57,7 +57,7 @@
 </tr>
 <tr>
 	<td>TOP_VISITED_PAGES</td>
-	<td>//*[contains(text(),'${key_entryName}')]/ancestor::tr//td//h4[contains(text(),'${key_resultNumber}')]</td>
+	<td>//*[contains(text(),'${key_entryName}')]/ancestor::tr//td//div[contains(text(),'${key_resultNumber}')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Header.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Header.path
@@ -27,12 +27,12 @@
 </tr>
 <tr>
 	<td>H4_TITLE</td>
-	<td>//h4[contains(.,'${key_title}')]</td>
+	<td>//div[contains(@class,'h4') and contains(.,'${key_title}')]</td>
 	<td></td>
 </tr>
 <tr>
 	<td>H4_SPECIFIC_TITLE</td>
-	<td>//h4[@class='text-default' and contains(.,'${key_title}')]</td>
+	<td>//div[contains(@class,'text-default') and contains(.,'${key_title}')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/ToggleSwitch.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/ToggleSwitch.path
@@ -82,7 +82,7 @@
 </tr>
 <tr>
 	<td>ENABLE_SPECIFIC_TOGGLE_SWITCH</td>
-	<td>//h4[contains(.,"${key_name}")]//span[contains(@id,'toggle-switch')]</td>
+	<td>//div[contains(@class,'h4') and contains(.,"${key_name}")]//span[contains(@id,'toggle-switch')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/AssetRelatedAssets.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/AssetRelatedAssets.path
@@ -86,7 +86,7 @@
 
 <tr>
 	<td>MESSAGE_BOARDS_THREAD_TITLE</td>
-	<td>//h4[@title='${key_assetTitle}']</td>
+	<td>//div[@title='${key_assetTitle}']</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/ExportImport.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/ExportImport.path
@@ -27,7 +27,7 @@
 </tr>
 <tr>
 	<td>VALIDATION_ERROR_MESSAGE_HEADER</td>
-	<td>//h4[@class='upload-error-message']</td>
+	<td>//div[contains(@class,'upload-error-message')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/Portlet.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/Portlet.path
@@ -57,7 +57,7 @@
 </tr>
 <tr>
 	<td>H4_COMPONENT_TITLE</td>
-	<td>//h4[@class='component-title']/span</td>
+	<td>//div[contains(@class,'component-title') and contains(@class,'h4')]/span</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/Ratings.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/Ratings.path
@@ -45,7 +45,7 @@
 </tr>
 <tr>
 	<td>REPLY_RATING_THUMB</td>
-	<td>//h4[contains(@title,'RE: ${key_threadSubject}')]//following-sibling::div//button[contains(@title,'${key_ratingResult}') or contains(@data-title,'${key_ratingResult}')]</td>
+	<td>//div[contains(@title,'RE: ${key_threadSubject}')]//following-sibling::div//button[contains(@title,'${key_ratingResult}') or contains(@data-title,'${key_ratingResult}')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/abtest/ABTest.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/abtest/ABTest.path
@@ -37,7 +37,7 @@
 </tr>
 <tr>
 	<td>CONNECTED_NOT_SYNC_BUTTON</td>
-	<td>//div[div[h1[contains(.,'Tests')]]] //h4[contains(.,'Sync to Liferay Analytics Cloud')]</td>
+	<td>//div[div[h1[contains(.,'Tests')]]] //div[contains(.,'Sync to Liferay Analytics Cloud')]</td>
 	<td></td>
 </tr>
 <tr>
@@ -87,7 +87,7 @@
 </tr>
 <tr>
 	<td>NO_HAVE_HISTORY_AB_TEST_MESSAGE</td>
-	<td>//div[@class="text-center"]//h4[text()="There is no test history for this experience."]</td>
+	<td>//div[@class="text-center"]//div[text()="There is no test history for this experience."]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/blogs/Blogs.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/blogs/Blogs.path
@@ -45,7 +45,7 @@
 
 <tr>
 	<td>DESCRIPTIVE_VIEW_ENTRY_TITLE</td>
-	<td>//div[contains(@id,'blogEntriesSearchContainer')]//*[@data-qa-id='rowItemContent']/h4/a[contains(.,'${key_entryTitle}')]</td>
+	<td>//div[contains(@id,'blogEntriesSearchContainer')]//*[@data-qa-id='rowItemContent']/div[contains(@class,'h4')]/a[contains(.,'${key_entryTitle}')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/claysample/ClaySamplePortlet.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/claysample/ClaySamplePortlet.path
@@ -40,7 +40,7 @@
 </tr>
 <tr>
 	<td>CHECKBOX_SELECTABLE_IMAGE_CARD</td>
-	<td>//h4[contains(text(), '${key_header}')]//following::div[contains(@data-qa-id,'image-card-icon-block')]//input[contains(@type,'checkbox')]</td>
+	<td>//div[contains(@class,'h4') and contains(text(), '${key_header}')]//following::div[contains(@data-qa-id,'image-card-icon-block')]//input[contains(@type,'checkbox')]</td>
 	<td></td>
 </tr>
 <tr>
@@ -50,17 +50,17 @@
 </tr>
 <tr>
 	<td>CARD_ACTIVE</td>
-	<td>//h4[contains(text(), '${key_header}')]//following::div[contains(@class,'active file-card')]</td>
+	<td>//div[contains(@class,'h4') and contains(text(), '${key_header}')]//following::div[contains(@class,'active file-card')]</td>
 	<td></td>
 </tr>
 <tr>
 	<td>KEBAB_DROPDOWN_CARD_OPTION</td>
-	<td>//h4[contains(text(), '${key_header}')]//following::div[contains(@data-qa-id,'image-card-icon-block')]//button[contains(@class, 'dropdown-toggle')]</td>
+	<td>//div[contains(@class,'h4') and contains(text(), '${key_header}')]//following::div[contains(@data-qa-id,'image-card-icon-block')]//button[contains(@class, 'dropdown-toggle')]</td>
 	<td></td>
 </tr>
 <tr>
 	<td>TITLE_CARD</td>
-	<td>//h4[contains(text(), '${key_header}')]//following::a[contains(text(),'${key_title}')]</td>
+	<td>//div[contains(@class,'h4') and contains(text(), '${key_header}')]//following::a[contains(text(),'${key_title}')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/documentsandmedia/DocumentsAndMediaDocument.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/documentsandmedia/DocumentsAndMediaDocument.path
@@ -408,7 +408,7 @@
 </tr>
 <tr>
 	<td>METADATA_PANEL_UPLOAD</td>
-	<td>//label[normalize-space(text())='${key_fieldFieldLabel}']//following-sibling::div//h4</td>
+	<td>//label[normalize-space(text())='${key_fieldFieldLabel}']//following-sibling::div//div[contains(@class,'h4')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/forms/FormFields.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/forms/FormFields.path
@@ -1182,7 +1182,7 @@
 </tr>
 <tr>
 	<td>UPLOAD_FILE_NAME</td>
-	<td>//div[contains(@data-field-name,'${key_fieldName}')]//h4[contains(.,'${key_uploadFileName}')] | //div//label[text()='${key_fieldName}']/..//h4[contains(.,'Document_1.jpg')]</td>
+	<td>//div[contains(@data-field-name,'${key_fieldName}')]//div[contains(.,'${key_uploadFileName}')] | //div//label[text()='${key_fieldName}']/..//div[contains(.,'Document_1.jpg')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/knowledgebase/KnowledgeBaseArticle.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/knowledgebase/KnowledgeBaseArticle.path
@@ -142,7 +142,7 @@
 
 <tr>
 	<td>INFO_TITLE</td>
-	<td>//div[@class='sidebar-header']//h4[@class='component-title']</td>
+	<td>//div[@class='sidebar-header']//div[contains(@class,'component-title')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/knowledgebase/KnowledgeBaseSuggestions.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/knowledgebase/KnowledgeBaseSuggestions.path
@@ -22,7 +22,7 @@
 </tr>
 <tr>
 	<td>CONTENT_DUPLICATE</td>
-	<td>//dl[contains(@class,'tabular-list-group')]/li[contains(@class,'list-group-item')][2]/div[contains(@class,'list-group-item-field')]/following-sibling::*[@data-qa-id='rowItemContent']/h4[contains(.,'${kbSuggestionBody}')]</td>
+	<td>//dl[contains(@class,'tabular-list-group')]/li[contains(@class,'list-group-item')][2]/div[contains(@class,'list-group-item-field')]/following-sibling::*[@data-qa-id='rowItemContent']/div[contains(.,'${kbSuggestionBody}')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/messageboards/MessageBoards.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/messageboards/MessageBoards.path
@@ -144,7 +144,7 @@
 </tr>
 <tr>
 	<td>CATEGORY_LIST_CATEGORY_DESCRIPTION</td>
-	<td>//*[@data-qa-id='rowItemContent']/h4/a[contains(.,'${key_categoryName}')]/../..//h5[contains(.,'${key_categoryDescription}')]</td>
+	<td>//*[@data-qa-id='rowItemContent']/div[contains(@class,'h4')]/a[contains(.,'${key_categoryName}')]/../..//h5[contains(.,'${key_categoryDescription}')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/messageboards/MessageBoardsEditMessage.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/messageboards/MessageBoardsEditMessage.path
@@ -25,7 +25,7 @@
 </tr>
 <tr>
 	<td>ATTACHMENTS_SAVED_STATUS</td>
-	<td>//h4[contains(.,'All files ready to be saved')]</td>
+	<td>//div[contains(.,'All files ready to be saved')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/messageboards/MessageBoardsStatistics.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/messageboards/MessageBoardsStatistics.path
@@ -58,7 +58,7 @@
 </tr>
 <tr>
 	<td>TOP_POSTERS_AUTHOR_ICON</td>
-	<td>//*[@data-qa-id='rowItemContent']//h4[contains(@title,'${key_userName}')]/../../div/div[contains(@class,'user-icon')]</td>
+	<td>//*[@data-qa-id='rowItemContent']//div[contains(@title,'${key_userName}')]/../../div/div[contains(@class,'user-icon')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/messageboards/MessageBoardsThread.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/messageboards/MessageBoardsThread.path
@@ -65,17 +65,17 @@
 </tr>
 <tr>
 	<td>THREAD_REPLY_SUBJECT</td>
-	<td>//div[contains(@class,'autofit-col')]//h4[contains(.,'${key_threadSubject}')]</td>
+	<td>//div[contains(@class,'autofit-col')]//div[contains(@class,'h4') and contains(.,'${key_threadSubject}')]</td>
 	<td></td>
 </tr>
 <tr>
 	<td>THREAD_SUBJECT</td>
-	<td>//div[@class='panel-heading' and contains(.,'${key_threadSubject}')]//h4[contains(.,'${key_threadSubject}')]</td>
+	<td>//div[@class='panel-heading' and contains(.,'${key_threadSubject}')]//div[contains(@class,'h4') and contains(.,'${key_threadSubject}')]</td>
 	<td></td>
 </tr>
 <tr>
 	<td>THREAD_SUBJECT_2</td>
-	<td>xpath=(//div[@class='panel-heading' and contains(.,'${key_threadSubject}')]//h4[contains(.,'${key_threadSubject}')])[2]</td>
+	<td>xpath=(//div[@class='panel-heading' and contains(.,'${key_threadSubject}')]//div[contains(@class,'h4') and contains(.,'${key_threadSubject}')])[2]</td>
 	<td></td>
 </tr>
 <tr>
@@ -123,7 +123,7 @@
 </tr>
 <tr>
 	<td>MESSAGE_ANSWER_1</td>
-	<td>//h4[contains(.,'Answer')]</td>
+	<td>//div[contains(@class,'h4') and contains(.,'Answer')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/questions/Questions.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/questions/Questions.path
@@ -292,7 +292,7 @@
 </tr>
 <tr>
 	<td>QUESTIONS_STATISTICS_HEADER</td>
-	<td>//h4[contains(@class,'text-secondary') and contains(.,'${key_headerName}')]</td>
+	<td>//div[contains(@class,'text-secondary') and contains(.,'${key_headerName}')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/sites/SiteMemberships.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/sites/SiteMemberships.path
@@ -12,7 +12,7 @@
 <tbody>
 <tr>
 	<td>MEMBERSHIP_TYPE</td>
-	<td>//div[contains(@class,'sidebar-header') and contains(.,'Membership Type')]/h4</td>
+	<td>//div[contains(@class,'sidebar-header') and contains(.,'Membership Type')]/div[contains(@class,'h4')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/wiki/Wiki.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/wiki/Wiki.path
@@ -96,7 +96,7 @@
 
 <tr>
 	<td>CHILD_PAGE_HEADER</td>
-	<td>//div[contains(@class,'container-fluid')]//h4</td>
+	<td>//div[contains(@class,'container-fluid')]//div[contains(@class,'h4')]</td>
 	<td></td>
 </tr>
 <tr>
@@ -175,7 +175,7 @@
 
 <tr>
 	<td>DESCRIPTIVE_VIEW_ENTRY_TITLE</td>
-	<td>//*[@data-qa-id='row']/*[@data-qa-id='rowItemContent']/h4[contains(.,'${key_wikiPageTitle}')]/a</td>
+	<td>//*[@data-qa-id='row']/*[@data-qa-id='rowItemContent']/div[contains(.,'${key_wikiPageTitle}')]/a</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-4680

@ethib137 This pr reverts the reverts and fixes `upload.js` selectors. I also added the `h4` class back to `card-header` since it didn't modify `font-size`, `font-weight`, `line-height`, etc.

**LocalFile.RolesandpermissionsUsecase#ExportRoleWithSiteAssignee** should pass now.

**LocalFile.SFCommerceProductDiagrams#VerifyAllPinTypeAndMappedProductInformation** fails on a different line:

`[exec]     com.liferay.poshi.runner.exception.ElementNotFoundPoshiRunnerException: Element is not present at "//div[@class='data-set-wrapper' or @class='searchcontainer-content']//a[text()='Diagram1']"`

I think it's trying to add `Diagram1` and searching for it to make sure it was added. The returning json contains:

```
[exec]       "status" : "BAD_REQUEST",
[exec]       "type" : "CPDefinitionProductTypeNameException"
```

I can't reproduce the other commerce test failures. When I run them locally, they fail with the error:

```[exec]     com.jayway.jsonpath.PathNotFoundException: No results for path: $['userId']```

The server outputs:

`2024-05-16 20:42:53.685 ERROR [http-nio-8080-exec-4][JSONWebServiceServiceAction:123] Conversion failed: 34340,34902; <--- java.lang.NumberFormatException: For input string: "34340,34902"`

I also ran the tests on bchans version of master that contain your reverts. They all fail the same way.