### PR TITLE
LPD-35779 Add functional tests and instance scoped globalJS sample

### DIFF
--- a/modules/test/playwright/tests/client-extension-web/env/client-extensions.list
+++ b/modules/test/playwright/tests/client-extension-web/env/client-extensions.list
@@ -8,6 +8,7 @@ liferay-sample-etc-frontend
 liferay-sample-global-css
 liferay-sample-global-js-1
 liferay-sample-global-js-2
+liferay-sample-global-js-3
 liferay-sample-iframe-1
 liferay-sample-iframe-2
 liferay-sample-js-import-maps-entry

--- a/modules/test/playwright/tests/client-extension-web/js.spec.ts
+++ b/modules/test/playwright/tests/client-extension-web/js.spec.ts
@@ -5,10 +5,12 @@
 
 import {Page, expect, mergeTests} from '@playwright/test';
 
+import {featureFlagsTest} from '../../fixtures/featureFlagsTest';
 import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
 import {localizationSiteSettingsPageTest} from '../../fixtures/localizationSiteSettingsPageTest';
 import {loginTest} from '../../fixtures/loginTest';
 import {pagesAdminPagesTest} from '../../fixtures/pagesAdminPagesTest';
+import {styleBookPageTest} from '../../fixtures/styleBookPageTest';
 import {PagesAdminPage} from '../../pages/layout-admin-web/PagesAdminPage';
 import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
 import getRandomString from '../../utils/getRandomString';
@@ -28,6 +30,11 @@ const SAMPLES = [
 		erc: 'LXC:liferay-sample-global-js-2',
 		name: 'Liferay Sample Global JS 2',
 		url: '/o/liferay-sample-global-js-2/global.a0ff2e4a08889609cd1e.js',
+	},
+	{
+		erc: 'LXC:liferay-sample-global-js-3',
+		name: 'Liferay Sample Global JS 3',
+		url: '/o/liferay-sample-global-js-3/global.8c51c23d2fbc94a8abfa.js',
 	},
 ];
 
@@ -57,6 +64,51 @@ for (const sample of SAMPLES) {
 		}
 	);
 }
+
+export const testInstanceScoped = mergeTests(
+	clientExtensionsPageTest,
+	featureFlagsTest({
+		'LPD-30371': true,
+	}),
+	loginTest(),
+	styleBookPageTest
+);
+
+testInstanceScoped(
+	'Assert that instance scoped client extensions are injected into site pages, site control panel pages and instance control panel pages',
+	async ({clientExtensionsPage, page, styleBooksPage}) => {
+		const scriptLocator = page.locator(
+			`script[src="/o/liferay-sample-global-js-3/global.8c51c23d2fbc94a8abfa.js"]`
+		);
+
+		await testInstanceScoped.step(
+			'Assert that client extension is imported into a site page',
+			async () => {
+				await page.goto('/');
+
+				await expect(scriptLocator).toBeAttached();
+			}
+		);
+
+		await testInstanceScoped.step(
+			"Assert that client extension is imported into an instance's control panel page",
+			async () => {
+				await clientExtensionsPage.goto();
+
+				await expect(scriptLocator).toBeAttached();
+			}
+		);
+
+		await testInstanceScoped.step(
+			"Assert that client extension is imported into a sites's control panel page",
+			async () => {
+				await styleBooksPage.goto();
+
+				await expect(scriptLocator).toBeAttached();
+			}
+		);
+	}
+);
 
 export const test = mergeTests(
 	clientExtensionsPageTest,

--- a/test.properties
+++ b/test.properties
@@ -12147,6 +12147,8 @@ test.batch.run.property.query[functional-orcllinux9-tomcat90-mysql57-jdk8]=\
         liferay-sample-fds-cell-renderer,\
         liferay-sample-global-css,\
         liferay-sample-global-js-1,\
+        liferay-sample-global-js-2,\
+        liferay-sample-global-js-3,\
         liferay-sample-iframe-1,\
         liferay-sample-iframe-2,\
         liferay-sample-theme-css,\

--- a/workspaces/liferay-sample-workspace/README.markdown
+++ b/workspaces/liferay-sample-workspace/README.markdown
@@ -114,6 +114,10 @@ For `liferay-sample-etc-cron` and `liferay-sample-etc-spring-boot` the third typ
 
 	Add a global script element with attributes to a page.
 
+- *liferay-sample-global-js-3*
+
+	Add a global script element to an entire instance.
+
 - *liferay-sample-iframe-1*
 
 	Add an IFrame widget with an interactive counter app.

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-global-js-3/assets/global.js
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-global-js-3/assets/global.js
@@ -1,0 +1,7 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+// eslint-disable-next-line no-console
+console.log('Sample Global JS 3 deployed.');

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-global-js-3/client-extension.yaml
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-global-js-3/client-extension.yaml
@@ -1,0 +1,9 @@
+assemble:
+    - from: build/static
+      into: static
+liferay-sample-global-js-3:
+    name: Liferay Sample Global JS 3
+    scope: "instance"
+    scriptLocation: "head"
+    type: globalJS
+    url: global.*.js

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-global-js-3/package.json
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-global-js-3/package.json
@@ -1,0 +1,12 @@
+{
+	"devDependencies": {
+		"webpack": "5.90.1",
+		"webpack-cli": "5.1.4"
+	},
+	"name": "@liferay/liferay-sample-global-js-3",
+	"private": true,
+	"scripts": {
+		"build": "webpack"
+	},
+	"version": "0.0.0"
+}

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-global-js-3/webpack.config.js
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-global-js-3/webpack.config.js
@@ -1,0 +1,29 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+const path = require('path');
+const webpack = require('webpack');
+
+const DEVELOPMENT = process.env.NODE_ENV === 'development';
+
+module.exports = {
+	devtool: DEVELOPMENT ? 'source-map' : false,
+	entry: {
+		global: './assets/global.js',
+	},
+	mode: DEVELOPMENT ? 'development' : 'production',
+	optimization: {
+		minimize: !DEVELOPMENT,
+	},
+	output: {
+		filename: '[name].[contenthash].js',
+		path: path.resolve('build', 'static'),
+	},
+	plugins: [
+		new webpack.optimize.LimitChunkCountPlugin({
+			maxChunks: 1,
+		}),
+	],
+};


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPD-35779

### Added a new globalJS client extension sample.
That one is not showing up a window alert (as the other two samples) because it would mess up with other tests, since it is applied on every page. So I'm just logging something.

### Test scenario added

Assert that the GlobalJS sample 3 is injected into site pages, instance control panel pages and site control panel pages.

