### PR TITLE
LPD-26624 - Modify CSS for corrected input-localized markup order

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/css/main.scss
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/css/main.scss
@@ -119,18 +119,11 @@ $productMenuWidth: 320px;
 			}
 
 			.input-localized {
-				flex-direction: row-reverse;
-
 				.form-validator-stack {
 					display: none;
 				}
 
-				.input-group-item {
-					order: 2;
-				}
-
 				.input-localized-content {
-					order: 1;
 					padding-right: 0.5rem;
 				}
 			}

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/css/main.scss
@@ -109,18 +109,11 @@ $productMenuWidth: 320px;
 			}
 
 			.input-localized {
-				flex-direction: row-reverse;
-
 				.form-validator-stack {
 					display: none;
 				}
 
-				.input-group-item {
-					order: 2;
-				}
-
 				.input-localized-content {
-					order: 1;
 					padding-right: 0.5rem;
 				}
 			}

--- a/modules/apps/template/template-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/template/template-web/src/main/resources/META-INF/resources/css/main.scss
@@ -33,18 +33,11 @@ $productMenuWidth: 320px;
 		}
 
 		.input-localized {
-			flex-direction: row-reverse;
-
 			.form-validator-stack {
 				display: none;
 			}
 
-			.input-group-item {
-				order: 2;
-			}
-
 			.input-localized-content {
-				order: 1;
 				padding-right: 0.5rem;
 			}
 		}


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPD-26624

## Motivation
When the user tries to navigate through the following component using the Tab key, the focus is inverted compared to the order of elements:
![image](https://github.com/liferay/liferay-portal/assets/101599314/567cd50a-dce1-4f34-83e5-2fe5853d2d4b)

To allow for the correct focus order, we should swap these elements:
![image](https://github.com/liferay/liferay-portal/assets/101599314/08e72169-b20b-494a-8aff-dd3edd58393a)

## Proposed Solution
Remove the CSS responsible for this visual change in template-web, journal-web, and document-library web to make this change only in those locations. 

## Steps to Verify

This change is visible in 3 locations:

Web Content:
1. Navigate to Content & Data > Web Content > Web Content.
2. Create a new Basic Web Content Article.

Template:
1. Navigate to Content & Data > Web Content > Templates.
2. Create a new Template.

Documents & Media:
1. Navigate to Content & Data > Documents & Media > Document Types.
2. Create a new Document Type.

All:

   3. Click the Control Menu at the top of the page, then use the tab key to navigate to the Language Selector and Title input field.
   4. Observe focus order.

## Screenshots
![document_LPD-26624](https://github.com/liferay/liferay-portal/assets/101599314/de7c962f-2e0b-4965-8e4c-f2ba10b9fffd)
![template_LPD-26624](https://github.com/liferay/liferay-portal/assets/101599314/848614e0-0bf2-4227-b951-f3efc7b969a4)
![web_content_LPD-26624](https://github.com/liferay/liferay-portal/assets/101599314/1d1160e8-7ac9-4863-aa4e-7a3892460f1d)

## Alternative Solutions that were discarded
We attempted to swap these elements only in the markup and preserve their order visually, but this caused unintended consequences in other locations. This discarded solution can be found here: https://github.com/liferay-platform-experience/liferay-portal/pull/637