### PR TITLE
LPD-33373 fix tests

### DIFF
--- a/modules/apps/portal-language/portal-language-override-test/src/testFunctional/tests/LanguageOverride.testcase
+++ b/modules/apps/portal-language/portal-language-override-test/src/testFunctional/tests/LanguageOverride.testcase
@@ -72,96 +72,6 @@ definition {
 		}
 	}
 
-	@description = "Filtering by 'Selected Language' and choosing a language will only show keys created with translations available in the selected language."
-	@priority = 3
-	test CanFilterLanguageKeysByLocaleViaLanguageSelector {
-		task ("Given two separate language keys are added") {
-			LanguageOverride.addLanguageKey(
-				languageKey = "BR-Key",
-				translationOverrideList = "pt-BR",
-				translationOverrideValueList = "BR Key");
-
-			LanguageOverride.addLanguageKey(
-				languageKey = "ES-Key",
-				translationOverrideList = "ca-ES",
-				translationOverrideValueList = "ES Key");
-		}
-
-		task ("When the filter is set to 'Selected Language' it will default to 'en-US' language which has no created keys") {
-			ManagementBar.setFilterAndOrder(filterBy = "Selected Language");
-
-			AssertTextEquals(
-				locator1 = "Message#EMPTY_INFO",
-				value1 = "No language entries were found.");
-		}
-
-		task ("Then switching to another language with created keys should only show keys that have translations in that language") {
-			PageEditor.changeLocale(
-				currentLocale = "en-US",
-				locale = "pt-BR");
-
-			LexiconList.viewListEntryTitle(listEntry = "BR-Key");
-
-			AssertElementNotPresent(
-				key_listEntry = "ES-Key",
-				locator1 = "LexiconList#LIST_ENTRY_TITLE");
-
-			PageEditor.changeLocale(
-				currentLocale = "pt-BR",
-				locale = "ca-ES");
-
-			LexiconList.viewListEntryTitle(listEntry = "ES-Key");
-
-			AssertElementNotPresent(
-				key_listEntry = "BR-Key",
-				locator1 = "LexiconList#LIST_ENTRY_TITLE");
-		}
-	}
-
-	@description = "This test filters to only see Overrides."
-	@priority = 4
-	test CanFilterOverridesByAnyLanguage {
-		task ("Given that assert no existing keys filter by Any Language") {
-			ManagementBar.setFilterAndOrder(filterBy = "Any Language");
-
-			AssertTextEquals.assertPartialText(
-				locator1 = "Search#SEARCH_INFO",
-				value1 = "0 Results Found");
-
-			AssertTextEquals(
-				locator1 = "Message#EMPTY_INFO",
-				value1 = "No language entries were found.");
-
-			Click(locator1 = "LanguageOverride#FILTER_BY_OVERRIDE_REMOVE_FILTER_SCOPE");
-
-			LanguageOverride.assertLanguageKeyWithoutOverride(
-				languageKey = "0-analytics-cloud-connection",
-				translation = "Analytics Cloud Connection");
-		}
-
-		task ("When add a language key and filters by Any Language") {
-			LanguageOverride.addLanguageKey(
-				languageKey = "text-contains-error",
-				translationOverrideList = "en-US",
-				translationOverrideValueList = "Text contains error");
-
-			ManagementBar.setFilterAndOrder(filterBy = "Any Language");
-		}
-
-		task ("Then user can only view Overridden keys") {
-			AssertTextEquals.assertPartialText(
-				locator1 = "Search#SEARCH_INFO",
-				value1 = "1 Result Found");
-
-			LanguageOverride.assertFilterScope(filterScope = "Any Language");
-
-			LanguageOverride.assertSelectedLanguageInListView(
-				currentTranslationOverride = "Text contains error",
-				languageKey = "text-contains-error",
-				selectedLanguage = "en_US");
-		}
-	}
-
 	@description = "The testcase asserts the override filtered by 'Selected Language'."
 	@priority = 4
 	test CanFilterOverridesBySelectedLanguage {
@@ -567,30 +477,6 @@ definition {
 			LanguageOverride.assertLanguageKeyWithOverrideInListView(
 				languageKey = "text-not-bold",
 				languagesWithOverride = "en_US");
-		}
-	}
-
-	@description = "This test assert the OOTB Language Key added by default has no override related information."
-	@priority = 3
-	test NoOverrideRelatedInfosDisplayForOOTBLanguageKey {
-		task ("Given that assert no existing keys when filter by Any Language") {
-			ManagementBar.setFilterAndOrder(filterBy = "Any Language");
-
-			AssertTextEquals(
-				locator1 = "Message#EMPTY_INFO",
-				value1 = "No language entries were found.");
-		}
-
-		task ("When remove any language fiter") {
-			Click(locator1 = "LanguageOverride#FILTER_BY_OVERRIDE_REMOVE_FILTER_SCOPE");
-		}
-
-		task ("Then the OOTB language keys display") {
-			LanguageOverride.assertLanguageKeyWithoutOverride(
-				languageKey = "0-analytics-cloud-connection",
-				translation = "Analytics Cloud Connection");
-
-			AssertElementNotPresent(locator1 = "LanguageOverride#FILTER_BY_OVERRIDE_LANGUAGES_WITH_OVERRIDE");
 		}
 	}
 

