### PR TITLE
LPD-32127 Centralize the logic to import .properties files for a given language id

### DIFF
--- a/modules/apps/portal-language/portal-language-override-api/bnd.bnd
+++ b/modules/apps/portal-language/portal-language-override-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Language Override API
 Bundle-SymbolicName: com.liferay.portal.language.override.api
-Bundle-Version: 3.1.1
+Bundle-Version: 3.2.0
 Export-Package:\
 	com.liferay.portal.language.override.constants,\
 	com.liferay.portal.language.override.exception,\

--- a/modules/apps/portal-language/portal-language-override-api/src/main/java/com/liferay/portal/language/override/exception/ImportTranslationsException.java
+++ b/modules/apps/portal-language/portal-language-override-api/src/main/java/com/liferay/portal/language/override/exception/ImportTranslationsException.java
@@ -1,0 +1,47 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.language.override.exception;
+
+import com.liferay.portal.kernel.exception.PortalException;
+
+import java.util.Map;
+
+/**
+ * @author Thiago Buarque
+ */
+public class ImportTranslationsException extends PortalException {
+
+	public static class InvalidPropertiesFile
+		extends ImportTranslationsException {
+
+		public InvalidPropertiesFile() {
+			super("Invalid properties file");
+		}
+
+	}
+
+	public static class InvalidTranslations
+		extends ImportTranslationsException {
+
+		public InvalidTranslations(Map<Class<?>, Exception> exceptions) {
+			super("Unable to import translations");
+
+			_exceptions = exceptions;
+		}
+
+		public Map<Class<?>, Exception> getExceptions() {
+			return _exceptions;
+		}
+
+		private final Map<Class<?>, Exception> _exceptions;
+
+	}
+
+	private ImportTranslationsException(String msg) {
+		super(msg);
+	}
+
+}

--- a/modules/apps/portal-language/portal-language-override-api/src/main/java/com/liferay/portal/language/override/exception/ImportTranslationsException.java
+++ b/modules/apps/portal-language/portal-language-override-api/src/main/java/com/liferay/portal/language/override/exception/ImportTranslationsException.java
@@ -7,7 +7,7 @@ package com.liferay.portal.language.override.exception;
 
 import com.liferay.portal.kernel.exception.PortalException;
 
-import java.util.Map;
+import java.util.List;
 
 /**
  * @author Thiago Buarque
@@ -26,17 +26,17 @@ public class ImportTranslationsException extends PortalException {
 	public static class InvalidTranslations
 		extends ImportTranslationsException {
 
-		public InvalidTranslations(Map<Class<?>, Exception> exceptions) {
+		public InvalidTranslations(List<Exception> exceptions) {
 			super("Unable to import translations");
 
 			_exceptions = exceptions;
 		}
 
-		public Map<Class<?>, Exception> getExceptions() {
+		public List<Exception> getExceptions() {
 			return _exceptions;
 		}
 
-		private final Map<Class<?>, Exception> _exceptions;
+		private final List<Exception> _exceptions;
 
 	}
 

--- a/modules/apps/portal-language/portal-language-override-api/src/main/java/com/liferay/portal/language/override/service/PLOEntryLocalService.java
+++ b/modules/apps/portal-language/portal-language-override-api/src/main/java/com/liferay/portal/language/override/service/PLOEntryLocalService.java
@@ -23,6 +23,8 @@ import com.liferay.portal.kernel.transaction.Transactional;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.language.override.model.PLOEntry;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.io.Serializable;
 
 import java.util.List;
@@ -266,6 +268,11 @@ public interface PLOEntryLocalService
 	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public PLOEntry getPLOEntry(long ploEntryId) throws PortalException;
+
+	public void importPLOEntries(
+			long companyId, InputStream inputStream, String languageId,
+			long userId)
+		throws IOException, PortalException;
 
 	public void setPLOEntries(
 			long companyId, long userId, String key,

--- a/modules/apps/portal-language/portal-language-override-api/src/main/java/com/liferay/portal/language/override/service/PLOEntryLocalServiceUtil.java
+++ b/modules/apps/portal-language/portal-language-override-api/src/main/java/com/liferay/portal/language/override/service/PLOEntryLocalServiceUtil.java
@@ -13,6 +13,7 @@ import com.liferay.portal.kernel.module.service.Snapshot;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.language.override.model.PLOEntry;
 
+import java.io.InputStream;
 import java.io.Serializable;
 
 import java.util.List;
@@ -304,6 +305,15 @@ public class PLOEntryLocalServiceUtil {
 	 */
 	public static PLOEntry getPLOEntry(long ploEntryId) throws PortalException {
 		return getService().getPLOEntry(ploEntryId);
+	}
+
+	public static void importPLOEntries(
+			long companyId, InputStream inputStream, String languageId,
+			long userId)
+		throws java.io.IOException, PortalException {
+
+		getService().importPLOEntries(
+			companyId, inputStream, languageId, userId);
 	}
 
 	public static void setPLOEntries(

--- a/modules/apps/portal-language/portal-language-override-api/src/main/java/com/liferay/portal/language/override/service/PLOEntryLocalServiceWrapper.java
+++ b/modules/apps/portal-language/portal-language-override-api/src/main/java/com/liferay/portal/language/override/service/PLOEntryLocalServiceWrapper.java
@@ -353,6 +353,17 @@ public class PLOEntryLocalServiceWrapper
 	}
 
 	@Override
+	public void importPLOEntries(
+			long companyId, java.io.InputStream inputStream, String languageId,
+			long userId)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			   java.io.IOException {
+
+		_ploEntryLocalService.importPLOEntries(
+			companyId, inputStream, languageId, userId);
+	}
+
+	@Override
 	public void setPLOEntries(
 			long companyId, long userId, String key,
 			java.util.Map<java.util.Locale, String> localizationMap)

