### PR TITLE
LPD-26624

### DIFF
--- a/portal-web/docroot/html/taglib/ui/input_localized/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_localized/page.jsp
@@ -20,59 +20,6 @@ Map<String, Map<String, String>> languagesTranslationsAriaLabelsMap = new HashMa
 </c:if>
 
 <div class="input-group input-localized input-localized-<%= type %>" id="<%= namespace + id %>BoundingBox">
-	<div class="input-group-item">
-		<c:choose>
-			<c:when test='<%= type.equals("editor") %>'>
-				<liferay-ui:input-editor
-					contents="<%= mainLanguageValue %>"
-					contentsLanguageId="<%= languageId %>"
-					cssClass='<%= "language-value " + cssClass %>'
-					editorName="<%= editorName %>"
-					name="<%= inputEditorName %>"
-					onChangeMethod='<%= randomNamespace + "onChangeEditor" %>'
-					onInitMethod='<%= randomNamespace + "onInitEditor" %>'
-					placeholder="<%= placeholder %>"
-					toolbarSet="<%= toolbarSet %>"
-				/>
-
-				<aui:script>
-					function <%= namespace + randomNamespace %>onChangeEditor() {
-						var inputLocalized = Liferay.component('<%= namespace + HtmlUtil.escapeJS(fieldName) %>');
-
-						var editor = window['<%= namespace + HtmlUtil.escapeJS(inputEditorName) %>'];
-
-						inputLocalized.updateInputLanguage(editor.getHTML());
-					}
-
-					function <%= namespace + randomNamespace %>onInitEditor() {
-						Liferay.componentReady('<%= namespace + HtmlUtil.escapeJS(fieldName) %>')
-							.then(inputLocalized => {
-								var editor = window['<%= namespace + HtmlUtil.escapeJS(inputEditorName) %>'];
-								inputLocalized.updateInputPlaceholder(editor);
-							}
-						);
-					}
-				</aui:script>
-			</c:when>
-			<c:when test='<%= type.equals("input") %>'>
-				<input aria-describedby="<%= namespace + HtmlUtil.escapeAttribute(id + fieldSuffix) %>_desc" class="form-control language-value <%= cssClass %>" dir="<%= mainLanguageDir %>" <%= disabled ? "disabled=\"disabled\"" : "" %> id="<%= namespace + id + HtmlUtil.getAUICompatibleId(fieldSuffix) %>" name="<%= namespace + HtmlUtil.escapeAttribute(name + fieldSuffix) %>" <%= Validator.isNotNull(placeholder) ? "placeholder=\"" + LanguageUtil.get(resourceBundle, placeholder) + "\"" : StringPool.BLANK %> type="text" value="<%= HtmlUtil.escapeAttribute(mainLanguageValue) %>" <%= InlineUtil.buildDynamicAttributes(dynamicAttributes) %> />
-			</c:when>
-			<c:when test='<%= type.equals("textarea") %>'>
-				<textarea maxlength="<%= maxLength %>" aria-labelledby='<%= namespace + id %> <%= namespace + id %>_maxCharacters' aria-describedby="<%= namespace + HtmlUtil.escapeAttribute(id + fieldSuffix) %>_desc" class="form-control language-value <%= cssClass %>" dir="<%= mainLanguageDir %>" <%= disabled ? "disabled=\"disabled\"" : "" %> id="<%= namespace + id + HtmlUtil.getAUICompatibleId(fieldSuffix) %>" name="<%= namespace + HtmlUtil.escapeAttribute(name + fieldSuffix) %>" <%= Validator.isNotNull(placeholder) ? "placeholder=\"" + LanguageUtil.get(resourceBundle, placeholder) + "\"" : StringPool.BLANK %> <%= InlineUtil.buildDynamicAttributes(dynamicAttributes) %>><%= HtmlUtil.escape(mainLanguageValue) %></textarea>
-
-				<span class="sr-only" id="<%= namespace + id %>_maxCharacters">
-					<liferay-ui:message key="characters-maximum" />: <%= maxLength %>
-				</span>
-
-				<c:if test="<%= autoSize %>">
-					<aui:script use="aui-autosize-deprecated">
-						A.one('#<%= namespace + id + HtmlUtil.getAUICompatibleId(fieldSuffix) %>').plug(A.Plugin.Autosize);
-					</aui:script>
-				</c:if>
-			</c:when>
-		</c:choose>
-	</div>
-
 	<div class="hide-accessible sr-only" id="<%= namespace + HtmlUtil.escapeAttribute(id + fieldSuffix) %>_desc"><%= defaultLocale.getDisplayName(LocaleUtil.fromLanguageId(LanguageUtil.getLanguageId(request))) %> <liferay-ui:message key="translation" /></div>
 
 	<c:if test="<%= !availableLocales.isEmpty() && Validator.isNull(languageId) %>">
@@ -263,6 +210,59 @@ Map<String, Map<String, String>> languagesTranslationsAriaLabelsMap = new HashMa
 					</div>
 				</div>
 			</liferay-ui:icon-menu>
