### PR TITLE
LPD-38391 Fixes bug with fixed head without background

### DIFF
--- a/modules/apps/frontend-css/frontend-css-cadmin-web/src/main/resources/META-INF/resources/clay_admin.scss
+++ b/modules/apps/frontend-css/frontend-css-cadmin-web/src/main/resources/META-INF/resources/clay_admin.scss
@@ -887,6 +887,7 @@ html#{$cadmin-selector} {
 									sm,
 									$cadmin-grid-breakpoints
 								) {
+									background-color: #fff;
 									left: 0;
 									position: absolute;
 									right: 15px;

--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/taglib/_search_container.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/taglib/_search_container.scss
@@ -57,6 +57,7 @@ $table-responsive-margin-left-md: 375px !default;
 
 					&:first-child {
 						@include media-breakpoint-up(sm) {
+							background-color: #fff;
 							left: 0;
 							position: absolute;
 							right: 15px;


### PR DESCRIPTION
Well, looking at the code, this is not actually a problem in Clay or Cadmin. They had some really strange code to create the fixed head with CSS and JS. The first item in the head does not have a background due to some strange logic they did to make the head have a fixed left margin the size of the table and then they put the first item with an absolute position. It is really confusing and I don't really understand why they did this. I believe this broke the implementation and it didn't come from Clay. I thought about redoing it, but it would take time, so I'm going simpler here and adding the background, which should fix the problem now. Thoughts?

![Screenshot 2024-10-04 at 14 48 04](https://github.com/user-attachments/assets/8699f20c-517b-4ae6-9b19-93cd899a40aa)
