### PR TITLE
LPD-35557 - Rename search function for document library

### DIFF
--- a/modules/test/playwright/pages/document-library-web/DocumentLibraryPage.ts
+++ b/modules/test/playwright/pages/document-library-web/DocumentLibraryPage.ts
@@ -215,7 +215,7 @@ export class DocumentLibraryPage {
 		await this.page.getByRole('button', {name: 'Save'}).click();
 	}
 
-	async searchFor(entryTitle: string) {
+	async search(entryTitle: string) {
 		const dlPortlet = this.page.locator('.portlet-document-library');
 
 		await dlPortlet.getByPlaceholder('Search for').first().fill(entryTitle);
@@ -239,7 +239,7 @@ export class DocumentLibraryPage {
 			.getByRole('checkbox');
 
 		if (await fileEntryCheckbox.isHidden()) {
-			await this.searchFor(entryTitle);
+			await this.search(entryTitle);
 
 			await expect(fileEntryCheckbox).toBeVisible();
 		}

--- a/modules/test/playwright/tests/document-library-web/fileEntry.spec.ts
+++ b/modules/test/playwright/tests/document-library-web/fileEntry.spec.ts
@@ -300,7 +300,7 @@ testSearchInDlPortlet(
 
 		await page.goto('/web' + site.friendlyUrlPath);
 
-		await documentLibraryPage.searchFor(title);
+		await documentLibraryPage.search(title);
 
 		await clickAndExpectToBeVisible({
 			autoClick: true,


### PR DESCRIPTION
This pull request aims to ensure consistent function naming across the Playwright files. Previously, there were instances where `search` was used in some places while `searchFor` was used in others.


