### PR TITLE
LPD-24964 System/instance configurations that are hidden from the interface can be accessible by its URL

### DIFF
--- a/modules/apps/configuration-admin/configuration-admin-test/src/testIntegration/java/com/liferay/configuration/admin/internal/configuration/TestCompanyConfiguration.java
+++ b/modules/apps/configuration-admin/configuration-admin-test/src/testIntegration/java/com/liferay/configuration/admin/internal/configuration/TestCompanyConfiguration.java
@@ -1,0 +1,24 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.configuration.admin.internal.configuration;
+
+import aQute.bnd.annotation.metatype.Meta;
+
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
+
+/**
+ * @author Thiago Buarque
+ */
+@ExtendedObjectClassDefinition(category = "other")
+@Meta.OCD(
+	id = "com.liferay.configuration.admin.internal.configuration.TestCompanyConfiguration"
+)
+public interface TestCompanyConfiguration {
+
+	@Meta.AD(deflt = "", name = "company-configuration-key", required = false)
+	public String companyConfigurationKey();
+
+}

--- a/modules/apps/configuration-admin/configuration-admin-test/src/testIntegration/java/com/liferay/configuration/admin/internal/configuration/TestSystemConfiguration.java
+++ b/modules/apps/configuration-admin/configuration-admin-test/src/testIntegration/java/com/liferay/configuration/admin/internal/configuration/TestSystemConfiguration.java
@@ -1,0 +1,26 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.configuration.admin.internal.configuration;
+
+import aQute.bnd.annotation.metatype.Meta;
+
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
+
+/**
+ * @author Thiago Buarque
+ */
+@ExtendedObjectClassDefinition(
+	category = "other", scope = ExtendedObjectClassDefinition.Scope.SYSTEM
+)
+@Meta.OCD(
+	id = "com.liferay.configuration.admin.internal.configuration.TestSystemConfiguration"
+)
+public interface TestSystemConfiguration {
+
+	@Meta.AD(deflt = "", name = "system-configuration-key", required = false)
+	public String systemConfigurationKey();
+
+}

--- a/modules/apps/configuration-admin/configuration-admin-test/src/testIntegration/java/com/liferay/configuration/admin/internal/configuration/admin/display/BaseTestConfigurationScreen.java
+++ b/modules/apps/configuration-admin/configuration-admin-test/src/testIntegration/java/com/liferay/configuration/admin/internal/configuration/admin/display/BaseTestConfigurationScreen.java
@@ -1,0 +1,42 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.configuration.admin.internal.configuration.admin.display;
+
+import com.liferay.configuration.admin.display.ConfigurationScreen;
+
+import java.util.Locale;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * @author Thiago Buarque
+ */
+public abstract class BaseTestConfigurationScreen
+	implements ConfigurationScreen {
+
+	@Override
+	public String getCategoryKey() {
+		return "other";
+	}
+
+	@Override
+	public String getName(Locale locale) {
+		return "configuration-name";
+	}
+
+	@Override
+	public boolean isVisible() {
+		return false;
+	}
+
+	@Override
+	public void render(
+		HttpServletRequest httpServletRequest,
+		HttpServletResponse httpServletResponse) {
+	}
+
+}

--- a/modules/apps/configuration-admin/configuration-admin-test/src/testIntegration/java/com/liferay/configuration/admin/internal/configuration/admin/display/TestCompanyConfigurationScreen.java
+++ b/modules/apps/configuration-admin/configuration-admin-test/src/testIntegration/java/com/liferay/configuration/admin/internal/configuration/admin/display/TestCompanyConfigurationScreen.java
@@ -1,0 +1,29 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.configuration.admin.internal.configuration.admin.display;
+
+import com.liferay.configuration.admin.display.ConfigurationScreen;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Thiago Buarque
+ */
+@Component(service = ConfigurationScreen.class)
+public class TestCompanyConfigurationScreen
+	extends BaseTestConfigurationScreen {
+
+	@Override
+	public String getKey() {
+		return "company-configuration-key";
+	}
+
+	@Override
+	public String getScope() {
+		return "company";
+	}
+
+}

