### PR TITLE
LPD-32128 Process Language Client Extensions for PaaS and Self-hosted

### DIFF
--- a/modules/apps/portal-language/portal-language-extender-test/bnd.bnd
+++ b/modules/apps/portal-language/portal-language-extender-test/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Liferay Portal Language Extender Test
+Bundle-SymbolicName: com.liferay.portal.language.extender.test
+Bundle-Version: 1.0.0

--- a/modules/apps/portal-language/portal-language-extender-test/build.gradle
+++ b/modules/apps/portal-language/portal-language-extender-test/build.gradle
@@ -1,0 +1,7 @@
+dependencies {
+	testIntegrationImplementation group: "org.osgi", name: "osgi.core", version: "6.0.0"
+	testIntegrationImplementation project(":apps:portal-language:portal-language-extender")
+	testIntegrationImplementation project(":apps:portal-language:portal-language-override-api")
+	testIntegrationImplementation project(":core:osgi-service-tracker-collections")
+	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
+}

--- a/modules/apps/portal-language/portal-language-extender-test/src/testIntegration/java/com/liferay/portal/language/extender/internal/test/LanguageClientExtensionTest.java
+++ b/modules/apps/portal-language/portal-language-extender-test/src/testIntegration/java/com/liferay/portal/language/extender/internal/test/LanguageClientExtensionTest.java
@@ -1,0 +1,178 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.language.extender.internal.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.zip.ZipWriter;
+import com.liferay.portal.kernel.zip.ZipWriterFactory;
+import com.liferay.portal.language.override.model.PLOEntry;
+import com.liferay.portal.language.override.service.PLOEntryLocalService;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LogEntry;
+import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.io.FileInputStream;
+import java.io.InputStream;
+
+import java.net.URL;
+
+import java.util.Arrays;
+import java.util.Enumeration;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+
+/**
+ * @author Thiago Buarque
+ */
+@RunWith(Arquillian.class)
+public class LanguageClientExtensionTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() {
+		_bundle = FrameworkUtil.getBundle(LanguageClientExtensionTest.class);
+
+		_bundleContext = _bundle.getBundleContext();
+	}
+
+	@Test
+	public void testAddingBundle() throws Exception {
+		Bundle bundle = _bundleContext.installBundle(
+			RandomTestUtil.randomString(),
+			_getBatchBundleInputStream("batchTest"));
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.portal.language.extender.internal." +
+					"LanguageClientExtension",
+				LoggerTestUtil.ERROR)) {
+
+			bundle.start();
+
+			Thread.sleep(2000);
+
+			PLOEntry ploEntry = _ploEntryLocalService.fetchPLOEntry(
+				TestPropsValues.getCompanyId(), "my-english-key", "en_US");
+
+			Assert.assertEquals("my-english-key", ploEntry.getKey());
+			Assert.assertEquals("en_US", ploEntry.getLanguageId());
+			Assert.assertEquals("My English value", ploEntry.getValue());
+
+			Assert.assertNull(
+				_ploEntryLocalService.fetchPLOEntry(
+					TestPropsValues.getCompanyId(), "my-key-with-empty-value",
+					"pt_BR"));
+
+			Assert.assertNull(
+				_ploEntryLocalService.fetchPLOEntry(
+					TestPropsValues.getCompanyId(),
+					"file-with-invalid-language-id", "yy_ZZ"));
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertEquals(logEntries.toString(), 3, logEntries.size());
+
+			for (LogEntry logEntry : logEntries) {
+				String message = logEntry.getMessage();
+
+				boolean matches = false;
+
+				for (String expectedMessage : _expectedLogMessages) {
+					if (message.matches(expectedMessage)) {
+						matches = true;
+
+						break;
+					}
+				}
+
+				if (!matches) {
+					Assert.fail(
+						StringBundler.concat(
+							"Log message \"", message,
+							"\" must match one of the following: ",
+							_expectedLogMessages));
+				}
+			}
+		}
+		finally {
+			bundle.uninstall();
+		}
+	}
+
+	private InputStream _getBatchBundleInputStream(String batchName)
+		throws Exception {
+
+		String basePath = StringBundler.concat(
+			"com/liferay/portal/language/extender/internal/test/dependencies/",
+			batchName, StringPool.SLASH);
+
+		Enumeration<URL> enumeration = _bundle.findEntries(basePath, "*", true);
+
+		ZipWriter zipWriter = _zipWriterFactory.getZipWriter();
+
+		if (enumeration != null) {
+			while (enumeration.hasMoreElements()) {
+				URL url = enumeration.nextElement();
+
+				String urlPath = url.getPath();
+
+				if (urlPath.endsWith(StringPool.SLASH)) {
+					continue;
+				}
+
+				String zipPath = urlPath.substring(basePath.length());
+
+				if (zipPath.startsWith(StringPool.SLASH)) {
+					zipPath = zipPath.substring(1);
+				}
+
+				try (InputStream inputStream = url.openStream()) {
+					zipWriter.addEntry(zipPath, inputStream);
+				}
+			}
+		}
+
+		return new FileInputStream(zipWriter.getFile());
+	}
+
+	private Bundle _bundle;
+	private BundleContext _bundleContext;
+	private final List<String> _expectedLogMessages = Arrays.asList(
+		"Unable to process language file \"Language_pt_BR.properties\". " +
+			"Value must not be null.",
+		"Unable to process language file \"Language_pt_BR.properties\". Key " +
+			"must not be null.",
+		"Unable to process language file \"Language_yy_ZZ.properties\". " +
+			"Language ID \"yy_ZZ\" is not one of the available language IDs: " +
+				"\\[(.*)\\].");
+
+	@Inject
+	private PLOEntryLocalService _ploEntryLocalService;
+
+	@Inject
+	private ZipWriterFactory _zipWriterFactory;
+
+}

