### PR TITLE
LPD-36917 - CSS Client Extension throws Null Pointer Exception when applied to a page and then removed from Liferay.

### DIFF
--- a/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/internal/service/taglib/ClientExtensionTopHeadDynamicInclude.java
+++ b/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/internal/service/taglib/ClientExtensionTopHeadDynamicInclude.java
@@ -57,6 +57,10 @@ public class ClientExtensionTopHeadDynamicInclude implements DynamicInclude {
 				clientExtensionEntryRel.getCompanyId(),
 				clientExtensionEntryRel.getCETExternalReferenceCode());
 
+			if (globalCSSCET == null) {
+				continue;
+			}
+
 			printWriter.print("<link data-senna-track=\"temporary\" href=\"");
 			printWriter.print(globalCSSCET.getURL());
 			printWriter.print(StringPool.QUOTE);

--- a/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/type/internal/manager/test/CETManagerImplTest.java
+++ b/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/type/internal/manager/test/CETManagerImplTest.java
@@ -1,0 +1,68 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.client.extension.type.internal.manager.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.client.extension.type.manager.CETManager;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LogEntry;
+import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Evan Thibodeau
+ */
+@RunWith(Arquillian.class)
+public class CETManagerImplTest {
+
+	@Test
+	public void testGetCET() throws PortalException {
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				_CLASS_NAME_CET_MANAGER_IMPL, LoggerTestUtil.WARN)) {
+
+			Assert.assertNull(
+				_cetManager.getCET(
+					TestPropsValues.getCompanyId(),
+					_NONEXISTENT_EXTERNAL_REFERENCE_CODE));
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertEquals(logEntries.toString(), 1, logEntries.size());
+
+			LogEntry logEntry = logEntries.get(0);
+
+			Assert.assertEquals(
+				"No CET found for external reference code " +
+					_NONEXISTENT_EXTERNAL_REFERENCE_CODE,
+				logEntry.getMessage());
+		}
+	}
+
+	@Rule
+	public final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	private static final String _CLASS_NAME_CET_MANAGER_IMPL =
+		"com.liferay.client.extension.type.internal.manager.CETManagerImpl";
+
+	private static final String _NONEXISTENT_EXTERNAL_REFERENCE_CODE =
+		"NONEXISTENT_EXTERNAL_REFERENCE_CODE";
+
+	@Inject
+	private CETManager _cetManager;
+
+}

--- a/modules/apps/client-extension/client-extension-type-impl/src/main/java/com/liferay/client/extension/type/internal/manager/CETManagerImpl.java
+++ b/modules/apps/client-extension/client-extension-type-impl/src/main/java/com/liferay/client/extension/type/internal/manager/CETManagerImpl.java
@@ -95,7 +95,17 @@ public class CETManagerImpl implements CETManager {
 
 		Map<String, CET> cetsMap = _getCETsMap(companyId);
 
-		return cetsMap.get(externalReferenceCode);
+		CET cet = cetsMap.get(externalReferenceCode);
+
+		if (cet == null) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"No CET found for external reference code " +
+						externalReferenceCode);
+			}
+		}
+
+		return cet;
 	}
 
 	@Override

--- a/modules/apps/client-extension/client-extension-type-impl/src/main/resources/META-INF/module-log4j.xml
+++ b/modules/apps/client-extension/client-extension-type-impl/src/main/resources/META-INF/module-log4j.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+
+<Configuration strict="true">
+	<Loggers>
+		<Logger level="WARN" name="com.liferay.client.extension.type.internal.manager" />
+	</Loggers>
+</Configuration>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-36917

When a css client extension has been deployed, assigned to a page and then undeployed, a null pointer exception is thrown when the page is loaded. This is because `ClientExtensionTopHeadDynamicInclude.java` does not check if the CET isNotNull prior to printing the link tag. 

In order to match the behavior of other client extensions that can be assigned to pages we should check for null prior to printing the link tag. This is better, but it's not good that we provide no warning to the user that they have a reference to a CET that is currently unavailable. The solution to this is to log a warning whenever CETManager.getCET is called if there is not a CET found. This provides admins some trace in the logs to help them figure out that there could be a problem.

This will need to get sent to @liferay-frontend after being reviewed by our team.