### PR TITLE
LPD-30904 Remove uses of shadow-none on links and buttons for keyboar…

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/shared/input_sets/Item.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/shared/input_sets/Item.js
@@ -51,7 +51,6 @@ function Item({
 						<ClayButton
 							aria-label={Liferay.Language.get('move')}
 							borderless
-							className="shadow-none"
 							displayType="secondary"
 							monospaced
 							small
@@ -66,7 +65,7 @@ function Item({
 						<ClayButton
 							aria-label={Liferay.Language.get('delete')}
 							borderless
-							className="c-ml-2 shadow-none"
+							className="c-ml-2"
 							displayType="secondary"
 							monospaced
 							onClick={onInputSetItemDelete(index)}

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/search/results/web/portlet/display/template/dependencies/portlet_display_template_list.ftl
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/search/results/web/portlet/display/template/dependencies/portlet_display_template_list.ftl
@@ -119,7 +119,7 @@
 								<#if entry.isDocumentFormVisible()>
 									<div class="expand-details text-default">
 										<span class="list-group-text text-2">
-											<a class="shadow-none" href="javascript:void(0);">
+											<a href="javascript:void(0);" role="button">
 												<@liferay.language key="details" />...
 											</a>
 										</span>


### PR DESCRIPTION
…d accessibility

https://liferay.atlassian.net/browse/LPD-30904

This pr doesn't remove `shadow-none` from:

liferay-portal/modules/apps/site-initializer/site-initializer-raylife-ap/extra/remote-app/src/routes/claims/pages/ClaimsTable/index.tsx

liferay-portal/modules/apps/site-initializer/site-initializer-raylife-ap/extra/remote-app/src/routes/policies/pages/PoliciesTable/index.tsx

liferay-portal/modules/apps/site-initializer/site-initializer-raylife-d2c/extra/remote-app/src/routes/get-a-quote/components/tip-container-modal/index.js

We should have the team that owns it make the changes. There might be more theme changes needed.