--- a/modules/apps/portal-language/portal-language-extender-test/src/testIntegration/resources/com/liferay/portal/language/extender/internal/test/dependencies/batchTest/META-INF/MANIFEST.MF
+++ b/modules/apps/portal-language/portal-language-extender-test/src/testIntegration/resources/com/liferay/portal/language/extender/internal/test/dependencies/batchTest/META-INF/MANIFEST.MF
@@ -1,0 +1,6 @@
+Manifest-Version: 2
+Bundle-ManifestVersion: 2
+Bundle-SymbolicName: batchTest
+Bundle-Version: 1.0.0
+Liferay-Client-Extension-Batch: batchTest
+Created-By: 11.0.17 (Ubuntu)

--- a/modules/apps/portal-language/portal-language-extender-test/src/testIntegration/resources/com/liferay/portal/language/extender/internal/test/dependencies/batchTest/batchTest/Language_en_US.properties
+++ b/modules/apps/portal-language/portal-language-extender-test/src/testIntegration/resources/com/liferay/portal/language/extender/internal/test/dependencies/batchTest/batchTest/Language_en_US.properties
@@ -1,0 +1,1 @@
+my-english-key=My English value

--- a/modules/apps/portal-language/portal-language-extender-test/src/testIntegration/resources/com/liferay/portal/language/extender/internal/test/dependencies/batchTest/batchTest/Language_pt_BR.properties
+++ b/modules/apps/portal-language/portal-language-extender-test/src/testIntegration/resources/com/liferay/portal/language/extender/internal/test/dependencies/batchTest/batchTest/Language_pt_BR.properties
@@ -1,0 +1,2 @@
+my-key-with-empty-value=
+=my value with empty key

