### PR TITLE
LPD-29502 - In the Applications menu focus should move directly from the tab to the first item in the tab content.

### DIFF
--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/js/index.js
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/js/index.js
@@ -292,7 +292,10 @@ const AppsPanel = ({
 						<ClayLayout.Col className="pr-0" md="9" xl="8">
 							<ClayTabs.Content activeIndex={activeTab}>
 								{categories.map(({childCategories}, index) => (
-									<ClayTabs.TabPane key={`tabPane-${index}`}>
+									<ClayTabs.TabPane
+										key={`tabPane-${index}`}
+										tabIndex={null}
+									>
 										<div
 											aria-labelledby={`${portletNamespace}tab_${index}`}
 											className="applications-menu-nav-columns c-pt-md-3 c-py-2"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-29502