--- a/modules/apps/portal-language/portal-language-override-api/src/main/java/com/liferay/portal/language/override/service/PLOEntryService.java
+++ b/modules/apps/portal-language/portal-language-override-api/src/main/java/com/liferay/portal/language/override/service/PLOEntryService.java
@@ -15,6 +15,9 @@ import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.Transactional;
 import com.liferay.portal.language.override.model.PLOEntry;
 
+import java.io.IOException;
+import java.io.InputStream;
+
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -65,6 +68,9 @@ public interface PLOEntryService extends BaseService {
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int getPLOEntriesCount(long companyId) throws PortalException;
+
+	public void importPLOEntries(InputStream inputStream, String languageId)
+		throws IOException, PortalException;
 
 	public void setPLOEntries(String key, Map<Locale, String> localizationMap)
 		throws PortalException;

--- a/modules/apps/portal-language/portal-language-override-api/src/main/java/com/liferay/portal/language/override/service/PLOEntryServiceUtil.java
+++ b/modules/apps/portal-language/portal-language-override-api/src/main/java/com/liferay/portal/language/override/service/PLOEntryServiceUtil.java
@@ -9,6 +9,8 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.module.service.Snapshot;
 import com.liferay.portal.language.override.model.PLOEntry;
 
+import java.io.InputStream;
+
 import java.util.List;
 import java.util.Map;
 
@@ -67,6 +69,13 @@ public class PLOEntryServiceUtil {
 		throws PortalException {
 
 		return getService().getPLOEntriesCount(companyId);
+	}
+
+	public static void importPLOEntries(
+			InputStream inputStream, String languageId)
+		throws java.io.IOException, PortalException {
+
+		getService().importPLOEntries(inputStream, languageId);
 	}
 
 	public static void setPLOEntries(

--- a/modules/apps/portal-language/portal-language-override-api/src/main/java/com/liferay/portal/language/override/service/PLOEntryServiceWrapper.java
+++ b/modules/apps/portal-language/portal-language-override-api/src/main/java/com/liferay/portal/language/override/service/PLOEntryServiceWrapper.java
@@ -74,6 +74,15 @@ public class PLOEntryServiceWrapper
 	}
 
 	@Override
+	public void importPLOEntries(
+			java.io.InputStream inputStream, String languageId)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			   java.io.IOException {
+
+		_ploEntryService.importPLOEntries(inputStream, languageId);
+	}
+
+	@Override
 	public void setPLOEntries(
 			String key, java.util.Map<java.util.Locale, String> localizationMap)
 		throws com.liferay.portal.kernel.exception.PortalException {

--- a/modules/apps/portal-language/portal-language-override-api/src/main/resources/com/liferay/portal/language/override/exception/packageinfo
+++ b/modules/apps/portal-language/portal-language-override-api/src/main/resources/com/liferay/portal/language/override/exception/packageinfo
@@ -1,1 +1,1 @@
-version 1.2.0
+version 1.3.0

--- a/modules/apps/portal-language/portal-language-override-api/src/main/resources/com/liferay/portal/language/override/service/packageinfo
+++ b/modules/apps/portal-language/portal-language-override-api/src/main/resources/com/liferay/portal/language/override/service/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 2.1.0

--- a/modules/apps/portal-language/portal-language-override-service/service.xml
+++ b/modules/apps/portal-language/portal-language-override-service/service.xml
@@ -49,6 +49,7 @@
 		</finder>
 	</entity>
 	<exceptions>
+		<exception>ImportTranslations</exception>
 		<exception>PLOEntryKey</exception>
 		<exception>PLOEntryLanguageId</exception>
 		<exception>PLOEntryValue</exception>

--- a/modules/apps/portal-language/portal-language-override-service/src/main/java/com/liferay/portal/language/override/internal/PLOEntryModelListener.java
+++ b/modules/apps/portal-language/portal-language-override-service/src/main/java/com/liferay/portal/language/override/internal/PLOEntryModelListener.java
@@ -12,6 +12,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.ModelListener;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
+import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
 import com.liferay.portal.kernel.util.MethodHandler;
 import com.liferay.portal.kernel.util.MethodKey;
 import com.liferay.portal.language.override.model.PLOEntry;
@@ -30,23 +31,38 @@ public class PLOEntryModelListener extends BaseModelListener<PLOEntry> {
 
 	@Override
 	public void onAfterCreate(PLOEntry ploEntry) {
-		_updatePLOLanguageOverrideProvider(MethodType.ADD, ploEntry);
+		TransactionCommitCallbackUtil.registerCallback(
+			() -> {
+				_updatePLOLanguageOverrideProvider(MethodType.ADD, ploEntry);
 
-		_notifyCluster(MethodType.ADD, ploEntry);
+				_notifyCluster(MethodType.ADD, ploEntry);
+
+				return null;
+			});
 	}
 
 	@Override
 	public void onAfterRemove(PLOEntry ploEntry) {
-		_updatePLOLanguageOverrideProvider(MethodType.REMOVE, ploEntry);
+		TransactionCommitCallbackUtil.registerCallback(
+			() -> {
+				_updatePLOLanguageOverrideProvider(MethodType.REMOVE, ploEntry);
 
-		_notifyCluster(MethodType.REMOVE, ploEntry);
+				_notifyCluster(MethodType.REMOVE, ploEntry);
+
+				return null;
+			});
 	}
 
 	@Override
 	public void onAfterUpdate(PLOEntry originalPLOEntry, PLOEntry ploEntry) {
-		_updatePLOLanguageOverrideProvider(MethodType.UPDATE, ploEntry);
+		TransactionCommitCallbackUtil.registerCallback(
+			() -> {
+				_updatePLOLanguageOverrideProvider(MethodType.UPDATE, ploEntry);
 
-		_notifyCluster(MethodType.UPDATE, ploEntry);
+				_notifyCluster(MethodType.UPDATE, ploEntry);
+
+				return null;
+			});
 	}
 
 	private static void _onNotify(MethodType methodType, PLOEntry ploEntry)

--- a/modules/apps/portal-language/portal-language-override-service/src/main/java/com/liferay/portal/language/override/service/http/PLOEntryServiceHttp.java
+++ b/modules/apps/portal-language/portal-language-override-service/src/main/java/com/liferay/portal/language/override/service/http/PLOEntryServiceHttp.java
@@ -242,6 +242,48 @@ public class PLOEntryServiceHttp {
 		}
 	}
 
+	public static void importPLOEntries(
+			HttpPrincipal httpPrincipal, java.io.InputStream inputStream,
+			String languageId)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			   java.io.IOException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				PLOEntryServiceUtil.class, "importPLOEntries",
+				_importPLOEntriesParameterTypes5);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, inputStream, languageId);
+
+			try {
+				TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof java.io.IOException) {
+					throw (java.io.IOException)exception;
+				}
+
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
 	public static void setPLOEntries(
 			HttpPrincipal httpPrincipal, String key,
 			java.util.Map<java.util.Locale, String> localizationMap)
@@ -250,7 +292,7 @@ public class PLOEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				PLOEntryServiceUtil.class, "setPLOEntries",
-				_setPLOEntriesParameterTypes5);
+				_setPLOEntriesParameterTypes6);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, key, localizationMap);
@@ -291,7 +333,9 @@ public class PLOEntryServiceHttp {
 		new Class[] {long.class};
 	private static final Class<?>[] _getPLOEntriesCountParameterTypes4 =
 		new Class[] {long.class};
-	private static final Class<?>[] _setPLOEntriesParameterTypes5 =
+	private static final Class<?>[] _importPLOEntriesParameterTypes5 =
+		new Class[] {java.io.InputStream.class, String.class};
+	private static final Class<?>[] _setPLOEntriesParameterTypes6 =
 		new Class[] {String.class, java.util.Map.class};
 
 }

