### PR TITLE
LPD-37649 show commerce channel panel entry if there is permission for it

### DIFF
--- a/modules/apps/commerce/commerce-channel-web/src/main/java/com/liferay/commerce/channel/web/internal/application/list/CommerceChannelPanelApp.java
+++ b/modules/apps/commerce/commerce-channel-web/src/main/java/com/liferay/commerce/channel/web/internal/application/list/CommerceChannelPanelApp.java
@@ -9,12 +9,7 @@ import com.liferay.application.list.BasePanelApp;
 import com.liferay.application.list.PanelApp;
 import com.liferay.commerce.application.list.constants.CommercePanelCategoryKeys;
 import com.liferay.commerce.product.constants.CPPortletKeys;
-import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Portlet;
-import com.liferay.portal.kernel.security.permission.ActionKeys;
-import com.liferay.portal.kernel.security.permission.PermissionChecker;
-import com.liferay.portal.kernel.service.permission.PortletPermissionUtil;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -40,15 +35,6 @@ public class CommerceChannelPanelApp extends BasePanelApp {
 	@Override
 	public String getPortletId() {
 		return CPPortletKeys.COMMERCE_CHANNELS;
-	}
-
-	@Override
-	public boolean isShow(PermissionChecker permissionChecker, Group group)
-		throws PortalException {
-
-		return PortletPermissionUtil.contains(
-			permissionChecker, _portlet.getPortletId(),
-			ActionKeys.ACCESS_IN_CONTROL_PANEL);
 	}
 
 	@Reference(

--- a/modules/apps/commerce/commerce-channel-web/src/main/java/com/liferay/commerce/channel/web/internal/application/list/CommerceChannelPanelApp.java
+++ b/modules/apps/commerce/commerce-channel-web/src/main/java/com/liferay/commerce/channel/web/internal/application/list/CommerceChannelPanelApp.java
@@ -9,7 +9,12 @@ import com.liferay.application.list.BasePanelApp;
 import com.liferay.application.list.PanelApp;
 import com.liferay.commerce.application.list.constants.CommercePanelCategoryKeys;
 import com.liferay.commerce.product.constants.CPPortletKeys;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Portlet;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.service.permission.PortletPermissionUtil;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -35,6 +40,15 @@ public class CommerceChannelPanelApp extends BasePanelApp {
 	@Override
 	public String getPortletId() {
 		return CPPortletKeys.COMMERCE_CHANNELS;
+	}
+
+	@Override
+	public boolean isShow(PermissionChecker permissionChecker, Group group)
+		throws PortalException {
+
+		return PortletPermissionUtil.contains(
+			permissionChecker, _portlet.getPortletId(),
+			ActionKeys.ACCESS_IN_CONTROL_PANEL);
 	}
 
 	@Reference(

--- a/modules/apps/commerce/commerce-channel-web/src/main/java/com/liferay/commerce/channel/web/internal/portlet/CommerceChannelControlPanelEntry.java
+++ b/modules/apps/commerce/commerce-channel-web/src/main/java/com/liferay/commerce/channel/web/internal/portlet/CommerceChannelControlPanelEntry.java
@@ -12,8 +12,10 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.portlet.BaseControlPanelEntry;
 import com.liferay.portal.kernel.portlet.ControlPanelEntry;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.resource.PortletResourcePermission;
+import com.liferay.portal.kernel.service.permission.PortletPermissionUtil;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -32,12 +34,18 @@ public class CommerceChannelControlPanelEntry extends BaseControlPanelEntry {
 			PermissionChecker permissionChecker, Group group, Portlet portlet)
 		throws Exception {
 
-		if (super.hasAccessPermission(permissionChecker, group, portlet)) {
+		if (PortletPermissionUtil.contains(
+				permissionChecker, portlet.getPortletId(),
+				ActionKeys.ACCESS_IN_CONTROL_PANEL) &&
+			_portletResourcePermission.contains(
+				permissionChecker, group,
+				CPActionKeys.VIEW_COMMERCE_CHANNELS) &&
+			super.hasAccessPermission(permissionChecker, group, portlet)) {
+
 			return true;
 		}
 
-		return _portletResourcePermission.contains(
-			permissionChecker, group, CPActionKeys.VIEW_COMMERCE_CHANNELS);
+		return false;
 	}
 
 	@Reference(


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPD-37649
## Motivation
When using the left-side flyout Menu, Commerce menu is incorrectly displayed despite not having permissions.

## Proposed Solution

Check permission of commerce channel control panel entry ( override isShow() method).

## Steps to Verify
Follows steps on ticket