### PR TITLE
LPD-30357 - Update Style Books Import process to handle Token Definition property

### DIFF
--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/model/impl/StyleBookEntryImpl.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/model/impl/StyleBookEntryImpl.java
@@ -55,6 +55,8 @@ public class StyleBookEntryImpl extends StyleBookEntryBaseImpl {
 			"frontendTokensValuesPath", "frontend-tokens-values.json"
 		).put(
 			"name", getName()
+		).put(
+			"themeId", getThemeId()
 		);
 
 		FileEntry previewFileEntry = _getPreviewFileEntry();

--- a/modules/apps/style-book/style-book-web-test/src/testIntegration/java/com/liferay/style/book/web/internal/portlet/action/test/ExportImportStyleBookEntriesMVCResourceCommandTest.java
+++ b/modules/apps/style-book/style-book-web-test/src/testIntegration/java/com/liferay/style/book/web/internal/portlet/action/test/ExportImportStyleBookEntriesMVCResourceCommandTest.java
@@ -117,12 +117,14 @@ public class ExportImportStyleBookEntriesMVCResourceCommandTest {
 			ServiceContextTestUtil.getServiceContext(
 				_sourceGroup, TestPropsValues.getUserId());
 
+		String themeId = RandomTestUtil.randomString();
+
 		StyleBookEntry styleBookEntry =
 			_styleBookEntryLocalService.addStyleBookEntry(
 				null, TestPropsValues.getUserId(), _sourceGroup.getGroupId(),
 				false, _read("frontend-tokens-values.json"),
 				"Style Book Entry Name", "STYLE_BOOK_ENTRY_KEY",
-				RandomTestUtil.randomString(), serviceContext);
+				themeId, serviceContext);
 
 		File file = ReflectionTestUtil.invoke(
 			_exportStyleBookEntriesMVCResourceCommand,
@@ -148,6 +150,8 @@ public class ExportImportStyleBookEntriesMVCResourceCommandTest {
 
 		Assert.assertEquals(
 			"Style Book Entry Name", targetGroupStyleBookEntry.getName());
+		Assert.assertEquals(
+			themeId, targetGroupStyleBookEntry.getThemeId());
 
 		JSONObject expectedFrontendTokensValuesJSONObject =
 			JSONFactoryUtil.createJSONObject(


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPD-30357

## Motivation
Given the the new Token Definition/Stylebook relationship, the import/export should include the reference to the Frontend Token Definition.

## Proposed Solution
Include **themeId** property when import/export