--- a/modules/apps/portal-language/portal-language-extender-test/src/testIntegration/resources/com/liferay/portal/language/extender/internal/test/dependencies/batchTest/batchTest/Language_yy_ZZ.properties
+++ b/modules/apps/portal-language/portal-language-extender-test/src/testIntegration/resources/com/liferay/portal/language/extender/internal/test/dependencies/batchTest/batchTest/Language_yy_ZZ.properties
@@ -1,0 +1,1 @@
+file-with-invalid-language-id=File with invalid language id

--- a/modules/apps/portal-language/portal-language-extender/build.gradle
+++ b/modules/apps/portal-language/portal-language-extender/build.gradle
@@ -4,5 +4,7 @@ dependencies {
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
+	compileOnly project(":apps:portal-language:portal-language-override-api")
+	compileOnly project(":core:petra:petra-reflect")
 	compileOnly project(":core:petra:petra-string")
 }

--- a/modules/apps/portal-language/portal-language-extender/src/main/java/com/liferay/portal/language/extender/internal/LanguageClientExtension.java
+++ b/modules/apps/portal-language/portal-language-extender/src/main/java/com/liferay/portal/language/extender/internal/LanguageClientExtension.java
@@ -1,0 +1,200 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.language.extender.internal;
+
+import com.liferay.petra.reflect.ReflectionUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.PropsUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.language.override.exception.PLOEntryImportException;
+import com.liferay.portal.language.override.service.PLOEntryLocalService;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+
+import java.net.URL;
+import java.net.URLConnection;
+
+import java.nio.charset.StandardCharsets;
+
+import java.util.Dictionary;
+import java.util.Enumeration;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.BundleEvent;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.util.tracker.BundleTracker;
+import org.osgi.util.tracker.BundleTrackerCustomizer;
+
+/**
+ * @author Thiago Buarque
+ */
+@Component(service = {})
+public class LanguageClientExtension
+	implements BundleTrackerCustomizer<Bundle> {
+
+	@Override
+	public Bundle addingBundle(Bundle bundle, BundleEvent event) {
+		Dictionary<String, String> headers = bundle.getHeaders(
+			StringPool.BLANK);
+
+		if (Validator.isNull(headers.get("Liferay-Client-Extension-Batch")) ||
+			_isAlreadyProcessed(bundle)) {
+
+			return null;
+		}
+
+		Enumeration<URL> enumeration = bundle.findEntries(
+			headers.get("Liferay-Client-Extension-Batch"),
+			"Language_*.properties", true);
+
+		while ((enumeration != null) && enumeration.hasMoreElements()) {
+			URL url = enumeration.nextElement();
+
+			File file = new File(url.getFile());
+
+			String fileName = file.getName();
+
+			try {
+				Company company = _companyLocalService.getCompanyByWebId(
+					PropsUtil.get(PropsKeys.COMPANY_DEFAULT_WEB_ID));
+
+				long companyId = company.getCompanyId();
+
+				String languageId = StringUtil.removeSubstring(
+					fileName, "Language_");
+
+				languageId = StringUtil.removeSubstring(
+					languageId, ".properties");
+
+				URLConnection urlConnection = url.openConnection();
+
+				Reader reader = new InputStreamReader(
+					urlConnection.getInputStream(), StandardCharsets.UTF_8);
+
+				Properties properties = new Properties();
+
+				properties.load(reader);
+
+				User user = _userLocalService.getUserByScreenName(
+					companyId,
+					PropsUtil.get(PropsKeys.DEFAULT_ADMIN_SCREEN_NAME));
+
+				_ploEntryLocalService.importPLOEntries(
+					companyId, languageId, properties, user.getUserId());
+
+				if (_log.isInfoEnabled()) {
+					_log.info(
+						"Processed language file \"" + fileName +
+							"\" successfully");
+				}
+			}
+			catch (PLOEntryImportException.InvalidTranslations
+						ploEntryImportException) {
+
+				for (Throwable throwable :
+						ploEntryImportException.getSuppressed()) {
+
+					_log.error(
+						StringBundler.concat(
+							"Unable to process language file \"", fileName,
+							"\". ", throwable.getMessage(), StringPool.PERIOD));
+				}
+			}
+			catch (IOException | PortalException exception) {
+				_log.error(
+					"Unable to process language file \"" + fileName + "\"",
+					exception);
+			}
+		}
+
+		return bundle;
+	}
+
+	@Override
+	public void modifiedBundle(
+		Bundle bundle, BundleEvent event, Bundle object) {
+	}
+
+	@Override
+	public void removedBundle(Bundle bundle, BundleEvent event, Bundle object) {
+	}
+
+	@Activate
+	protected void activate(
+		BundleContext bundleContext, Map<String, Object> properties) {
+
+		_bundleTracker = new BundleTracker<>(
+			bundleContext, Bundle.ACTIVE, this);
+
+		_bundleTracker.open();
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		_bundleTracker.close();
+	}
+
+	private boolean _isAlreadyProcessed(Bundle bundle) {
+		File file = bundle.getDataFile(".liferay-client-extension-language");
+
+		String lastModifiedString = String.valueOf(bundle.getLastModified());
+
+		try {
+			if ((file != null) && file.exists() &&
+				Objects.equals(FileUtil.read(file), lastModifiedString)) {
+
+				return true;
+			}
+
+			if (!file.exists()) {
+				file.createNewFile();
+			}
+
+			FileUtil.write(file, lastModifiedString, true);
+		}
+		catch (IOException ioException) {
+			ReflectionUtil.throwException(ioException);
+		}
+
+		return false;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		LanguageClientExtension.class);
+
+	private BundleTracker<?> _bundleTracker;
+
+	@Reference
+	private CompanyLocalService _companyLocalService;
+
+	@Reference
+	private PLOEntryLocalService _ploEntryLocalService;
+
+	@Reference
+	private UserLocalService _userLocalService;
+
+}

