### PR TITLE
LPD-35069 - Refactor - Move out bundle tracker code

### DIFF
--- a/modules/apps/frontend-token/frontend-token-definition-impl/src/main/java/com/liferay/frontend/token/definition/internal/FrontendTokenDefinitionRegistryImpl.java
+++ b/modules/apps/frontend-token/frontend-token-definition-impl/src/main/java/com/liferay/frontend/token/definition/internal/FrontendTokenDefinitionRegistryImpl.java
@@ -11,6 +11,7 @@ import com.liferay.client.extension.service.ClientExtensionEntryRelLocalService;
 import com.liferay.client.extension.type.ThemeCSSCET;
 import com.liferay.frontend.token.definition.FrontendTokenDefinition;
 import com.liferay.frontend.token.definition.FrontendTokenDefinitionRegistry;
+import com.liferay.frontend.token.definition.internal.tracker.FrontendTokenDefinitionThemeBundleTracker;
 import com.liferay.frontend.token.definition.internal.validator.FrontendTokenDefinitionJSONValidator;
 import com.liferay.osgi.util.ServiceTrackerFactory;
 import com.liferay.petra.concurrent.DCLSingleton;
@@ -40,14 +41,12 @@ import java.util.regex.Pattern;
 
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
-import org.osgi.framework.BundleEvent;
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.util.tracker.BundleTracker;
-import org.osgi.util.tracker.BundleTrackerCustomizer;
 import org.osgi.util.tracker.ServiceTracker;
 import org.osgi.util.tracker.ServiceTrackerCustomizer;
 
@@ -71,7 +70,8 @@ public class FrontendTokenDefinitionRegistryImpl
 	@Activate
 	protected void activate(BundleContext bundleContext) {
 		_bundleTracker = new BundleTracker<>(
-			bundleContext, Bundle.ACTIVE, _bundleTrackerCustomizer);
+			bundleContext, Bundle.ACTIVE,
+			_frontendTokenDefinitionThemeBundleTracker);
 
 		_serviceTracker = ServiceTrackerFactory.open(
 			bundleContext, ThemeCSSCET.class,
@@ -257,30 +257,24 @@ public class FrontendTokenDefinitionRegistryImpl
 		return clientExtensionEntryRel.getCETExternalReferenceCode();
 	}
 
+	private FrontendTokenDefinition _getClientExtensionFrontendTokenDefinition(
+		long companyId, String externalReferenceCode) {
+
+		Map<String, FrontendTokenDefinition> frontendTokenDefinitions =
+			_getFrontendTokenDefinitions(companyId);
+
+		return frontendTokenDefinitions.get(externalReferenceCode);
+	}
+
 	private FrontendTokenDefinition _getFrontendTokenDefinition(
 		long companyId, String externalReferenceCode, String themeId) {
 
 		if (externalReferenceCode != null) {
-			Map<String, FrontendTokenDefinition> frontendTokenDefinitions =
-				_getFrontendTokenDefinitions(companyId);
-
-			FrontendTokenDefinition frontendTokenDefinition =
-				frontendTokenDefinitions.get(externalReferenceCode);
-
-			if (frontendTokenDefinition != null) {
-				return frontendTokenDefinition;
-			}
+			return _getClientExtensionFrontendTokenDefinition(
+				companyId, externalReferenceCode);
 		}
 
-		Map<String, FrontendTokenDefinitionImpl> frontendTokenDefinitionImpls =
-			_frontendTokenDefinitionImplsDCLSingleton.getSingleton(
-				() -> {
-					_bundleTracker.open();
-
-					return _frontendTokenDefinitionImpls;
-				});
-
-		return frontendTokenDefinitionImpls.get(themeId);
+		return _getThemeFrontendTokenDefinition(themeId);
 	}
 
 	private String _getFrontendTokenDefinitionJSON(Bundle bundle) {
@@ -307,6 +301,21 @@ public class FrontendTokenDefinitionRegistryImpl
 			companyId, new ConcurrentHashMap<>());
 	}
 
