### PR TITLE
LPD-35757 Prevent InstanceScoped JS Client Extension from being applied at any other scope

### DIFF
--- a/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/internal/service/taglib/BaseDynamicInclude.java
+++ b/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/internal/service/taglib/BaseDynamicInclude.java
@@ -13,7 +13,6 @@ import com.liferay.client.extension.type.GlobalJSCET;
 import com.liferay.client.extension.type.manager.CETManager;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.content.security.policy.ContentSecurityPolicyNonceProviderUtil;
-import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.json.JSONException;
 import com.liferay.portal.kernel.json.JSONFactory;
@@ -28,7 +27,6 @@ import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
-import com.liferay.portal.vulcan.pagination.Pagination;
 
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -103,9 +101,8 @@ public abstract class BaseDynamicInclude implements DynamicInclude {
 
 		try {
 			List<CET> cets = cetManager.getCETs(
-				themeDisplay.getCompanyId(), null,
-				ClientExtensionEntryConstants.TYPE_GLOBAL_JS,
-				Pagination.of(QueryUtil.ALL_POS, QueryUtil.ALL_POS), null);
+				themeDisplay.getCompanyId(),
+				ClientExtensionEntryConstants.TYPE_GLOBAL_JS);
 
 			for (CET cet : cets) {
 				GlobalJSCET globalJSCET = (GlobalJSCET)cet;

--- a/modules/apps/client-extension/client-extension-type-api/bnd.bnd
+++ b/modules/apps/client-extension/client-extension-type-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Client Extension Type API
 Bundle-SymbolicName: com.liferay.client.extension.type.api
-Bundle-Version: 10.1.0
+Bundle-Version: 11.0.0
 Export-Package:\
 	com.liferay.client.extension.type,\
 	com.liferay.client.extension.type.annotation,\

--- a/modules/apps/client-extension/client-extension-type-api/src/main/java/com/liferay/client/extension/type/manager/CETManager.java
+++ b/modules/apps/client-extension/client-extension-type-api/src/main/java/com/liferay/client/extension/type/manager/CETManager.java
@@ -31,8 +31,16 @@ public interface CETManager {
 	public CET getCET(long companyId, String externalReferenceCode);
 
 	public List<CET> getCETs(
-			long companyId, String keywords, String type, Pagination pagination,
-			Sort sort)
+			long companyId, boolean excludeInstanceScopedCETs, String keywords,
+			String type, Pagination pagination, Sort sort)
+		throws PortalException;
+
+	public List<CET> getCETs(long companyId, String type)
+		throws PortalException;
+
+	public int getCETsCount(
+			long companyId, boolean excludeInstanceCETs, String keywords,
+			String type)
 		throws PortalException;
 
 	public int getCETsCount(long companyId, String keywords, String type)

--- a/modules/apps/client-extension/client-extension-type-api/src/main/resources/com/liferay/client/extension/type/manager/packageinfo
+++ b/modules/apps/client-extension/client-extension-type-api/src/main/resources/com/liferay/client/extension/type/manager/packageinfo
@@ -1,1 +1,1 @@
-version 3.0.0
+version 4.0.0

--- a/modules/apps/client-extension/client-extension-type-impl/src/main/java/com/liferay/client/extension/type/internal/manager/CETManagerImpl.java
+++ b/modules/apps/client-extension/client-extension-type-impl/src/main/java/com/liferay/client/extension/type/internal/manager/CETManagerImpl.java
@@ -5,10 +5,12 @@
 
 package com.liferay.client.extension.type.internal.manager;
 
+import com.liferay.client.extension.constants.ClientExtensionEntryConstants;
 import com.liferay.client.extension.exception.ClientExtensionEntryTypeException;
 import com.liferay.client.extension.model.ClientExtensionEntry;
 import com.liferay.client.extension.service.ClientExtensionEntryLocalService;
 import com.liferay.client.extension.type.CET;
+import com.liferay.client.extension.type.GlobalJSCET;
 import com.liferay.client.extension.type.configuration.CETConfiguration;
 import com.liferay.client.extension.type.deployer.CETDeployer;
 import com.liferay.client.extension.type.factory.CETFactory;
@@ -100,24 +102,43 @@ public class CETManagerImpl implements CETManager {
 
 	@Override
 	public List<CET> getCETs(
-			long companyId, String keywords, String type, Pagination pagination,
-			Sort sort)
+			long companyId, boolean excludeInstanceScopedCETs, String keywords,
+			String type, Pagination pagination, Sort sort)
 		throws PortalException {
 
 		// TODO Sort
 
 		return ListUtil.subList(
-			_getCETs(companyId, keywords, type), pagination.getStartPosition(),
-			pagination.getEndPosition());
+			_getCETs(companyId, excludeInstanceScopedCETs, keywords, type),
+			pagination.getStartPosition(), pagination.getEndPosition());
+	}
+
+	@Override
+	public List<CET> getCETs(long companyId, String type)
+		throws PortalException {
+
+		return getCETs(
+			companyId, false, null, type,
+			Pagination.of(QueryUtil.ALL_POS, QueryUtil.ALL_POS), null);
+	}
+
+	@Override
+	public int getCETsCount(
+			long companyId, boolean excludeInstanceScopedCETs, String keywords,
+			String type)
+		throws PortalException {
+
+		List<CET> cets = _getCETs(
+			companyId, excludeInstanceScopedCETs, keywords, type);
+
+		return cets.size();
 	}
 
 	@Override
 	public int getCETsCount(long companyId, String keywords, String type)
 		throws PortalException {
 
-		List<CET> cets = _getCETs(companyId, keywords, type);
-
-		return cets.size();
+		return getCETsCount(companyId, false, keywords, type);
 	}
 
 	@Deactivate
@@ -144,7 +165,9 @@ public class CETManagerImpl implements CETManager {
 		return string1.contains(string2);
 	}
 
-	private List<CET> _getCETs(long companyId, String keywords, String type)
+	private List<CET> _getCETs(
+			long companyId, boolean excludeInstanceScopedCETs, String keywords,
+			String type)
 		throws PortalException {
 
 		List<CET> cets = new ArrayList<>();
@@ -156,7 +179,9 @@ public class CETManagerImpl implements CETManager {
 			try {
 				CET cet = _cetFactory.create(clientExtensionEntry, true);
 
-				if (_isInclude(cet, keywords, type)) {
+				if (_isInclude(
+						cet, excludeInstanceScopedCETs, keywords, type)) {
+
 					cets.add(cet);
 				}
 			}
@@ -174,7 +199,7 @@ public class CETManagerImpl implements CETManager {
 		for (Map.Entry<String, CET> entry : cetsMap.entrySet()) {
 			CET cet = entry.getValue();
 
-			if (_isInclude(cet, keywords, type)) {
+			if (_isInclude(cet, excludeInstanceScopedCETs, keywords, type)) {
 				cets.add(cet);
 			}
 		}
@@ -209,9 +234,23 @@ public class CETManagerImpl implements CETManager {
 		return serviceRegistrationsMap;
 	}
 
-	private boolean _isInclude(CET cet, String keywords, String type) {
+	private boolean _isInclude(
+		CET cet, boolean excludeInstanceScopedCETs, String keywords,
+		String type) {
+
 		if (Validator.isNotNull(type) && !Objects.equals(type, cet.getType())) {
 			return false;
+		}
+
+		if (excludeInstanceScopedCETs &&
+			Objects.equals(
+				type, ClientExtensionEntryConstants.TYPE_GLOBAL_JS)) {
+
+			GlobalJSCET globalJSCET = (GlobalJSCET)cet;
+
+			if (Objects.equals(globalJSCET.getScope(), "instance")) {
+				return false;
+			}
 		}
 
 		if (Validator.isNotNull(keywords) &&

--- a/modules/apps/client-extension/client-extension-type-item-selector-web/src/main/java/com/liferay/client/extension/type/item/selector/web/internal/item/selector/CETItemSelectorViewDescriptor.java
+++ b/modules/apps/client-extension/client-extension-type-item-selector-web/src/main/java/com/liferay/client/extension/type/item/selector/web/internal/item/selector/CETItemSelectorViewDescriptor.java
@@ -11,13 +11,11 @@ import com.liferay.client.extension.type.item.selector.criterion.CETItemSelector
 import com.liferay.client.extension.type.manager.CETManager;
 import com.liferay.item.selector.ItemSelectorReturnType;
 import com.liferay.item.selector.ItemSelectorViewDescriptor;
-import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.WebKeys;
-import com.liferay.portal.vulcan.pagination.Pagination;
 
 import javax.portlet.PortletRequest;
 import javax.portlet.PortletURL;
@@ -69,9 +67,8 @@ public class CETItemSelectorViewDescriptor
 
 		searchContainer.setResultsAndTotal(
 			_cetManager.getCETs(
-				themeDisplay.getCompanyId(), null,
-				_cetItemSelectorCriterion.getType(),
-				Pagination.of(QueryUtil.ALL_POS, QueryUtil.ALL_POS), null));
+				themeDisplay.getCompanyId(),
+				_cetItemSelectorCriterion.getType()));
 
 		return searchContainer;
 	}

--- a/modules/apps/client-extension/client-extension-type-item-selector-web/src/main/java/com/liferay/client/extension/type/item/selector/web/internal/item/selector/CETItemSelectorViewDescriptor.java
+++ b/modules/apps/client-extension/client-extension-type-item-selector-web/src/main/java/com/liferay/client/extension/type/item/selector/web/internal/item/selector/CETItemSelectorViewDescriptor.java
@@ -11,11 +11,13 @@ import com.liferay.client.extension.type.item.selector.criterion.CETItemSelector
 import com.liferay.client.extension.type.manager.CETManager;
 import com.liferay.item.selector.ItemSelectorReturnType;
 import com.liferay.item.selector.ItemSelectorViewDescriptor;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.vulcan.pagination.Pagination;
 
 import javax.portlet.PortletRequest;
 import javax.portlet.PortletURL;
@@ -67,8 +69,9 @@ public class CETItemSelectorViewDescriptor
 
 		searchContainer.setResultsAndTotal(
 			_cetManager.getCETs(
-				themeDisplay.getCompanyId(),
-				_cetItemSelectorCriterion.getType()));
+				themeDisplay.getCompanyId(), true, null,
+				_cetItemSelectorCriterion.getType(),
+				Pagination.of(QueryUtil.ALL_POS, QueryUtil.ALL_POS), null));
 
 		return searchContainer;
 	}

--- a/modules/apps/client-extension/client-extension-type-test/bnd.bnd
+++ b/modules/apps/client-extension/client-extension-type-test/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Liferay Client Extension Type Test
+Bundle-SymbolicName: com.liferay.client.extension.type.test
+Bundle-Version: 1.0.0

--- a/modules/apps/client-extension/client-extension-type-test/build.gradle
+++ b/modules/apps/client-extension/client-extension-type-test/build.gradle
@@ -1,0 +1,7 @@
+dependencies {
+	testIntegrationImplementation project(":apps:client-extension:client-extension-api")
+	testIntegrationImplementation project(":apps:client-extension:client-extension-type-api")
+	testIntegrationImplementation project(":apps:portal-vulcan:portal-vulcan-api")
+	testIntegrationImplementation project(":apps:static:portal-configuration:portal-configuration-metatype-api")
+	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
+}

--- a/modules/apps/client-extension/client-extension-type-test/src/testIntegration/java/com/liferay/client/extension/type/internal/manager/test/CETManagerTest.java
+++ b/modules/apps/client-extension/client-extension-type-test/src/testIntegration/java/com/liferay/client/extension/type/internal/manager/test/CETManagerTest.java
@@ -1,0 +1,141 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.client.extension.type.internal.manager.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.client.extension.constants.ClientExtensionEntryConstants;
+import com.liferay.client.extension.type.CET;
+import com.liferay.client.extension.type.configuration.CETConfiguration;
+import com.liferay.client.extension.type.manager.CETManager;
+import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.CompanyTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.vulcan.pagination.Pagination;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Thiago Buarque
+ */
+@RunWith(Arquillian.class)
+public class CETManagerTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_company = CompanyTestUtil.addCompany();
+	}
+
+	@Test
+	public void testGetCETs() throws PortalException {
+		CET cet1 = _addGlobalJSCET("instance");
+		CET cet2 = _addGlobalJSCET(null);
+
+		try {
+			List<CET> cets = _cetManager.getCETs(
+				_company.getCompanyId(),
+				ClientExtensionEntryConstants.TYPE_GLOBAL_JS);
+
+			Assert.assertEquals(cets.toString(), 2, cets.size());
+
+			for (CET cet : cets) {
+				String name = cet.getName();
+
+				Assert.assertTrue(
+					Objects.equals(name, cet1.getName()) ||
+					Objects.equals(name, cet2.getName()));
+			}
+
+			cets = _cetManager.getCETs(
+				_company.getCompanyId(), true, null,
+				ClientExtensionEntryConstants.TYPE_GLOBAL_JS,
+				Pagination.of(QueryUtil.ALL_POS, QueryUtil.ALL_POS), null);
+
+			Assert.assertEquals(cets.toString(), 1, cets.size());
+
+			CET cet3 = cets.get(0);
+
+			Assert.assertEquals(cet2.getName(), cet3.getName());
+		}
+		finally {
+			_cetManager.deleteCET(cet1);
+			_cetManager.deleteCET(cet2);
+		}
+	}
+
+	private CET _addCET(String type, String typeSettings)
+		throws PortalException {
+
+		String projectName = RandomTestUtil.randomString();
+
+		CETConfiguration cetConfiguration = ConfigurableUtil.createConfigurable(
+			CETConfiguration.class,
+			HashMapBuilder.<String, Object>put(
+				"baseURL", "${portalURL}/o/" + projectName
+			).put(
+				"name", RandomTestUtil.randomString()
+			).put(
+				"project-id", RandomTestUtil.randomString()
+			).put(
+				"project-name", projectName
+			).put(
+				"properties", new String[0]
+			).put(
+				"service.pid",
+				"com.liferay.client.extension.type.configuration." +
+					"CETConfiguration~" + projectName
+			).put(
+				"type", type
+			).put(
+				"typeSettings", typeSettings
+			).put(
+				"webContextPath", "/" + projectName
+			).build());
+
+		return _cetManager.addCET(
+			cetConfiguration, _company.getCompanyId(),
+			RandomTestUtil.randomString());
+	}
+
+	private CET _addGlobalJSCET(String scope) throws PortalException {
+		StringBuilder typeSettings = new StringBuilder();
+
+		if (Validator.isNotNull(scope)) {
+			typeSettings.append("scope=");
+			typeSettings.append(scope);
+		}
+
+		return _addCET(
+			ClientExtensionEntryConstants.TYPE_GLOBAL_JS,
+			typeSettings.toString());
+	}
+
+	@Inject
+	private CETManager _cetManager;
+
+	private Company _company;
+
+}

--- a/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/frontend/data/set/provider/CETFDSDataProvider.java
+++ b/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/frontend/data/set/provider/CETFDSDataProvider.java
@@ -46,7 +46,8 @@ public class CETFDSDataProvider implements FDSDataProvider<CETFDSEntry> {
 
 		return TransformUtil.transform(
 			_cetManager.getCETs(
-				themeDisplay.getCompanyId(), fdsKeywords.getKeywords(), null,
+				themeDisplay.getCompanyId(), false, fdsKeywords.getKeywords(),
+				null,
 				Pagination.of(
 					fdsPagination.getPage(), fdsPagination.getPageSize()),
 				sort),

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/java/com/liferay/frontend/data/set/admin/web/internal/display/context/FDSAdminDisplayContext.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/java/com/liferay/frontend/data/set/admin/web/internal/display/context/FDSAdminDisplayContext.java
@@ -14,7 +14,6 @@ import com.liferay.frontend.data.set.resolver.FDSAPIURLResolverRegistry;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerList;
-import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
@@ -27,7 +26,6 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.WebKeys;
-import com.liferay.portal.vulcan.pagination.Pagination;
 
 import java.util.Collections;
 import java.util.Comparator;
@@ -86,9 +84,8 @@ public class FDSAdminDisplayContext {
 
 		return JSONUtil.toJSONArray(
 			_cetManager.getCETs(
-				themeDisplay.getCompanyId(), null,
-				ClientExtensionEntryConstants.TYPE_FDS_CELL_RENDERER,
-				Pagination.of(QueryUtil.ALL_POS, QueryUtil.ALL_POS), null),
+				themeDisplay.getCompanyId(),
+				ClientExtensionEntryConstants.TYPE_FDS_CELL_RENDERER),
 			fdsCellRendererCET -> JSONUtil.put(
 				"externalReferenceCode",
 				fdsCellRendererCET.getExternalReferenceCode()
@@ -136,9 +133,8 @@ public class FDSAdminDisplayContext {
 
 		return JSONUtil.toJSONArray(
 			_cetManager.getCETs(
-				themeDisplay.getCompanyId(), null,
-				ClientExtensionEntryConstants.TYPE_FDS_FILTER,
-				Pagination.of(QueryUtil.ALL_POS, QueryUtil.ALL_POS), null),
+				themeDisplay.getCompanyId(),
+				ClientExtensionEntryConstants.TYPE_FDS_FILTER),
 			fdsFilterCET -> JSONUtil.put(
 				"externalReferenceCode", fdsFilterCET.getExternalReferenceCode()
 			).put(

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/filter/CustomizedClientExtensionFDSFilter.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/filter/CustomizedClientExtensionFDSFilter.java
@@ -12,11 +12,9 @@ import com.liferay.frontend.data.set.constants.FDSEntityFieldTypes;
 import com.liferay.frontend.data.set.filter.BaseClientExtensionFDSFilter;
 import com.liferay.frontend.data.set.filter.FDSFilter;
 import com.liferay.frontend.data.set.sample.web.internal.constants.FDSSampleFDSNames;
-import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
-import com.liferay.portal.vulcan.pagination.Pagination;
 
 import java.util.List;
 import java.util.Objects;
@@ -55,9 +53,8 @@ public class CustomizedClientExtensionFDSFilter
 
 		try {
 			List<FDSFilterCET> fdsFilterCETs = (List)_cetManager.getCETs(
-				CompanyThreadLocal.getCompanyId(), null,
-				ClientExtensionEntryConstants.TYPE_FDS_FILTER,
-				Pagination.of(QueryUtil.ALL_POS, QueryUtil.ALL_POS), null);
+				CompanyThreadLocal.getCompanyId(),
+				ClientExtensionEntryConstants.TYPE_FDS_FILTER);
 
 			// Use the UI client extension if available
 

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/view/CustomizedTableFDSView.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/view/CustomizedTableFDSView.java
@@ -14,13 +14,11 @@ import com.liferay.frontend.data.set.view.table.BaseTableFDSView;
 import com.liferay.frontend.data.set.view.table.FDSTableSchema;
 import com.liferay.frontend.data.set.view.table.FDSTableSchemaBuilder;
 import com.liferay.frontend.data.set.view.table.FDSTableSchemaBuilderFactory;
-import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.url.builder.AbsolutePortalURLBuilder;
 import com.liferay.portal.url.builder.AbsolutePortalURLBuilderFactory;
-import com.liferay.portal.vulcan.pagination.Pagination;
 
 import java.util.List;
 import java.util.Locale;
@@ -73,10 +71,8 @@ public class CustomizedTableFDSView extends BaseTableFDSView {
 
 				List<FDSCellRendererCET> fdsCellRendererCETs =
 					(List)_cetManager.getCETs(
-						CompanyThreadLocal.getCompanyId(), null,
-						ClientExtensionEntryConstants.TYPE_FDS_CELL_RENDERER,
-						Pagination.of(QueryUtil.ALL_POS, QueryUtil.ALL_POS),
-						null);
+						CompanyThreadLocal.getCompanyId(),
+						ClientExtensionEntryConstants.TYPE_FDS_CELL_RENDERER);
 
 				// Use the UI client extension if available
 

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
@@ -205,7 +205,6 @@ import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
 import com.liferay.portal.vulcan.multipart.BinaryFile;
 import com.liferay.portal.vulcan.multipart.MultipartBody;
 import com.liferay.portal.vulcan.pagination.Page;
-import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.segments.model.SegmentsEntry;
 import com.liferay.segments.model.SegmentsExperience;
 import com.liferay.segments.service.SegmentsEntryLocalService;
@@ -1561,8 +1560,7 @@ public class BundleSiteInitializer implements SiteInitializer {
 		throws Exception {
 
 		List<CET> cets = _cetManager.getCETs(
-			serviceContext.getCompanyId(), null, null,
-			Pagination.of(QueryUtil.ALL_POS, QueryUtil.ALL_POS), null);
+			serviceContext.getCompanyId(), null);
 
 		for (CET cet : cets) {
 			stringUtilReplaceValues.put(


### PR DESCRIPTION
Task: https://liferay.atlassian.net/browse/LPD-35757
Story: https://liferay.atlassian.net/browse/LPD-35637

## Motivation
There is no benefit of allowing a JS client extension, that is applied to the entire instance, to be applied to the page level. 

## Goal
Hide instance scoped cxs when a user is selecting a globalJS cx to a page.

### Steps to reproduce

1. Deploy a globalJS client extension with instance scope. You can deploy the one in the sample workspace
2. Go to `Site builder > pages > configuration > JavaScript > in page head` and assert that the client extension is not listed there.
3. Enable the feature flag LPD-30371
4. Repeat step 2

Related thread: https://liferay.slack.com/archives/C04A7NLM7L1/p1725471451574919 