--- a/modules/apps/portal-language/portal-language-override-service/src/main/java/com/liferay/portal/language/override/service/impl/PLOEntryLocalServiceImpl.java
+++ b/modules/apps/portal-language/portal-language-override-service/src/main/java/com/liferay/portal/language/override/service/impl/PLOEntryLocalServiceImpl.java
@@ -30,7 +30,7 @@ import java.io.InputStreamReader;
 
 import java.nio.charset.StandardCharsets;
 
-import java.util.HashMap;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -142,7 +142,7 @@ public class PLOEntryLocalServiceImpl extends PLOEntryLocalServiceBaseImpl {
 			throw new ImportTranslationsException.InvalidPropertiesFile();
 		}
 
-		Map<Class<?>, Exception> exceptions = new HashMap<>();
+		List<Exception> exceptions = new ArrayList<>();
 
 		for (Map.Entry<Object, Object> entry : properties.entrySet()) {
 			try {
@@ -151,7 +151,7 @@ public class PLOEntryLocalServiceImpl extends PLOEntryLocalServiceBaseImpl {
 					(String)entry.getValue());
 			}
 			catch (Exception exception) {
-				exceptions.putIfAbsent(exception.getClass(), exception);
+				exceptions.add(exception);
 			}
 		}
 

--- a/modules/apps/portal-language/portal-language-override-service/src/main/java/com/liferay/portal/language/override/service/impl/PLOEntryLocalServiceImpl.java
+++ b/modules/apps/portal-language/portal-language-override-service/src/main/java/com/liferay/portal/language/override/service/impl/PLOEntryLocalServiceImpl.java
@@ -16,6 +16,7 @@ import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.language.override.exception.ImportTranslationsException;
 import com.liferay.portal.language.override.exception.PLOEntryKeyException;
 import com.liferay.portal.language.override.exception.PLOEntryLanguageIdException;
 import com.liferay.portal.language.override.exception.PLOEntryValueException;
@@ -23,10 +24,18 @@ import com.liferay.portal.language.override.model.PLOEntry;
 import com.liferay.portal.language.override.service.base.PLOEntryLocalServiceBaseImpl;
 import com.liferay.portal.util.PropsValues;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+import java.nio.charset.StandardCharsets;
+
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Properties;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -116,6 +125,40 @@ public class PLOEntryLocalServiceImpl extends PLOEntryLocalServiceBaseImpl {
 	@Override
 	public int getPLOEntriesCount(long companyId) {
 		return ploEntryPersistence.countByCompanyId(companyId);
+	}
+
+	@Override
+	public void importPLOEntries(
+			long companyId, InputStream inputStream, String languageId,
+			long userId)
+		throws IOException, PortalException {
+
+		Properties properties = new Properties();
+
+		properties.load(
+			new InputStreamReader(inputStream, StandardCharsets.UTF_8));
+
+		if (properties.isEmpty()) {
+			throw new ImportTranslationsException.InvalidPropertiesFile();
+		}
+
+		Map<Class<?>, Exception> exceptions = new HashMap<>();
+
+		for (Map.Entry<Object, Object> entry : properties.entrySet()) {
+			try {
+				addOrUpdatePLOEntry(
+					companyId, userId, (String)entry.getKey(), languageId,
+					(String)entry.getValue());
+			}
+			catch (Exception exception) {
+				exceptions.putIfAbsent(exception.getClass(), exception);
+			}
+		}
+
+		if (!exceptions.isEmpty()) {
+			throw new ImportTranslationsException.InvalidTranslations(
+				exceptions);
+		}
 	}
 
 	@Override

--- a/modules/apps/portal-language/portal-language-override-service/src/main/java/com/liferay/portal/language/override/service/impl/PLOEntryServiceImpl.java
+++ b/modules/apps/portal-language/portal-language-override-service/src/main/java/com/liferay/portal/language/override/service/impl/PLOEntryServiceImpl.java
@@ -13,6 +13,9 @@ import com.liferay.portal.language.override.constants.PLOActionKeys;
 import com.liferay.portal.language.override.model.PLOEntry;
 import com.liferay.portal.language.override.service.base.PLOEntryServiceBaseImpl;
 
+import java.io.IOException;
+import java.io.InputStream;
+
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -84,6 +87,20 @@ public class PLOEntryServiceImpl extends PLOEntryServiceBaseImpl {
 			getPermissionChecker(), PLOActionKeys.MANAGE_LANGUAGE_OVERRIDES);
 
 		return ploEntryLocalService.getPLOEntriesCount(companyId);
+	}
+
+	@Override
+	public void importPLOEntries(InputStream inputStream, String languageId)
+		throws IOException, PortalException {
+
+		PermissionChecker permissionChecker = getPermissionChecker();
+
+		PortalPermissionUtil.check(
+			permissionChecker, PLOActionKeys.MANAGE_LANGUAGE_OVERRIDES);
+
+		ploEntryLocalService.importPLOEntries(
+			permissionChecker.getCompanyId(), inputStream, languageId,
+			permissionChecker.getUserId());
 	}
 
 	@Override

