### PR TITLE
LPD-36494 add playwright test to the language client extension

### DIFF
--- a/modules/test/playwright/pages/portal-language-override-web/LanguageOverridePage.ts
+++ b/modules/test/playwright/pages/portal-language-override-web/LanguageOverridePage.ts
@@ -10,9 +10,9 @@ import fillAndClickOutside from '../../utils/fillAndClickOutside';
 import {PORTLET_URLS} from '../../utils/portletUrls';
 import {waitForAlert} from '../../utils/waitForAlert';
 
-export type TTranslation = {
+export type TLanguageKey = {
 	key: string;
-	values: {
+	translations: {
 		languageId: string;
 		value: string;
 	}[];
@@ -36,14 +36,12 @@ export class LanguageOverridePage {
 		this.saveButton = page.getByRole('button', {name: 'Save'});
 	}
 
-	async addTranslation({key, values}: TTranslation) {
+	async addLanguageKey({key, translations}: TLanguageKey) {
 		await this.newButton.click();
 
 		await this.page.getByLabel('key required').fill(key);
 
-		for (let i = 0; i < values.length; i++) {
-			const {languageId, value} = values[i];
-
+		for (const {languageId, value} of translations) {
 			await fillAndClickOutside(
 				this.page,
 				this.page.getByLabel(languageId),
@@ -57,27 +55,27 @@ export class LanguageOverridePage {
 		await waitForAlert(this.page);
 	}
 
-	async addTranslations(languageOverrides: TTranslation[]) {
+	async addLanguageKeys(languageOverrides: TLanguageKey[]) {
 		for (const languageOverride of languageOverrides) {
-			await this.addTranslation(languageOverride);
+			await this.addLanguageKey(languageOverride);
 		}
 	}
 
-	async assertKeyTranslations({key, values}: TTranslation) {
+	async assertLanguageKeyTranslations({key, translations}: TLanguageKey) {
 		await this.page.getByRole('link', {name: key}).click();
 
 		await this.page.waitForLoadState();
 
-		for (const {languageId, value} of values) {
+		for (const {languageId, value} of translations) {
 			const input = this.page.getByLabel(languageId);
 
 			await expect(input).toHaveValue(value);
 		}
 	}
 
-	async assertTranslationInListView({key, values}: TTranslation) {
-		if (values.length) {
-			const normalizedLanguageIds = values.map(({languageId}) =>
+	async assertLanguageKeyInListView({key, translations}: TLanguageKey) {
+		if (translations.length) {
+			const normalizedLanguageIds = translations.map(({languageId}) =>
 				languageId.replace('-', '_')
 			);
 
@@ -94,7 +92,7 @@ export class LanguageOverridePage {
 		}
 	}
 
-	async assertTranslationNotInListView({key}: TTranslation) {
+	async assertLanguageKeyNotInListView({key}: TLanguageKey) {
 		await expect(this.page.getByRole('link', {name: key})).toBeHidden();
 	}
 
@@ -132,7 +130,7 @@ export class LanguageOverridePage {
 		await this.page.goto(`/group/guest${PORTLET_URLS.languageOverride}`);
 	}
 
-	async searchTranslation(key: string) {
+	async searchLanguageKey(key: string) {
 		await fillAndClickOutside(
 			this.page,
 			this.page.getByRole('searchbox'),

--- a/modules/test/playwright/pages/portal-language-override-web/LanguageOverridePage.ts
+++ b/modules/test/playwright/pages/portal-language-override-web/LanguageOverridePage.ts
@@ -63,6 +63,18 @@ export class LanguageOverridePage {
 		}
 	}
 
+	async assertKeyTranslations({key, values}: TTranslation) {
+		await this.page.getByRole('link', {name: key}).click();
+
+		await this.page.waitForLoadState();
+
+		for (const {languageId, value} of values) {
+			const input = this.page.getByLabel(languageId);
+
+			await expect(input).toHaveValue(value);
+		}
+	}
+
 	async assertTranslationInListView({key, values}: TTranslation) {
 		if (values.length) {
 			const normalizedLanguageIds = values.map(({languageId}) =>

--- a/modules/test/playwright/pages/portal-language-override-web/LanguageOverridePage.ts
+++ b/modules/test/playwright/pages/portal-language-override-web/LanguageOverridePage.ts
@@ -61,18 +61,6 @@ export class LanguageOverridePage {
 		}
 	}
 
-	async assertLanguageKeyTranslations({key, translations}: TLanguageKey) {
-		await this.page.getByRole('link', {name: key}).click();
-
-		await this.page.waitForLoadState();
-
-		for (const {languageId, value} of translations) {
-			const input = this.page.getByLabel(languageId);
-
-			await expect(input).toHaveValue(value);
-		}
-	}
-
 	async assertLanguageKeyInListView({key, translations}: TLanguageKey) {
 		if (translations.length) {
 			const normalizedLanguageIds = translations.map(({languageId}) =>
@@ -92,8 +80,20 @@ export class LanguageOverridePage {
 		}
 	}
 
-	async assertLanguageKeyNotInListView({key}: TLanguageKey) {
+    async assertLanguageKeyNotInListView(key: string) {
 		await expect(this.page.getByRole('link', {name: key})).toBeHidden();
+	}
+
+	async assertLanguageKeyTranslations({key, translations}: TLanguageKey) {
+		await this.page.getByRole('link', {name: key}).click();
+
+		await this.page.waitForLoadState();
+
+		for (const {languageId, value} of translations) {
+			const input = this.page.getByLabel(languageId);
+
+			await expect(input).toHaveValue(value);
+		}
 	}
 
 	async changeFilter(option: 'Any Language' | 'Selected Language') {

--- a/modules/test/playwright/pages/portal-language-override-web/LanguageOverridePage.ts
+++ b/modules/test/playwright/pages/portal-language-override-web/LanguageOverridePage.ts
@@ -80,8 +80,12 @@ export class LanguageOverridePage {
 		}
 	}
 
-    async assertLanguageKeyNotInListView(key: string) {
+	async assertLanguageKeyNotInListView(key: string) {
 		await expect(this.page.getByRole('link', {name: key})).toBeHidden();
+	}
+
+	async assertLanguageKeyTranslationIsEmpty(languageId: string) {
+		await expect(this.page.getByLabel(languageId)).toHaveValue('');
 	}
 
 	async assertLanguageKeyTranslations({key, translations}: TLanguageKey) {
@@ -90,9 +94,7 @@ export class LanguageOverridePage {
 		await this.page.waitForLoadState();
 
 		for (const {languageId, value} of translations) {
-			const input = this.page.getByLabel(languageId);
-
-			await expect(input).toHaveValue(value);
+			await expect(this.page.getByLabel(languageId)).toHaveValue(value);
 		}
 	}
 

--- a/modules/test/playwright/tests/client-extension-web/env/client-extensions.list
+++ b/modules/test/playwright/tests/client-extension-web/env/client-extensions.list
@@ -1,4 +1,3 @@
-language
 liferay-sample-custom-element-1
 liferay-sample-custom-element-2
 liferay-sample-custom-element-3
@@ -18,3 +17,4 @@ liferay-sample-theme-css-2
 liferay-sample-theme-favicon
 liferay-sample-theme-spritemap-1
 liferay-sample-theme-spritemap-2
+liferay-sample-workspace/language

--- a/modules/test/playwright/tests/client-extension-web/env/client-extensions.list
+++ b/modules/test/playwright/tests/client-extension-web/env/client-extensions.list
@@ -1,3 +1,4 @@
+language
 liferay-sample-custom-element-1
 liferay-sample-custom-element-2
 liferay-sample-custom-element-3

--- a/modules/test/playwright/tests/client-extension-web/env/portal-ext.properties
+++ b/modules/test/playwright/tests/client-extension-web/env/portal-ext.properties
@@ -1,1 +1,2 @@
+feature.flag.LPD-27222=true
 feature.flag.LPS-186870=true

--- a/modules/test/playwright/tests/client-extension-web/env/portal-ext.properties
+++ b/modules/test/playwright/tests/client-extension-web/env/portal-ext.properties
@@ -1,2 +1,3 @@
 feature.flag.LPD-27222=true
+
 feature.flag.LPS-186870=true

--- a/modules/test/playwright/tests/client-extension-web/language.spec.ts
+++ b/modules/test/playwright/tests/client-extension-web/language.spec.ts
@@ -11,10 +11,10 @@ import {loginTest} from '../../fixtures/loginTest';
 import {TLanguageKey} from '../../pages/portal-language-override-web/LanguageOverridePage';
 
 const test = mergeTests(
-	languageOverridePageTest,
-	featureFlagsTest({
-		'LPD-27222': true,
+    featureFlagsTest({
+        'LPD-27222': true,
 	}),
+    languageOverridePageTest,
 	loginTest()
 );
 
@@ -40,7 +40,7 @@ const EXPECTED_TRANSLATION: TLanguageKey = {
 	],
 };
 
-test('LPD-36494 assert that the language client extension is deployed', async ({
+test('LPD-36494 Assert that the language client extension is deployed', async ({
 	languageOverridePage,
 }) => {
 	await languageOverridePage.goto();

--- a/modules/test/playwright/tests/client-extension-web/language.spec.ts
+++ b/modules/test/playwright/tests/client-extension-web/language.spec.ts
@@ -8,6 +8,7 @@ import {mergeTests} from '@playwright/test';
 import {languageOverridePageTest} from '../../fixtures/LanguageOverridePageTest';
 import {featureFlagsTest} from '../../fixtures/featureFlagsTest';
 import {loginTest} from '../../fixtures/loginTest';
+import {TLanguageKey} from '../../pages/portal-language-override-web/LanguageOverridePage';
 
 const test = mergeTests(
 	languageOverridePageTest,
@@ -17,9 +18,9 @@ const test = mergeTests(
 	loginTest()
 );
 
-const EXPECTED_TRANSLATION = {
+const EXPECTED_TRANSLATION: TLanguageKey = {
 	key: 'do-you-like-to-eat-pizza-with-anchovies',
-	values: [
+	translations: [
 		{
 			languageId: 'de-DE',
 			value: 'Magst du es, Pizza mit Sardellen zu essen?',
@@ -46,11 +47,13 @@ test('LPD-36494 assert that the language client extension is deployed', async ({
 
 	await languageOverridePage.changeFilter('Any Language');
 
-	await languageOverridePage.searchTranslation(EXPECTED_TRANSLATION.key);
+	await languageOverridePage.searchLanguageKey(EXPECTED_TRANSLATION.key);
 
-	await languageOverridePage.assertTranslationInListView(
+	await languageOverridePage.assertLanguageKeyInListView(
 		EXPECTED_TRANSLATION
 	);
 
-	await languageOverridePage.assertKeyTranslations(EXPECTED_TRANSLATION);
+	await languageOverridePage.assertLanguageKeyTranslations(
+		EXPECTED_TRANSLATION
+	);
 });

--- a/modules/test/playwright/tests/client-extension-web/language.spec.ts
+++ b/modules/test/playwright/tests/client-extension-web/language.spec.ts
@@ -1,0 +1,56 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {mergeTests} from '@playwright/test';
+
+import {languageOverridePageTest} from '../../fixtures/LanguageOverridePageTest';
+import {featureFlagsTest} from '../../fixtures/featureFlagsTest';
+import {loginTest} from '../../fixtures/loginTest';
+
+const test = mergeTests(
+	languageOverridePageTest,
+	featureFlagsTest({
+		'LPD-27222': true,
+	}),
+	loginTest()
+);
+
+const EXPECTED_TRANSLATION = {
+	key: 'do-you-like-to-eat-pizza-with-anchovies',
+	values: [
+		{
+			languageId: 'de-DE',
+			value: 'Magst du es, Pizza mit Sardellen zu essen?',
+		},
+		{
+			languageId: 'en-US',
+			value: 'Do you like to eat pizza with anchovies?',
+		},
+		{
+			languageId: 'hu-HU',
+			value: 'Szereted a pizzát szardellával enni?',
+		},
+		{
+			languageId: 'ja-JP',
+			value: 'アンチョビ入りのピザは好きですか？',
+		},
+	],
+};
+
+test('LPD-36494 assert that the language client extension is deployed', async ({
+	languageOverridePage,
+}) => {
+	await languageOverridePage.goto();
+
+	await languageOverridePage.changeFilter('Any Language');
+
+	await languageOverridePage.searchTranslation(EXPECTED_TRANSLATION.key);
+
+	await languageOverridePage.assertTranslationInListView(
+		EXPECTED_TRANSLATION
+	);
+
+	await languageOverridePage.assertKeyTranslations(EXPECTED_TRANSLATION);
+});

--- a/modules/test/playwright/tests/client-extension-web/language.spec.ts
+++ b/modules/test/playwright/tests/client-extension-web/language.spec.ts
@@ -11,14 +11,14 @@ import {loginTest} from '../../fixtures/loginTest';
 import {TLanguageKey} from '../../pages/portal-language-override-web/LanguageOverridePage';
 
 const test = mergeTests(
-    featureFlagsTest({
-        'LPD-27222': true,
+	featureFlagsTest({
+		'LPD-27222': true,
 	}),
-    languageOverridePageTest,
+	languageOverridePageTest,
 	loginTest()
 );
 
-const EXPECTED_TRANSLATION: TLanguageKey = {
+const EXPECTED_LANGUAGE_KEY: TLanguageKey = {
 	key: 'do-you-like-to-eat-pizza-with-anchovies',
 	translations: [
 		{
@@ -47,13 +47,15 @@ test('LPD-36494 Assert that the language client extension is deployed', async ({
 
 	await languageOverridePage.changeFilter('Any Language');
 
-	await languageOverridePage.searchLanguageKey(EXPECTED_TRANSLATION.key);
+	await languageOverridePage.searchLanguageKey(EXPECTED_LANGUAGE_KEY.key);
 
 	await languageOverridePage.assertLanguageKeyInListView(
-		EXPECTED_TRANSLATION
+		EXPECTED_LANGUAGE_KEY
 	);
 
 	await languageOverridePage.assertLanguageKeyTranslations(
-		EXPECTED_TRANSLATION
+		EXPECTED_LANGUAGE_KEY
 	);
+
+	await languageOverridePage.assertLanguageKeyTranslationIsEmpty('es-ES');
 });

--- a/modules/test/playwright/tests/portal-language-override-web/languageOverride.spec.ts
+++ b/modules/test/playwright/tests/portal-language-override-web/languageOverride.spec.ts
@@ -112,7 +112,7 @@ test('LPD-33373 assert that overriden translations can be filtered', async ({
 
 	await languageOverridePage.searchLanguageKey(translation2.key);
 
-	await languageOverridePage.assertLanguageKeyNotInListView(translation2);
+	await languageOverridePage.assertLanguageKeyNotInListView(translation2.key);
 
 	await languageOverridePage.changeFilter('Any Language');
 

--- a/modules/test/playwright/tests/portal-language-override-web/languageOverride.spec.ts
+++ b/modules/test/playwright/tests/portal-language-override-web/languageOverride.spec.ts
@@ -7,7 +7,7 @@ import {expect, mergeTests} from '@playwright/test';
 
 import {languageOverridePageTest} from '../../fixtures/LanguageOverridePageTest';
 import {loginTest} from '../../fixtures/loginTest';
-import {TTranslation} from '../../pages/portal-language-override-web/LanguageOverridePage';
+import {TLanguageKey} from '../../pages/portal-language-override-web/LanguageOverridePage';
 import getRandomString from '../../utils/getRandomString';
 import {readFileFromZip} from '../../utils/zip';
 
@@ -17,10 +17,10 @@ test('LPD-33373 assert that overriden translations can be exported', async ({
 	languageOverridePage,
 	page,
 }) => {
-	const translations: TTranslation[] = [
+	const translations: TLanguageKey[] = [
 		{
 			key: getRandomString(),
-			values: [
+			translations: [
 				{
 					languageId: 'en-US',
 					value: getRandomString(),
@@ -37,7 +37,7 @@ test('LPD-33373 assert that overriden translations can be exported', async ({
 		},
 		{
 			key: getRandomString(),
-			values: [
+			translations: [
 				{
 					languageId: 'en-US',
 					value: getRandomString(),
@@ -48,12 +48,12 @@ test('LPD-33373 assert that overriden translations can be exported', async ({
 
 	await languageOverridePage.goto();
 
-	await languageOverridePage.addTranslations(translations);
+	await languageOverridePage.addLanguageKeys(translations);
 
 	page.on('download', async (download) => {
 		for (const translation of translations) {
-			for (let i = 0; i < translation.values.length; i++) {
-				const {languageId, value} = translation.values[i];
+			for (let i = 0; i < translation.translations.length; i++) {
+				const {languageId, value} = translation.translations[i];
 
 				const fileContent = (await readFileFromZip(
 					`Language_${languageId.replace('-', '_')}.properties`,
@@ -77,7 +77,7 @@ test('LPD-33373 assert that overriden translations can be filtered', async ({
 
 	const translation1 = {
 		key: getRandomString(),
-		values: [
+		translations: [
 			{
 				languageId: 'en-US',
 				value: getRandomString(),
@@ -88,9 +88,9 @@ test('LPD-33373 assert that overriden translations can be filtered', async ({
 			},
 		],
 	};
-	const translation2: TTranslation = {
+	const translation2: TLanguageKey = {
 		key: getRandomString(),
-		values: [
+		translations: [
 			{
 				languageId: 'en-US',
 				value: getRandomString(),
@@ -98,33 +98,33 @@ test('LPD-33373 assert that overriden translations can be filtered', async ({
 		],
 	};
 
-	await languageOverridePage.addTranslation(translation1);
+	await languageOverridePage.addLanguageKey(translation1);
 
-	await languageOverridePage.addTranslation(translation2);
+	await languageOverridePage.addLanguageKey(translation2);
 
 	await languageOverridePage.changeFilter('Selected Language');
 
 	await languageOverridePage.changeLocale('en-US', 'pt-BR');
 
-	await languageOverridePage.searchTranslation(translation1.key);
+	await languageOverridePage.searchLanguageKey(translation1.key);
 
-	await languageOverridePage.assertTranslationInListView(translation1);
+	await languageOverridePage.assertLanguageKeyInListView(translation1);
 
-	await languageOverridePage.searchTranslation(translation2.key);
+	await languageOverridePage.searchLanguageKey(translation2.key);
 
-	await languageOverridePage.assertTranslationNotInListView(translation2);
+	await languageOverridePage.assertLanguageKeyNotInListView(translation2);
 
 	await languageOverridePage.changeFilter('Any Language');
 
 	await languageOverridePage.changeLocale('pt-BR', 'en-US');
 
-	await languageOverridePage.searchTranslation(translation1.key);
+	await languageOverridePage.searchLanguageKey(translation1.key);
 
-	await languageOverridePage.assertTranslationInListView(translation1);
+	await languageOverridePage.assertLanguageKeyInListView(translation1);
 
-	await languageOverridePage.searchTranslation(translation2.key);
+	await languageOverridePage.searchLanguageKey(translation2.key);
 
-	await languageOverridePage.assertTranslationInListView(translation2);
+	await languageOverridePage.assertLanguageKeyInListView(translation2);
 });
 
 test('LPD-33373 assert that default and overriden translations show up when no filters are applied', async ({
@@ -132,9 +132,9 @@ test('LPD-33373 assert that default and overriden translations show up when no f
 }) => {
 	await languageOverridePage.goto();
 
-	const translation: TTranslation = {
+	const translation: TLanguageKey = {
 		key: getRandomString(),
-		values: [
+		translations: [
 			{
 				languageId: 'en-US',
 				value: getRandomString(),
@@ -146,14 +146,14 @@ test('LPD-33373 assert that default and overriden translations show up when no f
 		],
 	};
 
-	await languageOverridePage.addTranslation(translation);
+	await languageOverridePage.addLanguageKey(translation);
 
-	await languageOverridePage.assertTranslationInListView({
+	await languageOverridePage.assertLanguageKeyInListView({
 		key: '0-analytics-cloud-connection',
-		values: [],
+		translations: [],
 	});
 
-	await languageOverridePage.searchTranslation(translation.key);
+	await languageOverridePage.searchLanguageKey(translation.key);
 
-	await languageOverridePage.assertTranslationInListView(translation);
+	await languageOverridePage.assertLanguageKeyInListView(translation);
 });

--- a/workspaces/liferay-sample-workspace/language/Language_de_DE.properties
+++ b/workspaces/liferay-sample-workspace/language/Language_de_DE.properties
@@ -1,0 +1,1 @@
+do-you-like-to-eat-pizza-with-anchovies=Magst du es, Pizza mit Sardellen zu essen?

--- a/workspaces/liferay-sample-workspace/language/Language_es_AR.properties
+++ b/workspaces/liferay-sample-workspace/language/Language_es_AR.properties
@@ -1,1 +1,0 @@
-do-you-like-to-eat-pizza-with-anchovies=¿Te gusta comer pizza con anchoas?

--- a/workspaces/liferay-sample-workspace/language/Language_hu_HU.properties
+++ b/workspaces/liferay-sample-workspace/language/Language_hu_HU.properties
@@ -1,0 +1,1 @@
+do-you-like-to-eat-pizza-with-anchovies=Szereted a pizzát szardellával enni?

--- a/workspaces/liferay-sample-workspace/language/Language_pt_BR.properties
+++ b/workspaces/liferay-sample-workspace/language/Language_pt_BR.properties
@@ -1,1 +1,0 @@
-do-you-like-to-eat-pizza-with-anchovies=Você gosta de comer pizza com anchovas?

--- a/workspaces/liferay-sample-workspace/language/README.markdown
+++ b/workspaces/liferay-sample-workspace/language/README.markdown
@@ -1,6 +1,3 @@
-To import translations into Liferay's Language Override tool, place them into a `[Workspace Root]/language/Language.properties` file using `key=value` syntax and run `../gradlew :buildLang` from the `language` folder. Deploy the translations by running `../gradlew deploy`. Translations with _(Automatic Copy)_ at the end are not imported into Liferay.
+To import translations into Liferay's Language Override tool, place them into a `[Workspace Root]/language/Language.properties` file using `key=value` syntax and run `../gradlew :buildLang` from the `language` folder.
 
-Related documentation:
-
-* [Generating Translations Automatically](https://learn.liferay.com/w/dxp/liferay-development/liferay-internals/extending-liferay/customizing-localization/generating-translations-automatically)
-* [Changing Translations with Language Override](https://learn.liferay.com/w/dxp/system-administration/configuring-liferay/changing-translations-with-language-override)
+Deploy the translations by running `../gradlew deploy`. Translations with _(Automatic Copy)_ at the end are not imported into Liferay.

--- a/workspaces/liferay-sample-workspace/language/README.markdown
+++ b/workspaces/liferay-sample-workspace/language/README.markdown
@@ -1,0 +1,6 @@
+To import translations into Liferay's Language Override tool, place them into a `[Workspace Root]/language/Language.properties` file using `key=value` syntax and run `../gradlew :buildLang` from the `language` folder. Deploy the translations by running `../gradlew deploy`. Translations with _(Automatic Copy)_ at the end are not imported into Liferay.
+
+Related documentation:
+
+* [Generating Translations Automatically](https://learn.liferay.com/w/dxp/liferay-development/liferay-internals/extending-liferay/customizing-localization/generating-translations-automatically)
+* [Changing Translations with Language Override](https://learn.liferay.com/w/dxp/system-administration/configuring-liferay/changing-translations-with-language-override)


### PR DESCRIPTION
[Brian asked](https://github.com/brianchandotcom/liferay-portal/pull/155009#issuecomment-2405637671) to add a playwright test for the language cx and to rewrite the README file.

1. Brian [changed the sample example](https://github.com/brianchandotcom/liferay-portal/commit/3d88785aa6b2b6abef2e3bf4b6560b6c3c11a7e0) by adding three translations: `es_AR`, `ja_JP` and `pt_BR`. The languages es and pt have variations (`es_AR`, `es_ES`, `pt_PT` etc). When the `buildLang` task runs, it identify that `es_AR` and `pt_BR` are variations and copy that value to all variations of that language.

**Example:**

Language_pt_BR.properties
```properties
my-key=Minha chave
```

when I run `buildLang` I will get this file without the _(automatic copy)_ suffix.

Language_pt_PT.properties
```properties
my-key=Minha chave
```

This is a problem because the default instance of Liferay doesn't have `pt_PT` and `es_AR` as languages available by default. So the sample deploy would fail.

2. [As requested](https://github.com/brianchandotcom/liferay-portal/commit/cfd0f7c5721a8f2e5a99b6dedd752cd8f0e2e83a), I made the README file less wordy.