--- a/modules/apps/portal-language/portal-language-override-api/src/main/java/com/liferay/portal/language/override/service/PLOEntryLocalService.java
+++ b/modules/apps/portal-language/portal-language-override-api/src/main/java/com/liferay/portal/language/override/service/PLOEntryLocalService.java
@@ -269,8 +269,8 @@ public interface PLOEntryLocalService
 	public PLOEntry getPLOEntry(long ploEntryId) throws PortalException;
 
 	public void importPLOEntries(
-			long companyId, long userId, String languageId,
-			Properties properties)
+			long companyId, String languageId, Properties properties,
+			long userId)
 		throws PortalException;
 
 	public void setPLOEntries(

--- a/modules/apps/portal-language/portal-language-override-api/src/main/java/com/liferay/portal/language/override/service/PLOEntryLocalServiceUtil.java
+++ b/modules/apps/portal-language/portal-language-override-api/src/main/java/com/liferay/portal/language/override/service/PLOEntryLocalServiceUtil.java
@@ -307,12 +307,12 @@ public class PLOEntryLocalServiceUtil {
 	}
 
 	public static void importPLOEntries(
-			long companyId, long userId, String languageId,
-			java.util.Properties properties)
+			long companyId, String languageId, java.util.Properties properties,
+			long userId)
 		throws PortalException {
 
 		getService().importPLOEntries(
-			companyId, userId, languageId, properties);
+			companyId, languageId, properties, userId);
 	}
 
 	public static void setPLOEntries(

--- a/modules/apps/portal-language/portal-language-override-api/src/main/java/com/liferay/portal/language/override/service/PLOEntryLocalServiceWrapper.java
+++ b/modules/apps/portal-language/portal-language-override-api/src/main/java/com/liferay/portal/language/override/service/PLOEntryLocalServiceWrapper.java
@@ -354,12 +354,12 @@ public class PLOEntryLocalServiceWrapper
 
 	@Override
 	public void importPLOEntries(
-			long companyId, long userId, String languageId,
-			java.util.Properties properties)
+			long companyId, String languageId, java.util.Properties properties,
+			long userId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		_ploEntryLocalService.importPLOEntries(
-			companyId, userId, languageId, properties);
+			companyId, languageId, properties, userId);
 	}
 
 	@Override