+	private FrontendTokenDefinition _getThemeFrontendTokenDefinition(
+		String themeId) {
+
+		Map<String, FrontendTokenDefinitionImpl> frontendTokenDefinitionImpls =
+			_frontendTokenDefinitionImplsDCLSingleton.getSingleton(
+				() -> {
+					_bundleTracker.open();
+
+					return _frontendTokenDefinitionThemeBundleTracker.
+						getFrontendTokenDefinitions();
+				});
+
+		return frontendTokenDefinitionImpls.get(themeId);
+	}
+
 	private void _removedService(ThemeCSSCET themeCSSCET) {
 		Map<String, FrontendTokenDefinition> frontendTokenDefinitions =
 			_getFrontendTokenDefinitions(themeCSSCET.getCompanyId());
@@ -322,53 +331,10 @@ public class FrontendTokenDefinitionRegistryImpl
 
 	private BundleTracker<FrontendTokenDefinitionImpl> _bundleTracker;
 
-	private final BundleTrackerCustomizer<FrontendTokenDefinitionImpl>
-		_bundleTrackerCustomizer =
-			new BundleTrackerCustomizer<FrontendTokenDefinitionImpl>() {
-
-				@Override
-				public FrontendTokenDefinitionImpl addingBundle(
-					Bundle bundle, BundleEvent bundleEvent) {
-
-					FrontendTokenDefinitionImpl frontendTokenDefinitionImpl =
-						getFrontendTokenDefinitionImpl(bundle);
-
-					if ((frontendTokenDefinitionImpl != null) &&
-						(frontendTokenDefinitionImpl.getThemeId() != null)) {
-
-						_frontendTokenDefinitionImpls.put(
-							frontendTokenDefinitionImpl.getThemeId(),
-							frontendTokenDefinitionImpl);
-
-						return frontendTokenDefinitionImpl;
-					}
-
-					return null;
-				}
-
-				@Override
-				public void modifiedBundle(
-					Bundle bundle, BundleEvent bundleEvent,
-					FrontendTokenDefinitionImpl frontendTokenDefinitionImpl) {
-				}
-
-				@Override
-				public void removedBundle(
-					Bundle bundle, BundleEvent bundleEvent,
-					FrontendTokenDefinitionImpl frontendTokenDefinitionImpl) {
-
-					_frontendTokenDefinitionImpls.remove(
-						frontendTokenDefinitionImpl.getThemeId());
-				}
-
-			};
-
 	@Reference
 	private ClientExtensionEntryRelLocalService
 		_clientExtensionEntryRelLocalService;
 
-	private final Map<String, FrontendTokenDefinitionImpl>
-		_frontendTokenDefinitionImpls = new ConcurrentHashMap<>();
 	private final DCLSingleton<Map<String, FrontendTokenDefinitionImpl>>
 		_frontendTokenDefinitionImplsDCLSingleton = new DCLSingleton<>();
 	private final FrontendTokenDefinitionJSONValidator
@@ -376,6 +342,10 @@ public class FrontendTokenDefinitionRegistryImpl
 			new FrontendTokenDefinitionJSONValidator();
 	private final Map<Long, Map<String, FrontendTokenDefinition>>
 		_frontendTokenDefinitionsMap = new ConcurrentHashMap<>();
+
+	@Reference
+	private FrontendTokenDefinitionThemeBundleTracker
+		_frontendTokenDefinitionThemeBundleTracker;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/frontend-token/frontend-token-definition-impl/src/main/java/com/liferay/frontend/token/definition/internal/tracker/FrontendTokenDefinitionThemeBundleTracker.java
+++ b/modules/apps/frontend-token/frontend-token-definition-impl/src/main/java/com/liferay/frontend/token/definition/internal/tracker/FrontendTokenDefinitionThemeBundleTracker.java
@@ -1,0 +1,206 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.frontend.token.definition.internal.tracker;
+
+import com.liferay.frontend.token.definition.internal.FrontendTokenDefinitionImpl;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.json.JSONException;
+import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.PortletConstants;
+import com.liferay.portal.kernel.resource.bundle.ResourceBundleLoader;
+import com.liferay.portal.kernel.resource.bundle.ResourceBundleLoaderUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.URLUtil;
+
+import java.io.IOException;
+
+import java.net.URL;
+
+import java.util.Dictionary;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleEvent;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.util.tracker.BundleTrackerCustomizer;
+
+/**
+ * @author Anderson Luiz
+ */
+@Component(service = FrontendTokenDefinitionThemeBundleTracker.class)
+public class FrontendTokenDefinitionThemeBundleTracker
+	implements BundleTrackerCustomizer<FrontendTokenDefinitionImpl> {
+
+	@Override
+	public FrontendTokenDefinitionImpl addingBundle(
+		Bundle bundle, BundleEvent bundleEvent) {
+
+		FrontendTokenDefinitionImpl frontendTokenDefinitionImpl =
+			_getFrontendTokenDefinitionImpl(bundle);
+
+		if ((frontendTokenDefinitionImpl != null) &&
+			(frontendTokenDefinitionImpl.getThemeId() != null)) {
+
+			_frontendTokenDefinitionImpls.put(
+				frontendTokenDefinitionImpl.getThemeId(),
+				frontendTokenDefinitionImpl);
+
+			return frontendTokenDefinitionImpl;
+		}
+
+		return null;
+	}
+
+	public Map<String, FrontendTokenDefinitionImpl>
+		getFrontendTokenDefinitions() {
+
+		return _frontendTokenDefinitionImpls;
+	}
+
+	@Override
+	public void modifiedBundle(
+		Bundle bundle, BundleEvent bundleEvent,
+		FrontendTokenDefinitionImpl frontendTokenDefinitionImpl) {
+	}
+
+	@Override
+	public void removedBundle(
+		Bundle bundle, BundleEvent bundleEvent,
+		FrontendTokenDefinitionImpl frontendTokenDefinitionImpl) {
+
+		_frontendTokenDefinitionImpls.remove(
+			frontendTokenDefinitionImpl.getThemeId());
+	}
+
+	protected String getServletContextName(Bundle bundle) {
+		Dictionary<String, String> headers = bundle.getHeaders(
+			StringPool.BLANK);
+
+		String webContextPath = headers.get("Web-ContextPath");
+
+		if (webContextPath == null) {
+			return null;
+		}
+
+		if (webContextPath.startsWith(StringPool.SLASH)) {
+			webContextPath = webContextPath.substring(1);
+		}
+
+		return webContextPath;
+	}
+
+	protected String getThemeId(Bundle bundle) {
+		URL url = bundle.getEntry("WEB-INF/liferay-look-and-feel.xml");
+
+		if (url == null) {
+			return null;
+		}
+
+		try {
+			String xml = URLUtil.toString(url);
+
+			xml = xml.replaceAll(StringPool.NEW_LINE, StringPool.SPACE);
+
+			Matcher matcher = _themeIdPattern.matcher(xml);
+
+			if (!matcher.matches()) {
+				return null;
+			}
+
+			String themeId = matcher.group(1);
+
+			String servletContextName = getServletContextName(bundle);
+
+			if (servletContextName != null) {
+				themeId =
+					themeId + PortletConstants.WAR_SEPARATOR +
+						servletContextName;
+			}
+
+			return _portal.getJsSafePortletId(themeId);
+		}
+		catch (IOException ioException) {
+			throw new RuntimeException(
+				"Unable to read WEB-INF/liferay-look-and-feel.xml",
+				ioException);
+		}
+	}
+
+	private String _extractBundleFrontendTokenDefinitionJSON(Bundle bundle) {
+		URL url = bundle.getEntry("WEB-INF/frontend-token-definition.json");
+
+		if (url == null) {
+			return null;
+		}
+
+		try {
+			return URLUtil.toString(url);
+		}
+		catch (IOException ioException) {
+			throw new RuntimeException(
+				"Unable to read WEB-INF/frontend-token-definition.json",
+				ioException);
+		}
+	}
+
+	private FrontendTokenDefinitionImpl _getFrontendTokenDefinitionImpl(
+		Bundle bundle) {
+
+		String json = _extractBundleFrontendTokenDefinitionJSON(bundle);
+
+		if (json == null) {
+			return null;
+		}
+
+		String themeId = getThemeId(bundle);
+
+		try {
+			ResourceBundleLoader resourceBundleLoader =
+				ResourceBundleLoaderUtil.
+					getResourceBundleLoaderByBundleSymbolicName(
+						bundle.getSymbolicName());
+
+			if (resourceBundleLoader == null) {
+				resourceBundleLoader =
+					ResourceBundleLoaderUtil.getPortalResourceBundleLoader();
+			}
+
+			return new FrontendTokenDefinitionImpl(
+				_jsonFactory.createJSONObject(json), _jsonFactory,
+				resourceBundleLoader, themeId);
+		}
+		catch (JSONException | RuntimeException exception) {
+			_log.error(
+				"Unable to parse frontend token definitions for theme " +
+					themeId,
+				exception);
+		}
+
+		return null;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		FrontendTokenDefinitionThemeBundleTracker.class);
+
+	private static final Pattern _themeIdPattern = Pattern.compile(
+		".*<theme id=\"([^\"]*)\"[^>]*>.*");
+
+	private final Map<String, FrontendTokenDefinitionImpl>
+		_frontendTokenDefinitionImpls = new ConcurrentHashMap<>();
+
+	@Reference
+	private JSONFactory _jsonFactory;
+
+	@Reference
+	private Portal _portal;
+
+}

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -976,7 +976,8 @@
         modules/dxp/apps/sharepoint-rest/sharepoint-rest-repository/src/main/java/com/liferay/sharepoint/rest/repository/internal/document/library/repository,\
         modules/extender/internal/resolution/BrowserModulesResolver.java,\
         modules/extender/internal/servlet/JSResolveModulesServlet.java,\
-        modules/extender/npm/NPMResolverProvider.java
+        modules/extender/npm/NPMResolverProvider.java,\
+        modules/apps/frontend-token/frontend-token-definition-impl,
 
     source.check.JavaComponentAnnotationsCheck.allowedUsesInternalServiceClassNames=\
         modules/apps/ai-creator/ai-creator-openai-web,\


### PR DESCRIPTION
Refactor:

- Move out the code responsible to extract a frontend token definition from a theme, for better readability and decoupling. It would also improve testability, enabling us to add unit tests for isolation 