--- a/modules/apps/configuration-admin/configuration-admin-test/src/testIntegration/java/com/liferay/configuration/admin/internal/configuration/admin/display/TestSystemConfigurationScreen.java
+++ b/modules/apps/configuration-admin/configuration-admin-test/src/testIntegration/java/com/liferay/configuration/admin/internal/configuration/admin/display/TestSystemConfigurationScreen.java
@@ -1,0 +1,28 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.configuration.admin.internal.configuration.admin.display;
+
+import com.liferay.configuration.admin.display.ConfigurationScreen;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Thiago Buarque
+ */
+@Component(service = ConfigurationScreen.class)
+public class TestSystemConfigurationScreen extends BaseTestConfigurationScreen {
+
+	@Override
+	public String getKey() {
+		return "system-configuration-key";
+	}
+
+	@Override
+	public String getScope() {
+		return "system";
+	}
+
+}

--- a/modules/apps/configuration-admin/configuration-admin-test/src/testIntegration/java/com/liferay/configuration/admin/internal/portlet/action/test/ViewConfigurationScreenMVCRenderCommandTest.java
+++ b/modules/apps/configuration-admin/configuration-admin-test/src/testIntegration/java/com/liferay/configuration/admin/internal/portlet/action/test/ViewConfigurationScreenMVCRenderCommandTest.java
@@ -1,0 +1,132 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.configuration.admin.internal.portlet.action.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.configuration.admin.constants.ConfigurationAdminPortletKeys;
+import com.liferay.portal.kernel.portlet.PortletConfigFactoryUtil;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.PortletLocalService;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderRequest;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderResponse;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.JavaConstants;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import javax.portlet.PortletException;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Thiago Buarque
+ */
+@RunWith(Arquillian.class)
+public class ViewConfigurationScreenMVCRenderCommandTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Test
+	public void testRender() throws Exception {
+		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
+			_getMockLiferayPortletRenderRequest();
+
+		mockLiferayPortletRenderRequest.setParameter(
+			"configurationScreenKey", "company-configuration-key");
+
+		MockLiferayPortletRenderResponse mockLiferayPortletRenderResponse =
+			new MockLiferayPortletRenderResponse();
+
+		try {
+			_mvcRenderCommand.render(
+				mockLiferayPortletRenderRequest,
+				mockLiferayPortletRenderResponse);
+
+			Assert.fail();
+		}
+		catch (PortletException portletException) {
+			Assert.assertEquals(
+				"The company configuration \"configuration-name\" is not " +
+					"accessible",
+				portletException.getMessage());
+		}
+
+		mockLiferayPortletRenderRequest.setParameter(
+			"configurationScreenKey", "system-configuration-key");
+
+		try {
+			_mvcRenderCommand.render(
+				mockLiferayPortletRenderRequest,
+				mockLiferayPortletRenderResponse);
+
+			Assert.fail();
+		}
+		catch (PortletException portletException) {
+			Assert.assertEquals(
+				"The system configuration \"configuration-name\" is not " +
+					"accessible",
+				portletException.getMessage());
+		}
+	}
+
+	private MockLiferayPortletRenderRequest
+			_getMockLiferayPortletRenderRequest()
+		throws Exception {
+
+		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
+			new MockLiferayPortletRenderRequest();
+
+		mockLiferayPortletRenderRequest.setAttribute(
+			JavaConstants.JAVAX_PORTLET_CONFIG,
+			PortletConfigFactoryUtil.create(
+				_portletLocalService.getPortletById(
+					ConfigurationAdminPortletKeys.SYSTEM_SETTINGS),
+				null));
+
+		mockLiferayPortletRenderRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, _getThemeDisplay());
+
+		return mockLiferayPortletRenderRequest;
+	}
+
+	private ThemeDisplay _getThemeDisplay() throws Exception {
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		themeDisplay.setCompany(
+			_companyLocalService.getCompany(TestPropsValues.getCompanyId()));
+		themeDisplay.setLocale(LocaleUtil.US);
+
+		return themeDisplay;
+	}
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
+
+	@Inject(
+		filter = "mvc.command.name=/configuration_admin/view_configuration_screen",
+		type = MVCRenderCommand.class
+	)
+	private MVCRenderCommand _mvcRenderCommand;
+
+	@Inject
+	private PortletLocalService _portletLocalService;
+
+}