--- a/modules/apps/portal-language/portal-language-override-test/src/testFunctional/tests/LanguageOverrideExportImport.testcase
+++ b/modules/apps/portal-language/portal-language-override-test/src/testFunctional/tests/LanguageOverrideExportImport.testcase
@@ -59,39 +59,6 @@ definition {
 		}
 	}
 
-	@description = "This test ensures that separate language keys with overridden translation of the same locale will export successfully"
-	@priority = 4
-	test CanExportMultipleLanguageKeysWithOverride {
-		task ("Given that there are two language keys with en-US override") {
-			LanguageOverride.addLanguageKey(
-				languageKey = "hello-world",
-				translationOverrideList = "en-US",
-				translationOverrideValueList = "Hello world");
-
-			LanguageOverride.addLanguageKey(
-				languageKey = "this-is-a-language-key",
-				translationOverrideList = "en-US",
-				translationOverrideValueList = "This is a language key");
-		}
-
-		task ("When a user exports overridden translations,") {
-			LanguageOverride.exportOverriddenTranslations();
-
-			var originalFileDownloadName = TestCase.getDownloadedTempFileName(fileNamePattern = "*.zip");
-
-			AntCommands.runCommand("build-test.xml", "unzip-temp-file -DfileName=${originalFileDownloadName}");
-		}
-
-		task ("Then the language properties file for en-US displays all translations") {
-			DMDocument.assertFileNameFromTempFolder(fileName = "Language_en_US.properties");
-
-			DMDocument.assertDownloadedFileContent(
-				downloadedContent = '''hello-world=Hello world
-this-is-a-language-key=This is a language key''',
-				fileName = "Language_en_US.properties");
-		}
-	}
-
 	@description = "This test ensures that a user can export overridden translations for a single language key"
 	@priority = 5
 	test CanExportOverriddenTranslations {

--- a/modules/apps/portal-language/portal-language-override-web/test.properties
+++ b/modules/apps/portal-language/portal-language-override-web/test.properties
@@ -1,0 +1,17 @@
+##
+## Test Suites
+##
+
+    modified.files.includes[relevant][portal-language-override-web-rule]=**
+
+    relevant.rule.names=\
+        portal-language-override-web-rule
+
+    test.batch.names[relevant][portal-language-override-web-rule]=\
+        playwright-js-tomcat90-mysql57-jdk8
+
+    #
+    # Relevant
+    #
+
+    playwright.test.project[playwright-js-tomcat90-mysql57-jdk8][relevant][portal-language-override-web-rule]=portal-language-override-web

--- a/modules/apps/portal-language/test.properties
+++ b/modules/apps/portal-language/test.properties
@@ -1,4 +1,10 @@
 ##
+## Playwright
+##
+
+    playwright.test.project[playwright-js-tomcat90-mysql57-jdk8][relevant]=portal-language-override-web
+
+##
 ## Test Suites
 ##
 

--- a/modules/test/playwright/fixtures/LanguageOverridePageTest.ts
+++ b/modules/test/playwright/fixtures/LanguageOverridePageTest.ts
@@ -1,0 +1,18 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import test from '@playwright/test';
+
+import {LanguageOverridePage} from '../pages/portal-language-override-web/LanguageOverridePage';
+
+const languageOverridePageTest = test.extend<{
+	languageOverridePage: LanguageOverridePage;
+}>({
+	languageOverridePage: async ({page}, use) => {
+		await use(new LanguageOverridePage(page));
+	},
+});
+
+export {languageOverridePageTest};

--- a/modules/test/playwright/pages/portal-language-override-web/LanguageOverridePage.ts
+++ b/modules/test/playwright/pages/portal-language-override-web/LanguageOverridePage.ts
@@ -1,0 +1,135 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Locator, Page, expect} from '@playwright/test';
+
+import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
+import fillAndClickOutside from '../../utils/fillAndClickOutside';
+import {PORTLET_URLS} from '../../utils/portletUrls';
+import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+
+export type TLanguageOverride = {
+	key: string;
+	languageIds: string[];
+	values: string[];
+};
+
+export class LanguageOverridePage {
+	readonly filterButton: Locator;
+	readonly newButton: Locator;
+	readonly optionsButton: Locator;
+	readonly page: Page;
+	readonly saveButton: Locator;
+
+	constructor(page: Page) {
+		this.filterButton = page.getByRole('button', {
+			exact: true,
+			name: 'Filter',
+		});
+		this.newButton = page.getByRole('link', {name: 'Add Language Key'});
+		this.optionsButton = page.getByRole('button', {name: 'Options'});
+		this.page = page;
+		this.saveButton = page.getByRole('button', {name: 'Save'});
+	}
+
+	async addTranslation({key, languageIds, values}: TLanguageOverride) {
+		await this.newButton.click();
+
+		await this.page.getByLabel('key required').fill(key);
+
+		for (let i = 0; i < languageIds.length; i++) {
+			await fillAndClickOutside(
+				this.page,
+				this.page.getByLabel(languageIds[i]),
+				values[i],
+				false
+			);
+		}
+
+		await this.saveButton.click();
+
+		await waitForSuccessAlert(this.page);
+	}
+
+	async addTranslations(languageOverrides: TLanguageOverride[]) {
+		for (const languageOverride of languageOverrides) {
+			await this.addTranslation(languageOverride);
+		}
+	}
+
+	async assertTranslationInListView({key, languageIds}: TLanguageOverride) {
+		if (languageIds.length) {
+			const normalizedLanguageIds = languageIds.map((languageId) =>
+				languageId.replace('-', '_')
+			);
+
+			await expect(
+				this.page.locator(
+					`a:has-text("${key}"):has-text("Languages With Override: ${normalizedLanguageIds.join(', ')}")`
+				)
+			).toBeVisible();
+		}
+		else {
+			await expect(
+				this.page.getByRole('link', {name: key})
+			).toBeAttached();
+		}
+	}
+
+	async assertTranslationNotInListView({key}: TLanguageOverride) {
+		await expect(this.page.getByRole('link', {name: key})).toBeHidden();
+	}
+
+	async changeFilter(option: 'Any Language' | 'Selected Language') {
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: this.page.getByRole('menuitem', {name: option}),
+			trigger: this.filterButton,
+		});
+
+		await this.page
+			.getByText('Search Results', {exact: true})
+			.waitFor({state: 'visible'});
+	}
+
+	async changeLocale(currentLanguageId: string, languageId: string) {
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: this.page.getByRole('menuitem', {name: languageId}),
+			trigger: this.page.getByRole('button', {name: currentLanguageId}),
+		});
+
+		await this.page.waitForLoadState();
+	}
+
+	async exportOverridenTranslations() {
+		await this.optionsButton.click();
+
+		await this.page
+			.getByRole('menuitem', {name: 'Export Overridden Translations'})
+			.click();
+	}
+
+	async goto() {
+		await this.page.goto(`/group/guest${PORTLET_URLS.languageOverride}`);
+	}
+
+	async searchTranslation(key: string) {
+		await fillAndClickOutside(
+			this.page,
+			this.page.getByRole('searchbox'),
+			key,
+			false
+		);
+
+		await this.page
+			.getByRole('button', {exact: true, name: 'Search for'})
+			.click();
+
+		await this.page.waitForLoadState();
+
+		await this.page.getByText('Search Results').waitFor({state: 'visible'});
+	}
+}

