### PR TITLE
LPD-30969 fixes bug when always keeping two columns visible with Clay Table's FDS

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/ClayTable.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/ClayTable.tsx
@@ -136,7 +136,9 @@ export function ClayTable({
 
 	return (
 		<Table
-			alwaysVisibleColumns={defaultAlwaysVisibleColumns}
+			alwaysVisibleColumns={
+				selectable ? defaultAlwaysVisibleColumns : undefined
+			}
 			messages={{
 				columnsVisibility: Liferay.Language.get(
 					'manage-columns-visibility'


### PR DESCRIPTION
Ticket [LPD-30969](https://liferay.atlassian.net/browse/LPD-30969)

This fix the behavior for cases where there is no select column in the table, which broke the ClayTable mechanism, allowing two columns to always be visible instead of just one.