--- a/modules/apps/portal-language/portal-language-override-test/src/testIntegration/java/com/liferay/portal/language/override/service/test/PLOEntryLocalServiceTest.java
+++ b/modules/apps/portal-language/portal-language-override-test/src/testIntegration/java/com/liferay/portal/language/override/service/test/PLOEntryLocalServiceTest.java
@@ -35,8 +35,9 @@ import java.io.IOException;
 
 import java.nio.charset.StandardCharsets;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -225,16 +226,21 @@ public class PLOEntryLocalServiceTest {
 		catch (ImportTranslationsException.InvalidTranslations
 					importTranslationsException) {
 
-			Map<Class<?>, Exception> exceptions =
+			List<Exception> exceptions =
 				importTranslationsException.getExceptions();
 
 			Assert.assertEquals(exceptions.toString(), 2, exceptions.size());
 
-			Assert.assertNotNull(
-				exceptions.get(PLOEntryValueException.MustNotBeNull.class));
+			List<Class<?>> expectedClasses = Arrays.asList(
+				new Class<?>[] {
+					PLOEntryValueException.MustNotBeNull.class,
+					PLOEntryKeyException.MustNotBeNull.class
+				});
 
-			Assert.assertNotNull(
-				exceptions.get(PLOEntryKeyException.MustNotBeNull.class));
+			for (Exception exception : exceptions) {
+				Assert.assertTrue(
+					expectedClasses.contains(exception.getClass()));
+			}
 		}
 
 		Assert.assertEquals(key1, _language.get(LocaleUtil.US, key1));

--- a/modules/apps/portal-language/portal-language-override-test/src/testIntegration/java/com/liferay/portal/language/override/service/test/PLOEntryLocalServiceTest.java
+++ b/modules/apps/portal-language/portal-language-override-test/src/testIntegration/java/com/liferay/portal/language/override/service/test/PLOEntryLocalServiceTest.java
@@ -7,15 +7,21 @@ package com.liferay.portal.language.override.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.function.UnsafeRunnable;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.ModelHintsUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.transaction.Propagation;
+import com.liferay.portal.kernel.transaction.TransactionConfig;
+import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.language.LanguageResources;
+import com.liferay.portal.language.override.exception.ImportTranslationsException;
 import com.liferay.portal.language.override.exception.PLOEntryKeyException;
 import com.liferay.portal.language.override.exception.PLOEntryLanguageIdException;
 import com.liferay.portal.language.override.exception.PLOEntryValueException;
@@ -23,6 +29,14 @@ import com.liferay.portal.language.override.model.PLOEntry;
 import com.liferay.portal.language.override.service.PLOEntryLocalService;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import java.nio.charset.StandardCharsets;
+
+import java.util.Locale;
+import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -89,6 +103,145 @@ public class PLOEntryLocalServiceTest {
 				RandomTestUtil.randomString(), languageId, StringPool.BLANK));
 	}
 