--- a/modules/test/playwright/pages/portal-language-override-web/LanguageOverridePage.ts
+++ b/modules/test/playwright/pages/portal-language-override-web/LanguageOverridePage.ts
@@ -10,10 +10,12 @@ import fillAndClickOutside from '../../utils/fillAndClickOutside';
 import {PORTLET_URLS} from '../../utils/portletUrls';
 import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
 
-export type TLanguageOverride = {
+export type TTranslation = {
 	key: string;
-	languageIds: string[];
-	values: string[];
+	values: {
+		languageId: string;
+		value: string;
+	}[];
 };
 
 export class LanguageOverridePage {
@@ -34,16 +36,18 @@ export class LanguageOverridePage {
 		this.saveButton = page.getByRole('button', {name: 'Save'});
 	}
 
-	async addTranslation({key, languageIds, values}: TLanguageOverride) {
+	async addTranslation({key, values}: TTranslation) {
 		await this.newButton.click();
 
 		await this.page.getByLabel('key required').fill(key);
 
-		for (let i = 0; i < languageIds.length; i++) {
+		for (let i = 0; i < values.length; i++) {
+			const {languageId, value} = values[i];
+
 			await fillAndClickOutside(
 				this.page,
-				this.page.getByLabel(languageIds[i]),
-				values[i],
+				this.page.getByLabel(languageId),
+				value,
 				false
 			);
 		}
@@ -53,15 +57,15 @@ export class LanguageOverridePage {
 		await waitForSuccessAlert(this.page);
 	}
 
-	async addTranslations(languageOverrides: TLanguageOverride[]) {
+	async addTranslations(languageOverrides: TTranslation[]) {
 		for (const languageOverride of languageOverrides) {
 			await this.addTranslation(languageOverride);
 		}
 	}
 
-	async assertTranslationInListView({key, languageIds}: TLanguageOverride) {
-		if (languageIds.length) {
-			const normalizedLanguageIds = languageIds.map((languageId) =>
+	async assertTranslationInListView({key, values}: TTranslation) {
+		if (values.length) {
+			const normalizedLanguageIds = values.map(({languageId}) =>
 				languageId.replace('-', '_')
 			);
 
@@ -78,7 +82,7 @@ export class LanguageOverridePage {
 		}
 	}
 
-	async assertTranslationNotInListView({key}: TLanguageOverride) {
+	async assertTranslationNotInListView({key}: TTranslation) {
 		await expect(this.page.getByRole('link', {name: key})).toBeHidden();
 	}
 

--- a/modules/test/playwright/playwright.config.ts
+++ b/modules/test/playwright/playwright.config.ts
@@ -43,6 +43,7 @@ import {config as objectWebConfig} from './tests/object-web/config';
 import {config as openIdLinkConfig} from './tests/openid-link/config';
 import {config as osbFaroWebConfig} from './tests/osb-faro-web/config';
 import {config as portalDefaultPermissionsWebConfig} from './tests/portal-default-permissions-web/config';
+import {config as portalLanguageOverrideWebConfig} from './tests/portal-language-override-web/config';
 import {config as portalSearchAdminWebConfig} from './tests/portal-search-admin-web/config';
 import {config as portalSearchWebConfig} from './tests/portal-search-web/config';
 import {config as portalSecurityScriptManagementWebConfig} from './tests/portal-security-script-management-web/config';
@@ -124,6 +125,7 @@ export default defineConfig({
 		osbFaroWebConfig,
 		partnerConfig,
 		portalDefaultPermissionsWebConfig,
+		portalLanguageOverrideWebConfig,
 		portalSearchAdminWebConfig,
 		portalSearchWebConfig,
 		portalSecurityScriptManagementWebConfig,

--- a/modules/test/playwright/tests/portal-language-override-web/config.ts
+++ b/modules/test/playwright/tests/portal-language-override-web/config.ts
@@ -1,0 +1,9 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export const config = {
+	name: 'portal-language-override-web',
+	testDir: 'tests/portal-language-override-web',
+};

--- a/modules/test/playwright/tests/portal-language-override-web/languageOverride.spec.ts
+++ b/modules/test/playwright/tests/portal-language-override-web/languageOverride.spec.ts
@@ -1,0 +1,126 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {languageOverridePageTest} from '../../fixtures/LanguageOverridePageTest';
+import {loginTest} from '../../fixtures/loginTest';
+import {TLanguageOverride as TTranslation} from '../../pages/portal-language-override-web/LanguageOverridePage';
+import getRandomString from '../../utils/getRandomString';
+import {readFileFromZip} from '../../utils/zip';
+
+export const test = mergeTests(loginTest(), languageOverridePageTest);
+
+test('LPD-33373 assert that overriden translations can be exported', async ({
+	languageOverridePage,
+	page,
+}) => {
+	const translations: TTranslation[] = [
+		{
+			key: getRandomString(),
+			languageIds: ['en-US', 'es-ES', 'pt-BR'],
+			values: [getRandomString(), getRandomString(), getRandomString()],
+		},
+		{
+			key: getRandomString(),
+			languageIds: ['en-US'],
+			values: [getRandomString()],
+		},
+	];
+
+	await languageOverridePage.goto();
+
+	await languageOverridePage.addTranslations(translations);
+
+	page.on('download', async (download) => {
+		for (const translation of translations) {
+			for (let i = 0; i < translation.languageIds.length; i++) {
+				const languageId = translation.languageIds[i];
+
+				const fileContent = (await readFileFromZip(
+					`Language_${languageId.replace('-', '_')}.properties`,
+					await download.path()
+				)) as string;
+
+				expect(
+					fileContent.includes(
+						`${translation.key}=${translation.values[i]}`
+					)
+				).toBeTruthy();
+			}
+		}
+	});
+
+	await languageOverridePage.exportOverridenTranslations();
+});
+
+test('LPD-33373 assert that overriden translations can be filtered', async ({
+	languageOverridePage,
+}) => {
+	await languageOverridePage.goto();
+
+	const translation1 = {
+		key: getRandomString(),
+		languageIds: ['en-US', 'pt-BR'],
+		values: [getRandomString(), getRandomString()],
+	};
+	const translation2 = {
+		key: getRandomString(),
+		languageIds: ['en-US'],
+		values: [getRandomString()],
+	};
+
+	await languageOverridePage.addTranslation(translation1);
+
+	await languageOverridePage.addTranslation(translation2);
+
+	await languageOverridePage.changeFilter('Selected Language');
+
+	await languageOverridePage.changeLocale('en-US', 'pt-BR');
+
+	await languageOverridePage.searchTranslation(translation1.key);
+
+	await languageOverridePage.assertTranslationInListView(translation1);
+
+	await languageOverridePage.searchTranslation(translation2.key);
+
+	await languageOverridePage.assertTranslationNotInListView(translation2);
+
+	await languageOverridePage.changeFilter('Any Language');
+
+	await languageOverridePage.changeLocale('pt-BR', 'en-US');
+
+	await languageOverridePage.searchTranslation(translation1.key);
+
+	await languageOverridePage.assertTranslationInListView(translation1);
+
+	await languageOverridePage.searchTranslation(translation2.key);
+
+	await languageOverridePage.assertTranslationInListView(translation2);
+});
+
+test('LPD-33373 assert that default and overriden translations show up when no filters are applied', async ({
+	languageOverridePage,
+}) => {
+	await languageOverridePage.goto();
+
+	const translation = {
+		key: getRandomString(),
+		languageIds: ['en-US', 'pt-BR'],
+		values: [getRandomString(), getRandomString()],
+	};
+
+	await languageOverridePage.addTranslation(translation);
+
+	await languageOverridePage.assertTranslationInListView({
+		key: '0-analytics-cloud-connection',
+		languageIds: [],
+		values: [],
+	});
+
+	await languageOverridePage.searchTranslation(translation.key);
+
+	await languageOverridePage.assertTranslationInListView(translation);
+});

--- a/modules/test/playwright/tests/portal-language-override-web/languageOverride.spec.ts
+++ b/modules/test/playwright/tests/portal-language-override-web/languageOverride.spec.ts
@@ -7,7 +7,7 @@ import {expect, mergeTests} from '@playwright/test';
 
 import {languageOverridePageTest} from '../../fixtures/LanguageOverridePageTest';
 import {loginTest} from '../../fixtures/loginTest';
-import {TLanguageOverride as TTranslation} from '../../pages/portal-language-override-web/LanguageOverridePage';
+import {TTranslation} from '../../pages/portal-language-override-web/LanguageOverridePage';
 import getRandomString from '../../utils/getRandomString';
 import {readFileFromZip} from '../../utils/zip';
 
@@ -20,13 +20,29 @@ test('LPD-33373 assert that overriden translations can be exported', async ({
 	const translations: TTranslation[] = [
 		{
 			key: getRandomString(),
-			languageIds: ['en-US', 'es-ES', 'pt-BR'],
-			values: [getRandomString(), getRandomString(), getRandomString()],
+			values: [
+				{
+					languageId: 'en-US',
+					value: getRandomString(),
+				},
+				{
+					languageId: 'es-ES',
+					value: getRandomString(),
+				},
+				{
+					languageId: 'pt-BR',
+					value: getRandomString(),
+				},
+			],
 		},
 		{
 			key: getRandomString(),
-			languageIds: ['en-US'],
-			values: [getRandomString()],
+			values: [
+				{
+					languageId: 'en-US',
+					value: getRandomString(),
+				},
+			],
 		},
 	];
 
@@ -36,8 +52,8 @@ test('LPD-33373 assert that overriden translations can be exported', async ({
 
 	page.on('download', async (download) => {
 		for (const translation of translations) {
-			for (let i = 0; i < translation.languageIds.length; i++) {
-				const languageId = translation.languageIds[i];
+			for (let i = 0; i < translation.values.length; i++) {
+				const {languageId, value} = translation.values[i];
 
 				const fileContent = (await readFileFromZip(
 					`Language_${languageId.replace('-', '_')}.properties`,
@@ -45,9 +61,7 @@ test('LPD-33373 assert that overriden translations can be exported', async ({
 				)) as string;
 
 				expect(
-					fileContent.includes(
-						`${translation.key}=${translation.values[i]}`
-					)
+					fileContent.includes(`${translation.key}=${value}`)
 				).toBeTruthy();
 			}
 		}
@@ -63,13 +77,25 @@ test('LPD-33373 assert that overriden translations can be filtered', async ({
 
 	const translation1 = {
 		key: getRandomString(),
-		languageIds: ['en-US', 'pt-BR'],
-		values: [getRandomString(), getRandomString()],
+		values: [
+			{
+				languageId: 'en-US',
+				value: getRandomString(),
+			},
+			{
+				languageId: 'pt-BR',
+				value: getRandomString(),
+			},
+		],
 	};
-	const translation2 = {
+	const translation2: TTranslation = {
 		key: getRandomString(),
-		languageIds: ['en-US'],
-		values: [getRandomString()],
+		values: [
+			{
+				languageId: 'en-US',
+				value: getRandomString(),
+			},
+		],
 	};
 
 	await languageOverridePage.addTranslation(translation1);
@@ -106,17 +132,24 @@ test('LPD-33373 assert that default and overriden translations show up when no f
 }) => {
 	await languageOverridePage.goto();
 
-	const translation = {
+	const translation: TTranslation = {
 		key: getRandomString(),
-		languageIds: ['en-US', 'pt-BR'],
-		values: [getRandomString(), getRandomString()],
+		values: [
+			{
+				languageId: 'en-US',
+				value: getRandomString(),
+			},
+			{
+				languageId: 'pt-BR',
+				value: getRandomString(),
+			},
+		],
 	};
 
 	await languageOverridePage.addTranslation(translation);
 
 	await languageOverridePage.assertTranslationInListView({
 		key: '0-analytics-cloud-connection',
-		languageIds: [],
 		values: [],
 	});
 

--- a/modules/test/playwright/tests/portal-language-override-web/test.properties
+++ b/modules/test/playwright/tests/portal-language-override-web/test.properties
@@ -1,0 +1,5 @@
+##
+## Testray
+##
+
+    testray.main.component.name=Language Override

--- a/modules/test/playwright/utils/fillAndClickOutside.ts
+++ b/modules/test/playwright/utils/fillAndClickOutside.ts
@@ -10,9 +10,13 @@ import getRandomString from './getRandomString';
 export default async function fillAndClickOutside(
 	page: Page,
 	element: Locator,
-	content?: string
+	content?: string,
+	clickOutside: boolean = true
 ) {
 	await element.click();
 	await element.fill(content || getRandomString());
-	await page.locator('body').click();
+
+	if (clickOutside) {
+		await page.locator('body').click();
+	}
 }

--- a/modules/test/playwright/utils/portletUrls.ts
+++ b/modules/test/playwright/utils/portletUrls.ts
@@ -21,6 +21,8 @@ export const PORTLET_URLS = {
 		'/~/control_panel/manage?p_p_id=com_liferay_journal_web_portlet_JournalPortlet&_com_liferay_journal_web_portlet_JournalPortlet_mvcPath=%2Fview_ddm_templates.jsp',
 	knowledgeBase:
 		'/~/control_panel/manage?p_p_id=com_liferay_knowledge_base_web_portlet_AdminPortlet',
+	languageOverride:
+		'/~/control_panel/manage?p_p_id=com_liferay_portal_language_override_web_internal_portlet_PLOPortlet',
 	lockedItems:
 		'/~/control_panel/manage?p_p_id=com_liferay_locked_items_web_internal_portlet_LockedItemsPortlet',
 	masterPages:

--- a/modules/test/playwright/utils/zip.ts
+++ b/modules/test/playwright/utils/zip.ts
@@ -44,3 +44,41 @@ export async function unzipFile(filePath: string): Promise<string> {
 		});
 	});
 }
+
+export async function readFileFromZip(
+	fileName: string,
+	zipFilePath: string
+): Promise<string> {
+	return new Promise((resolve, reject) => {
+		open(zipFilePath, {lazyEntries: true}, (error, zipfile) => {
+			if (error) {
+				return reject(error);
+			}
+
+			zipfile.readEntry();
+
+			zipfile.on('entry', (entry) => {
+				if (entry.fileName.match(fileName)) {
+					zipfile.openReadStream(entry, (error, readStream) => {
+						if (error) {
+							return reject(error);
+						}
+
+						let data = '';
+
+						readStream.on('data', (chunk) => {
+							data += chunk;
+						});
+
+						readStream.on('end', () => {
+							resolve(data);
+						});
+					});
+				}
+				else {
+					zipfile.readEntry();
+				}
+			});
+		});
+	});
+}

--- a/test.properties
+++ b/test.properties
@@ -6983,6 +6983,7 @@ test.batch.run.property.query[functional-orcllinux9-tomcat90-mysql57-jdk8]=\
     playwright.test.project[playwright-js-tomcat90-mysql57-jdk8][platform-experience]=\
         configuration-admin-web,\
         feature-flag-web,\
+        portal-language-override-web,\
         style-book-web
 
     test.batch.class.names.includes[platform-experience]=\


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPD-33373

These tests started failing because now portal starts up with language overrides defined by the Objects functionality. The keys are similar to the ones in the image
![image](https://github.com/user-attachments/assets/1518180a-9382-407c-9335-f701f5ac8a10)

# Tests migration

- `LanguageOverrideExportImport#CanExportMultipleLanguageKeysWithOverride` -> Covered by "LPD-33373 assert that overriden translations can be exported"
- `LanguageOverride#CanFilterOverridesByAnyLanguage` -> Covered by "LPD-33373 assert that overriden translations can be filtered"
-  `LanguageOverride#NoOverrideRelatedInfosDisplayForOOTBLanguageKey` -> Covered by "LPD-33373 assert that default and overriden translations show up when no filters are applied"
- `LanguageOverride#CanFilterLanguageKeysByLocaleViaLanguageSelector` -> Covered by "LPD-33373 assert that overriden translations can be filtered"