--- a/modules/apps/portal-language/portal-language-override-service/src/main/java/com/liferay/portal/language/override/service/impl/PLOEntryLocalServiceImpl.java
+++ b/modules/apps/portal-language/portal-language-override-service/src/main/java/com/liferay/portal/language/override/service/impl/PLOEntryLocalServiceImpl.java
@@ -100,8 +100,8 @@ public class PLOEntryLocalServiceImpl extends PLOEntryLocalServiceBaseImpl {
 
 	@Override
 	public void importPLOEntries(
-			long companyId, long userId, String languageId,
-			Properties properties)
+			long companyId, String languageId, Properties properties,
+			long userId)
 		throws PortalException {
 
 		languageId = _normalizeLanguageId(languageId);

--- a/modules/apps/portal-language/portal-language-override-service/src/main/java/com/liferay/portal/language/override/service/impl/PLOEntryServiceImpl.java
+++ b/modules/apps/portal-language/portal-language-override-service/src/main/java/com/liferay/portal/language/override/service/impl/PLOEntryServiceImpl.java
@@ -99,8 +99,8 @@ public class PLOEntryServiceImpl extends PLOEntryServiceBaseImpl {
 			permissionChecker, PLOActionKeys.MANAGE_LANGUAGE_OVERRIDES);
 
 		ploEntryLocalService.importPLOEntries(
-			permissionChecker.getCompanyId(), permissionChecker.getUserId(),
-			languageId, properties);
+			permissionChecker.getCompanyId(), languageId, properties,
+			permissionChecker.getUserId());
 	}
 
 	@Override

--- a/modules/apps/portal-language/portal-language-override-test/src/testIntegration/java/com/liferay/portal/language/override/service/test/PLOEntryLocalServiceTest.java
+++ b/modules/apps/portal-language/portal-language-override-test/src/testIntegration/java/com/liferay/portal/language/override/service/test/PLOEntryLocalServiceTest.java
@@ -192,8 +192,9 @@ public class PLOEntryLocalServiceTest {
 		properties.setProperty(key2, value2);
 
 		_ploEntryLocalService.importPLOEntries(
-			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-			LanguageUtil.getLanguageId(LocaleUtil.US), properties);
+			TestPropsValues.getCompanyId(),
+			LanguageUtil.getLanguageId(LocaleUtil.US), properties,
+			TestPropsValues.getUserId());
 
 		Assert.assertEquals(value1, _language.get(LocaleUtil.US, key1));
 		Assert.assertEquals(value2, _language.get(LocaleUtil.US, key2));
@@ -214,8 +215,9 @@ public class PLOEntryLocalServiceTest {
 
 		try {
 			_ploEntryLocalService.importPLOEntries(
-				TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-				LanguageUtil.getLanguageId(LocaleUtil.US), properties);
+				TestPropsValues.getCompanyId(),
+				LanguageUtil.getLanguageId(LocaleUtil.US), properties,
+				TestPropsValues.getUserId());
 
 			Assert.fail();
 		}


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPD-32128

# Warning
Until [#153028](https://github.com/brianchandotcom/liferay-portal/pull/153028) is merged and synced on master, please only consider the last five commits on this PR

## Goal
To import translations using batch client extensions for PaaS and Self-hosted instances.

## Approach
Use a `BundleTracker` to track Language Client Extensions and process `Language_*.properties` files when importing a Language Client Extension in both PaaS and Self-hosted.

## Steps to Verify
1. Deploy a batch client extension with Language_<language_ID>.properties files
2. Navigate to the Global Menu > Control Panel > Language Override
3. Search for the keys you added in the .properties files

## Notes

- For SaaS, we have to use a different approach that will be added in https://liferay.atlassian.net/browse/LPD-32129