+	@Test
+	public void testAddOrUpdatePLOEntryRollback() throws Throwable {
+		String key = RandomTestUtil.randomString();
+
+		Locale locale = LocaleUtil.getDefault();
+
+		try {
+			TransactionInvokerUtil.invoke(
+				TransactionConfig.Factory.create(
+					Propagation.REQUIRED, new Class<?>[] {Exception.class}),
+				() -> {
+					_addOrUpdatePLOEntry(
+						key, LanguageUtil.getLanguageId(locale),
+						RandomTestUtil.randomString());
+
+					throw new Exception("Unable to add PLOEntry");
+				});
+
+			Assert.fail();
+		}
+		catch (Exception exception) {
+			Assert.assertEquals(
+				"Unable to add PLOEntry", exception.getMessage());
+
+			Assert.assertEquals(key, _language.get(locale, key));
+		}
+	}
+
+	@Test
+	public void testDeletePLOEntry() throws PortalException {
+		String key = RandomTestUtil.randomString();
+		Locale locale = LocaleUtil.getDefault();
+		String value = RandomTestUtil.randomString();
+
+		PLOEntry ploEntry = _addOrUpdatePLOEntry(
+			key, LanguageUtil.getLanguageId(locale), value);
+
+		Assert.assertEquals(value, _language.get(locale, key));
+
+		_ploEntryLocalService.deletePLOEntry(ploEntry.getPloEntryId());
+
+		Assert.assertEquals(key, _language.get(locale, key));
+	}
+
+	@Test
+	public void testDeletePLOEntryRollback() throws Throwable {
+		String key = RandomTestUtil.randomString();
+		Locale locale = LocaleUtil.getDefault();
+		String value = RandomTestUtil.randomString();
+
+		PLOEntry ploEntry = _addOrUpdatePLOEntry(
+			key, LanguageUtil.getLanguageId(locale), value);
+
+		try {
+			TransactionInvokerUtil.invoke(
+				TransactionConfig.Factory.create(
+					Propagation.REQUIRED, new Class<?>[] {Exception.class}),
+				() -> {
+					_ploEntryLocalService.deletePLOEntry(
+						ploEntry.getPloEntryId());
+
+					throw new Exception("Unable to delete PLOEntry");
+				});
+
+			Assert.fail();
+		}
+		catch (Exception exception) {
+			Assert.assertEquals(
+				"Unable to delete PLOEntry", exception.getMessage());
+
+			Assert.assertEquals(value, _language.get(locale, key));
+		}
+	}
+
+	@Test
+	public void testImportPLOEntries() throws IOException, PortalException {
+		String key1 = RandomTestUtil.randomString();
+		String key2 = RandomTestUtil.randomString();
+		String value1 = RandomTestUtil.randomString();
+		String value2 = RandomTestUtil.randomString();
+
+		String propertiesString = StringBundler.concat(
+			key1, StringPool.EQUAL, value1, StringPool.NEW_LINE, key2,
+			StringPool.EQUAL, value2);
+
+		_ploEntryLocalService.importPLOEntries(
+			TestPropsValues.getCompanyId(),
+			new ByteArrayInputStream(
+				propertiesString.getBytes(StandardCharsets.UTF_8)),
+			LanguageUtil.getLanguageId(LocaleUtil.US),
+			TestPropsValues.getUserId());
+
+		Assert.assertEquals(value1, _language.get(LocaleUtil.US, key1));
+
+		Assert.assertEquals(value2, _language.get(LocaleUtil.US, key2));
+	}
+
+	@Test
+	public void testImportPLOEntriesRollback()
+		throws IOException, PortalException {
+
+		String key1 = "good-key";
+		String key2 = "key-with-empty-value";
+
+		String propertiesString = StringBundler.concat(
+			key1, StringPool.EQUAL, RandomTestUtil.randomString(),
+			StringPool.NEW_LINE, key2, StringPool.EQUAL, StringPool.NEW_LINE,
+			StringPool.EQUAL, RandomTestUtil.randomString());
+
+		try {
+			_ploEntryLocalService.importPLOEntries(
+				TestPropsValues.getCompanyId(),
+				new ByteArrayInputStream(
+					propertiesString.getBytes(StandardCharsets.UTF_8)),
+				LanguageUtil.getLanguageId(LocaleUtil.US),
+				TestPropsValues.getUserId());
+
+			Assert.fail();
+		}
+		catch (ImportTranslationsException.InvalidTranslations
+					importTranslationsException) {
+
+			Map<Class<?>, Exception> exceptions =
+				importTranslationsException.getExceptions();
+
+			Assert.assertEquals(exceptions.toString(), 2, exceptions.size());
+
+			Assert.assertNotNull(
+				exceptions.get(PLOEntryValueException.MustNotBeNull.class));
+
+			Assert.assertNotNull(
+				exceptions.get(PLOEntryKeyException.MustNotBeNull.class));
+		}
+
+		Assert.assertEquals(key1, _language.get(LocaleUtil.US, key1));
+
+		Assert.assertEquals(key2, _language.get(LocaleUtil.US, key2));
+	}
+
 	private PLOEntry _addOrUpdatePLOEntry(
 			String key, String languageId, String value)
 		throws PortalException {
@@ -123,6 +276,9 @@ public class PLOEntryLocalServiceTest {
 				LanguageResources.getResourceBundle(LocaleUtil.getDefault()),
 				key));
 	}
+
+	@Inject
+	private Language _language;
 
 	@Inject
 	private PLOEntryLocalService _ploEntryLocalService;

--- a/modules/apps/portal-language/portal-language-override-web/src/main/java/com/liferay/portal/language/override/web/internal/portlet/action/ImportTranslationsMVCActionCommand.java
+++ b/modules/apps/portal-language/portal-language-override-web/src/main/java/com/liferay/portal/language/override/web/internal/portlet/action/ImportTranslationsMVCActionCommand.java
@@ -20,7 +20,6 @@ import java.io.File;
 
 import java.nio.file.Files;
 
-import java.util.Map;
 import java.util.Objects;
 
 import javax.portlet.ActionRequest;