+		</div>
+
+		<div class="input-group-item">
+			<c:choose>
+				<c:when test='<%= type.equals("editor") %>'>
+					<liferay-ui:input-editor
+						contents="<%= mainLanguageValue %>"
+						contentsLanguageId="<%= languageId %>"
+						cssClass='<%= "language-value " + cssClass %>'
+						editorName="<%= editorName %>"
+						name="<%= inputEditorName %>"
+						onChangeMethod='<%= randomNamespace + "onChangeEditor" %>'
+						onInitMethod='<%= randomNamespace + "onInitEditor" %>'
+						placeholder="<%= placeholder %>"
+						toolbarSet="<%= toolbarSet %>"
+					/>
+
+					<aui:script>
+						function <%= namespace + randomNamespace %>onChangeEditor() {
+						var inputLocalized = Liferay.component('<%= namespace + HtmlUtil.escapeJS(fieldName) %>');
+
+						var editor = window['<%= namespace + HtmlUtil.escapeJS(inputEditorName) %>'];
+
+						inputLocalized.updateInputLanguage(editor.getHTML());
+						}
+
+						function <%= namespace + randomNamespace %>onInitEditor() {
+						Liferay.componentReady('<%= namespace + HtmlUtil.escapeJS(fieldName) %>')
+						.then(inputLocalized => {
+						var editor = window['<%= namespace + HtmlUtil.escapeJS(inputEditorName) %>'];
+						inputLocalized.updateInputPlaceholder(editor);
+						}
+						);
+						}
+					</aui:script>
+				</c:when>
+				<c:when test='<%= type.equals("input") %>'>
+					<input aria-describedby="<%= namespace + HtmlUtil.escapeAttribute(id + fieldSuffix) %>_desc" class="form-control language-value <%= cssClass %>" dir="<%= mainLanguageDir %>" <%= disabled ? "disabled=\"disabled\"" : "" %> id="<%= namespace + id + HtmlUtil.getAUICompatibleId(fieldSuffix) %>" name="<%= namespace + HtmlUtil.escapeAttribute(name + fieldSuffix) %>" <%= Validator.isNotNull(placeholder) ? "placeholder=\"" + LanguageUtil.get(resourceBundle, placeholder) + "\"" : StringPool.BLANK %> type="text" value="<%= HtmlUtil.escapeAttribute(mainLanguageValue) %>" <%= InlineUtil.buildDynamicAttributes(dynamicAttributes) %> />
+				</c:when>
+				<c:when test='<%= type.equals("textarea") %>'>
+					<textarea maxlength="<%= maxLength %>" aria-labelledby='<%= namespace + id %> <%= namespace + id %>_maxCharacters' aria-describedby="<%= namespace + HtmlUtil.escapeAttribute(id + fieldSuffix) %>_desc" class="form-control language-value <%= cssClass %>" dir="<%= mainLanguageDir %>" <%= disabled ? "disabled=\"disabled\"" : "" %> id="<%= namespace + id + HtmlUtil.getAUICompatibleId(fieldSuffix) %>" name="<%= namespace + HtmlUtil.escapeAttribute(name + fieldSuffix) %>" <%= Validator.isNotNull(placeholder) ? "placeholder=\"" + LanguageUtil.get(resourceBundle, placeholder) + "\"" : StringPool.BLANK %> <%= InlineUtil.buildDynamicAttributes(dynamicAttributes) %>><%= HtmlUtil.escape(mainLanguageValue) %></textarea>
+
+					<span class="sr-only" id="<%= namespace + id %>_maxCharacters">
+						<liferay-ui:message key="characters-maximum" />: <%= maxLength %>
+					</span>
+
+					<c:if test="<%= autoSize %>">
+						<aui:script use="aui-autosize-deprecated">
+							A.one('#<%= namespace + id + HtmlUtil.getAUICompatibleId(fieldSuffix) %>').plug(A.Plugin.Autosize);
+						</aui:script>
+					</c:if>
+				</c:when>
+			</c:choose>
 		</div>
 	</c:if>
 </div>


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPD-26624
## Motivation
When the user tries to navigate through the following component (see the screenshot) using the Tab key, the focus is inverted:
Title input field
Language selector

Expected behaviour:
The focus should be in the following order:
Language selector
Title input field

## Proposed Solution
No new changes were added here, I just moved 1 div element further down. This switched element order allows for the focus to go to the language selector first. 

## Steps to Verify

1. Navigate to Content & Data > Web Content
2. Go to the Structures tab and create a new Structure
3. Click the Control Menu at the top of the page, then use the tab key to navigate to the Language Selector and Title input field
4. Observe focus order

## Screenshots/videos
Before:
https://github.com/liferay-platform-experience/liferay-portal/assets/101599314/875116ea-113d-43e5-84f4-dee683a8468f

After:
https://github.com/liferay-platform-experience/liferay-portal/assets/101599314/5b6a2904-4593-4563-8da2-6c986ebe298f


## Alternative Solutions that were discarded
Another solution would be to edit the focus order manually but I was not sure if this is possible/a better solution.