--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/portlet/action/ViewConfigurationScreenMVCRenderCommand.java
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/portlet/action/ViewConfigurationScreenMVCRenderCommand.java
@@ -13,6 +13,7 @@ import com.liferay.configuration.admin.web.internal.display.ConfigurationScreenC
 import com.liferay.configuration.admin.web.internal.display.context.ConfigurationScopeDisplayContext;
 import com.liferay.configuration.admin.web.internal.display.context.ConfigurationScopeDisplayContextFactory;
 import com.liferay.configuration.admin.web.internal.util.ConfigurationEntryRetriever;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -56,6 +57,14 @@ public class ViewConfigurationScreenMVCRenderCommand
 		ConfigurationScreen configurationScreen =
 			_configurationEntryRetriever.getConfigurationScreen(
 				configurationScreenKey);
+
+		if (!configurationScreen.isVisible()) {
+			throw new PortletException(
+				StringBundler.concat(
+					"The ", configurationScreen.getScope(), " configuration \"",
+					configurationScreen.getName(themeDisplay.getLocale()),
+					"\" is not accessible"));
+		}
 
 		ConfigurationScopeDisplayContext configurationScopeDisplayContext =
 			ConfigurationScopeDisplayContextFactory.create(renderRequest);

--- a/modules/apps/configuration-admin/source-formatter-suppressions.xml
+++ b/modules/apps/configuration-admin/source-formatter-suppressions.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+
+<suppressions>
+	<source-check>
+		<suppress checks="JavaConfigurationCategoryCheck" files="configuration-admin-test/src/testIntegration/java/com/liferay/configuration/admin/internal/configuration/TestCompanyConfiguration.java" />
+		<suppress checks="JavaConfigurationCategoryCheck" files="configuration-admin-test/src/testIntegration/java/com/liferay/configuration/admin/internal/configuration/TestSystemConfiguration.java" />
+		<suppress checks="LanguageKeysCheck" files="configuration-admin-test/src/testIntegration/java/com/liferay/configuration/admin/internal/configuration/TestCompanyConfiguration.java" />
+		<suppress checks="LanguageKeysCheck" files="configuration-admin-test/src/testIntegration/java/com/liferay/configuration/admin/internal/configuration/TestSystemConfiguration.java" />
+	</source-check>
+</suppressions>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-24964

# Issue
It is possible to access a System/Instance configuration when it's supposed to be hidden from the UI.

## Steps to reproduce
**Preconditions**

Make sure the Script Management configuration IS NOT visible on the System Configurations page. If it’s visible, find a system configuration that is not accessible via interface and change script-management on step 1 URL to configuration-key-you-found.

**Steps**

1. Access the [script management configuration URL](http://localhost:8080/group/guest/~/control_panel/manage?p_p_id=com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet&p_p_lifecycle=0&p_p_state=maximized&p_p_mode=view&_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_mvcRenderCommandName=%2Fconfiguration_admin%2Fview_configuration_screen&_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_configurationScreenKey=script-management) (or other configuration in case someone make this one visible in the future).

# Proposed fix
Before render the UI, check if the configuration should be visible, if not, prevent rendering.

## Preview of the proposed fix
![image](https://github.com/liferay-platform-experience/liferay-portal/assets/57292581/185f113b-6053-4993-bfb0-3308351f5d44)