@@ -92,12 +91,11 @@ public class ImportTranslationsMVCActionCommand extends BaseMVCActionCommand {
 		catch (ImportTranslationsException.InvalidTranslations
 					importTranslationsException) {
 
-			Map<Class<?>, Exception> exceptions =
-				importTranslationsException.getExceptions();
+			for (Exception exception :
+					importTranslationsException.getExceptions()) {
 
-			for (Map.Entry<Class<?>, Exception> entry : exceptions.entrySet()) {
 				SessionErrors.add(
-					actionRequest, entry.getKey(), entry.getValue());
+					actionRequest, exception.getClass(), exception);
 			}
 		}
 		catch (Exception exception) {

--- a/modules/apps/portal-language/portal-language-override-web/src/main/java/com/liferay/portal/language/override/web/internal/portlet/action/ImportTranslationsMVCActionCommand.java
+++ b/modules/apps/portal-language/portal-language-override-web/src/main/java/com/liferay/portal/language/override/web/internal/portlet/action/ImportTranslationsMVCActionCommand.java
@@ -5,7 +5,6 @@
 
 package com.liferay.portal.language.override.web.internal.portlet.action;
 
-import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.servlet.SessionErrors;
@@ -13,18 +12,16 @@ import com.liferay.portal.kernel.upload.UploadPortletRequest;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.language.override.exception.ImportTranslationsException;
 import com.liferay.portal.language.override.service.PLOEntryService;
 import com.liferay.portal.language.override.web.internal.constants.PLOPortletKeys;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.InputStreamReader;
 
-import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 
-import java.util.Enumeration;
+import java.util.Map;
 import java.util.Objects;
-import java.util.Properties;
 
 import javax.portlet.ActionRequest;
 import javax.portlet.ActionResponse;
@@ -66,8 +63,7 @@ public class ImportTranslationsMVCActionCommand extends BaseMVCActionCommand {
 	}
 
 	private void _importTranslations(
-			ActionRequest actionRequest, File file, String languageId)
-		throws Exception {
+		ActionRequest actionRequest, File file, String languageId) {
 
 		if ((file == null) || !file.exists()) {
 			SessionErrors.add(actionRequest, "fileEmpty");
@@ -83,32 +79,29 @@ public class ImportTranslationsMVCActionCommand extends BaseMVCActionCommand {
 			return;
 		}
 
-		Properties languageProperties = new Properties();
-
-		languageProperties.load(
-			new InputStreamReader(
-				new FileInputStream(file), StandardCharsets.UTF_8));
-
-		if (languageProperties.size() == 0) {
-			SessionErrors.add(actionRequest, "fileInvalid");
-
-			return;
+		try {
+			_ploEntryService.importPLOEntries(
+				Files.newInputStream(file.toPath()), languageId);
 		}
+		catch (ImportTranslationsException.InvalidPropertiesFile
+					importTranslationsException) {
 
-		Enumeration<String> enumeration =
-			(Enumeration<String>)languageProperties.propertyNames();
+			SessionErrors.add(
+				actionRequest, "fileInvalid", importTranslationsException);
+		}
+		catch (ImportTranslationsException.InvalidTranslations
+					importTranslationsException) {
 
-		while (enumeration.hasMoreElements()) {
-			String key = enumeration.nextElement();
+			Map<Class<?>, Exception> exceptions =
+				importTranslationsException.getExceptions();
 
-			try {
-				_ploEntryService.addOrUpdatePLOEntry(
-					key, languageId, languageProperties.getProperty(key));
-			}
-			catch (PortalException portalException) {
+			for (Map.Entry<Class<?>, Exception> entry : exceptions.entrySet()) {
 				SessionErrors.add(
-					actionRequest, portalException.getClass(), portalException);
+					actionRequest, entry.getKey(), entry.getValue());
 			}
+		}
+		catch (Exception exception) {
+			SessionErrors.add(actionRequest, exception.getClass(), exception);
 		}
 	}
 

--- a/modules/apps/portal-language/portal-language-rest-impl/src/main/java/com/liferay/portal/language/rest/internal/jaxrs/exception/mapper/ImportTranslationsExceptionInvalidPropertiesFileExceptionMapper.java
+++ b/modules/apps/portal-language/portal-language-rest-impl/src/main/java/com/liferay/portal/language/rest/internal/jaxrs/exception/mapper/ImportTranslationsExceptionInvalidPropertiesFileExceptionMapper.java
@@ -1,0 +1,43 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.language.rest.internal.jaxrs.exception.mapper;
+
+import com.liferay.portal.language.override.exception.ImportTranslationsException;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.BaseExceptionMapper;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.Problem;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Thiago Buarque
+ */
+@Component(
+	property = {
+		"osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Portal.Language.REST)",
+		"osgi.jaxrs.extension=true",
+		"osgi.jaxrs.name=Liferay.Portal.Language.REST.ImportTranslationsExceptionInvalidPropertiesFileExceptionMapper"
+	},
+	service = ExceptionMapper.class
+)
+public class ImportTranslationsExceptionInvalidPropertiesFileExceptionMapper
+	extends BaseExceptionMapper
+		<ImportTranslationsException.InvalidPropertiesFile> {
+
+	@Override
+	protected Problem getProblem(
+		ImportTranslationsException.InvalidPropertiesFile
+			invalidPropertiesFile) {
+
+		return new Problem(
+			invalidPropertiesFile.getMessage(), Response.Status.BAD_REQUEST,
+			null,
+			ImportTranslationsException.InvalidPropertiesFile.class.getName());
+	}
+
+}

--- a/modules/apps/portal-language/portal-language-rest-impl/src/main/java/com/liferay/portal/language/rest/internal/jaxrs/exception/mapper/ImportTranslationsExceptionInvalidTranslationsExceptionMapper.java
+++ b/modules/apps/portal-language/portal-language-rest-impl/src/main/java/com/liferay/portal/language/rest/internal/jaxrs/exception/mapper/ImportTranslationsExceptionInvalidTranslationsExceptionMapper.java
@@ -1,0 +1,62 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.language.rest.internal.jaxrs.exception.mapper;
+
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.language.override.exception.ImportTranslationsException;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.BaseExceptionMapper;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.Problem;
+
+import java.util.Map;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Thiago Buarque
+ */
+@Component(
+	property = {
+		"osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Portal.Language.REST)",
+		"osgi.jaxrs.extension=true",
+		"osgi.jaxrs.name=Liferay.Portal.Language.REST.ImportTranslationsExceptionInvalidTranslationsExceptionMapper"
+	},
+	service = ExceptionMapper.class
+)
+public class ImportTranslationsExceptionInvalidTranslationsExceptionMapper
+	extends BaseExceptionMapper
+		<ImportTranslationsException.InvalidTranslations> {
+
+	@Override
+	protected Problem getProblem(
+		ImportTranslationsException.InvalidTranslations invalidTranslations) {
+
+		return new Problem(
+			String.valueOf(_toJSONArray(invalidTranslations.getExceptions())),
+			Response.Status.BAD_REQUEST, invalidTranslations.getMessage(),
+			ImportTranslationsException.InvalidTranslations.class.getName());
+	}
+
+	private JSONArray _toJSONArray(Map<Class<?>, Exception> exceptions) {
+		JSONArray jsonArray = _jsonFactory.createJSONArray();
+
+		for (Map.Entry<Class<?>, Exception> entry : exceptions.entrySet()) {
+			Exception exception = entry.getValue();
+
+			jsonArray.put(exception.getMessage());
+		}
+
+		return jsonArray;
+	}
+
+	@Reference
+	private JSONFactory _jsonFactory;
+
+}

--- a/modules/apps/portal-language/portal-language-rest-impl/src/main/java/com/liferay/portal/language/rest/internal/jaxrs/exception/mapper/ImportTranslationsExceptionInvalidTranslationsExceptionMapper.java
+++ b/modules/apps/portal-language/portal-language-rest-impl/src/main/java/com/liferay/portal/language/rest/internal/jaxrs/exception/mapper/ImportTranslationsExceptionInvalidTranslationsExceptionMapper.java
@@ -11,8 +11,6 @@ import com.liferay.portal.language.override.exception.ImportTranslationsExceptio
 import com.liferay.portal.vulcan.jaxrs.exception.mapper.BaseExceptionMapper;
 import com.liferay.portal.vulcan.jaxrs.exception.mapper.Problem;
 
-import java.util.Map;
-
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 
@@ -38,22 +36,16 @@ public class ImportTranslationsExceptionInvalidTranslationsExceptionMapper
 	protected Problem getProblem(
 		ImportTranslationsException.InvalidTranslations invalidTranslations) {
 
-		return new Problem(
-			String.valueOf(_toJSONArray(invalidTranslations.getExceptions())),
-			Response.Status.BAD_REQUEST, invalidTranslations.getMessage(),
-			ImportTranslationsException.InvalidTranslations.class.getName());
-	}
-
-	private JSONArray _toJSONArray(Map<Class<?>, Exception> exceptions) {
 		JSONArray jsonArray = _jsonFactory.createJSONArray();
 
-		for (Map.Entry<Class<?>, Exception> entry : exceptions.entrySet()) {
-			Exception exception = entry.getValue();
-
+		for (Exception exception : invalidTranslations.getExceptions()) {
 			jsonArray.put(exception.getMessage());
 		}
 
-		return jsonArray;
+		return new Problem(
+			String.valueOf(jsonArray), Response.Status.BAD_REQUEST,
+			invalidTranslations.getMessage(),
+			ImportTranslationsException.InvalidTranslations.class.getName());
 	}
 
 	@Reference

--- a/modules/apps/portal-language/portal-language-rest-impl/src/main/java/com/liferay/portal/language/rest/internal/jaxrs/exception/mapper/PLOEntryKeyExceptionMapper.java
+++ b/modules/apps/portal-language/portal-language-rest-impl/src/main/java/com/liferay/portal/language/rest/internal/jaxrs/exception/mapper/PLOEntryKeyExceptionMapper.java
@@ -1,0 +1,38 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.language.rest.internal.jaxrs.exception.mapper;
+
+import com.liferay.portal.language.override.exception.PLOEntryKeyException;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.BaseExceptionMapper;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.Problem;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Thiago Buarque
+ */
+@Component(
+	property = {
+		"osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Portal.Language.REST)",
+		"osgi.jaxrs.extension=true",
+		"osgi.jaxrs.name=Liferay.Portal.Language.REST.PLOEntryKeyExceptionMapper"
+	},
+	service = ExceptionMapper.class
+)
+public class PLOEntryKeyExceptionMapper
+	extends BaseExceptionMapper<PLOEntryKeyException> {
+
+	@Override
+	protected Problem getProblem(PLOEntryKeyException ploEntryKeyException) {
+		return new Problem(
+			ploEntryKeyException.getMessage(), Response.Status.BAD_REQUEST,
+			null, PLOEntryKeyException.class.getName());
+	}
+
+}

--- a/modules/apps/portal-language/portal-language-rest-impl/src/main/java/com/liferay/portal/language/rest/internal/jaxrs/exception/mapper/PLOEntryLanguageIdExceptionMapper.java
+++ b/modules/apps/portal-language/portal-language-rest-impl/src/main/java/com/liferay/portal/language/rest/internal/jaxrs/exception/mapper/PLOEntryLanguageIdExceptionMapper.java
@@ -1,0 +1,41 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.language.rest.internal.jaxrs.exception.mapper;
+
+import com.liferay.portal.language.override.exception.PLOEntryLanguageIdException;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.BaseExceptionMapper;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.Problem;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Thiago Buarque
+ */
+@Component(
+	property = {
+		"osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Portal.Language.REST)",
+		"osgi.jaxrs.extension=true",
+		"osgi.jaxrs.name=Liferay.Portal.Language.REST.PLOEntryLanguageIdExceptionMapper"
+	},
+	service = ExceptionMapper.class
+)
+public class PLOEntryLanguageIdExceptionMapper
+	extends BaseExceptionMapper<PLOEntryLanguageIdException> {
+
+	@Override
+	protected Problem getProblem(
+		PLOEntryLanguageIdException ploEntryLanguageIdException) {
+
+		return new Problem(
+			ploEntryLanguageIdException.getMessage(),
+			Response.Status.BAD_REQUEST, null,
+			PLOEntryLanguageIdException.class.getName());
+	}
+
+}

--- a/modules/apps/portal-language/portal-language-rest-impl/src/main/java/com/liferay/portal/language/rest/internal/jaxrs/exception/mapper/PLOEntryValueExceptionMapper.java
+++ b/modules/apps/portal-language/portal-language-rest-impl/src/main/java/com/liferay/portal/language/rest/internal/jaxrs/exception/mapper/PLOEntryValueExceptionMapper.java
@@ -1,0 +1,40 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.language.rest.internal.jaxrs.exception.mapper;
+
+import com.liferay.portal.language.override.exception.PLOEntryValueException;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.BaseExceptionMapper;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.Problem;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Thiago Buarque
+ */
+@Component(
+	property = {
+		"osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Portal.Language.REST)",
+		"osgi.jaxrs.extension=true",
+		"osgi.jaxrs.name=Liferay.Portal.Language.REST.PLOEntryValueExceptionMapper"
+	},
+	service = ExceptionMapper.class
+)
+public class PLOEntryValueExceptionMapper
+	extends BaseExceptionMapper<PLOEntryValueException> {
+
+	@Override
+	protected Problem getProblem(
+		PLOEntryValueException ploEntryValueException) {
+
+		return new Problem(
+			ploEntryValueException.getMessage(), Response.Status.BAD_REQUEST,
+			null, PLOEntryValueException.class.getName());
+	}
+
+}

--- a/modules/apps/portal-language/portal-language-rest-impl/src/main/java/com/liferay/portal/language/rest/internal/resource/v1_0/MessageResourceImpl.java
+++ b/modules/apps/portal-language/portal-language-rest-impl/src/main/java/com/liferay/portal/language/rest/internal/resource/v1_0/MessageResourceImpl.java
@@ -17,7 +17,8 @@ import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.language.LanguageResources;
 import com.liferay.portal.language.override.model.PLOEntry;
-import com.liferay.portal.language.override.service.PLOEntryLocalService;
+import com.liferay.portal.language.override.model.PLOEntryModel;
+import com.liferay.portal.language.override.service.PLOEntryService;
 import com.liferay.portal.language.rest.dto.v1_0.Message;
 import com.liferay.portal.language.rest.resource.v1_0.MessageResource;
 import com.liferay.portal.vulcan.multipart.BinaryFile;
@@ -25,18 +26,13 @@ import com.liferay.portal.vulcan.multipart.MultipartBody;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
-import java.io.InputStreamReader;
 import java.io.Serializable;
-
-import java.nio.charset.StandardCharsets;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Enumeration;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Properties;
 import java.util.ResourceBundle;
 
 import javax.ws.rs.BadRequestException;
@@ -61,17 +57,15 @@ public class MessageResourceImpl extends BaseMessageResourceImpl {
 		}
 
 		if (Validator.isNull(languageId)) {
-			_ploEntryLocalService.deletePLOEntries(
-				contextCompany.getCompanyId(), key);
+			_ploEntryService.deletePLOEntries(key);
 		}
 		else {
-			_ploEntryLocalService.deletePLOEntry(
-				contextCompany.getCompanyId(), key, languageId);
+			_ploEntryService.deletePLOEntry(key, languageId);
 		}
 	}
 
 	@Override
-	public Message getMessage(String key, String languageId) throws Exception {
+	public Message getMessage(String key, String languageId) {
 		if (!FeatureFlagManagerUtil.isEnabled("LPD-27222")) {
 			throw new UnsupportedOperationException();
 		}
@@ -80,18 +74,8 @@ public class MessageResourceImpl extends BaseMessageResourceImpl {
 
 		message.setKey(() -> key);
 		message.setLanguageId(() -> languageId);
-
-		PLOEntry ploEntry = _ploEntryLocalService.fetchPLOEntry(
-			contextCompany.getCompanyId(), key, languageId);
-
-		if (ploEntry != null) {
-			message.setValue(ploEntry::getValue);
-		}
-		else {
-			message.setValue(
-				() -> _language.get(
-					LocaleUtil.fromLanguageId(languageId), key));
-		}
+		message.setValue(
+			() -> _language.get(LocaleUtil.fromLanguageId(languageId), key));
 
 		return message;
 	}
@@ -128,26 +112,8 @@ public class MessageResourceImpl extends BaseMessageResourceImpl {
 				"File name must have a \"properties\" file extension");
 		}
 
-		Properties properties = new Properties();
-
-		properties.load(
-			new InputStreamReader(
-				binaryFile.getInputStream(), StandardCharsets.UTF_8));
-
-		if (properties.isEmpty()) {
-			return;
-		}
-
-		Enumeration<String> enumeration =
-			(Enumeration<String>)properties.propertyNames();
-
-		while (enumeration.hasMoreElements()) {
-			String key = enumeration.nextElement();
-
-			_ploEntryLocalService.addOrUpdatePLOEntry(
-				contextCompany.getCompanyId(), contextUser.getUserId(), key,
-				languageId, properties.getProperty(key));
-		}
+		_ploEntryService.importPLOEntries(
+			binaryFile.getInputStream(), languageId);
 	}
 
 	@Override
@@ -170,8 +136,8 @@ public class MessageResourceImpl extends BaseMessageResourceImpl {
 		}
 
 		List<String> keys = transform(
-			_ploEntryLocalService.getPLOEntries(contextCompany.getCompanyId()),
-			ploEntry -> ploEntry.getKey());
+			_ploEntryService.getPLOEntries(contextCompany.getCompanyId()),
+			PLOEntryModel::getKey);
 
 		String languageId = GetterUtil.getString(parameters.get("languageId"));
 
@@ -210,8 +176,7 @@ public class MessageResourceImpl extends BaseMessageResourceImpl {
 	private Message _addOrUpdatePLOEntry(Message message)
 		throws PortalException {
 
-		PLOEntry ploEntry = _ploEntryLocalService.addOrUpdatePLOEntry(
-			contextCompany.getCompanyId(), contextUser.getUserId(),
+		PLOEntry ploEntry = _ploEntryService.addOrUpdatePLOEntry(
 			message.getKey(), message.getLanguageId(), message.getValue());
 
 		message.setKey(ploEntry::getKey);
@@ -225,6 +190,6 @@ public class MessageResourceImpl extends BaseMessageResourceImpl {
 	private Language _language;
 
 	@Reference
-	private PLOEntryLocalService _ploEntryLocalService;
+	private PLOEntryService _ploEntryService;
 
 }


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPD-32127

## Motivation
Currently we have the same logic to import a .properties file using the language override functionality (UI) or the Language headless API. 

## Proposed Solution
Centralize the logic into the PLOEntryLocalService. We're going to use this for the Language client extensions that will be created in the next tasks see https://liferay.atlassian.net/browse/LPD-30343

## Steps to Verify
Scenario 1: importing a Language.properties file using the headless API

1. Go to localhost:8080/o/api
2. Find the Language REST application
3. find the /messages/import endpoint and submit a file
4. Use the GET method to get a translation

Scenario 2: importing a Language.properties file using the UI

1. Go to control panel > Language Override
2. Click on the three dots on the upper right side
3. Import a Language.properties file
5. Verify the languages were added

## Note
There is no test since I'm not adding any new functionality, just refactoring