### PR TITLE
LPD-40974 Inconsistent Deprecation Feature Flag Behavior in New Installations

### DIFF
--- a/modules/apps/feature-flag/feature-flag-test/src/testIntegration/java/com/liferay/feature/flag/test/CompanyModelListenerTest.java
+++ b/modules/apps/feature-flag/feature-flag-test/src/testIntegration/java/com/liferay/feature/flag/test/CompanyModelListenerTest.java
@@ -10,15 +10,8 @@ import com.liferay.portal.kernel.feature.flag.FeatureFlag;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManager;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagType;
 import com.liferay.portal.kernel.model.Company;
-import com.liferay.portal.kernel.model.User;
-import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
-import com.liferay.portal.kernel.test.util.RandomTestUtil;
-import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
-import com.liferay.portal.kernel.test.util.TestPropsValues;
-import com.liferay.portal.kernel.test.util.UserTestUtil;
-import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -43,30 +36,15 @@ public class CompanyModelListenerTest {
 
 	@Test
 	public void testOnAfterCreate() throws Exception {
-		String originalName = PrincipalThreadLocal.getName();
+		Company company = CompanyTestUtil.addCompany();
 
-		try {
-			Company company = CompanyTestUtil.addCompany();
+		List<FeatureFlag> deprecationFeatureFlags =
+			_featureFlagManager.getFeatureFlags(
+				company.getCompanyId(),
+				FeatureFlagType.DEPRECATION.getPredicate());
 
-			User user = UserTestUtil.addUser(
-				company.getCompanyId(), TestPropsValues.getUserId(),
-				RandomTestUtil.randomString(), LocaleUtil.getDefault(),
-				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-				new long[0], ServiceContextTestUtil.getServiceContext());
-
-			PrincipalThreadLocal.setName(user.getUserId());
-
-			List<FeatureFlag> deprecationFeatureFlags =
-				_featureFlagManager.getFeatureFlags(
-					company.getCompanyId(),
-					FeatureFlagType.DEPRECATION.getPredicate());
-
-			for (FeatureFlag deprecationFeatureFlag : deprecationFeatureFlags) {
-				Assert.assertFalse(deprecationFeatureFlag.isEnabled());
-			}
-		}
-		finally {
-			PrincipalThreadLocal.setName(originalName);
+		for (FeatureFlag deprecationFeatureFlag : deprecationFeatureFlags) {
+			Assert.assertFalse(deprecationFeatureFlag.isEnabled());
 		}
 	}
 

--- a/modules/apps/feature-flag/feature-flag-web-test/bnd.bnd
+++ b/modules/apps/feature-flag/feature-flag-web-test/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Liferay Feature Flag Web Test
+Bundle-SymbolicName: com.liferay.feature.flag.web.test
+Bundle-Version: 1.0.0

--- a/modules/apps/feature-flag/feature-flag-web-test/build.gradle
+++ b/modules/apps/feature-flag/feature-flag-web-test/build.gradle
@@ -1,0 +1,6 @@
+dependencies {
+	testIntegrationImplementation project(":apps:feature-flag:feature-flag-web")
+	testIntegrationImplementation project(":apps:portal:portal-upgrade-test-util")
+	testIntegrationImplementation project(":apps:static:portal:portal-upgrade-api")
+	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
+}

--- a/modules/apps/feature-flag/feature-flag-web-test/src/testIntegration/java/com/liferay/feature/flag/web/internal/upgrade/v1_0_0/test/FeatureFlagUpgradeProcessTest.java
+++ b/modules/apps/feature-flag/feature-flag-web-test/src/testIntegration/java/com/liferay/feature/flag/web/internal/upgrade/v1_0_0/test/FeatureFlagUpgradeProcessTest.java
@@ -1,0 +1,116 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.feature.flag.web.internal.upgrade.v1_0_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.feature.flag.web.internal.feature.flag.FeatureFlagsBag;
+import com.liferay.feature.flag.web.internal.feature.flag.FeatureFlagsBagProvider;
+import com.liferay.portal.kernel.feature.flag.FeatureFlag;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagType;
+import com.liferay.portal.kernel.feature.flag.constants.FeatureFlagConstants;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.portlet.PortalPreferences;
+import com.liferay.portal.kernel.service.PortalPreferencesLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.CompanyTestUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.PortletKeys;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
+import com.liferay.portlet.PortalPreferencesWrapper;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Thiago Buarque
+ */
+@RunWith(Arquillian.class)
+public class FeatureFlagUpgradeProcessTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testDeprecationFeatureFlagPortalPreference() throws Exception {
+		Company company = CompanyTestUtil.addCompany();
+
+		PortalPreferences portalPreferences = _getPortalPreferences(
+			company.getCompanyId());
+
+		portalPreferences.setValue(
+			FeatureFlagConstants.PREFERENCE_NAMESPACE,
+			FeatureFlagConstants.PREFERENCE_KEY, "false");
+
+		_portalPreferencesLocalService.updatePreferences(
+			company.getCompanyId(), PortletKeys.PREFS_OWNER_TYPE_COMPANY,
+			portalPreferences);
+
+		_runUpgrade();
+
+		FeatureFlagsBag featureFlagsBag =
+			_featureFlagsBagProvider.getOrCreateFeatureFlagsBag(
+				company.getCompanyId());
+
+		List<FeatureFlag> deprecationFeatureFlags =
+			featureFlagsBag.getFeatureFlags(
+				FeatureFlagType.DEPRECATION.getPredicate());
+
+		for (FeatureFlag deprecationFeatureFlag : deprecationFeatureFlags) {
+			Assert.assertFalse(deprecationFeatureFlag.isEnabled());
+		}
+
+		portalPreferences = _getPortalPreferences(company.getCompanyId());
+
+		Assert.assertTrue(
+			GetterUtil.getBoolean(
+				portalPreferences.getValue(
+					FeatureFlagConstants.PREFERENCE_NAMESPACE,
+					FeatureFlagConstants.PREFERENCE_KEY)));
+	}
+
+	private PortalPreferences _getPortalPreferences(long companyId) {
+		PortalPreferencesWrapper portalPreferencesWrapper =
+			(PortalPreferencesWrapper)
+				_portalPreferencesLocalService.getPreferences(
+					companyId, PortletKeys.PREFS_OWNER_TYPE_COMPANY);
+
+		return portalPreferencesWrapper.getPortalPreferencesImpl();
+	}
+
+	private void _runUpgrade() throws Exception {
+		UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
+			_upgradeStepRegistrator, _CLASS_NAME);
+
+		upgradeProcess.upgrade();
+	}
+
+	private static final String _CLASS_NAME =
+		"com.liferay.feature.flag.web.internal.upgrade.v1_0_0." +
+			"FeatureFlagUpgradeProcess";
+
+	@Inject(
+		filter = "(&(component.name=com.liferay.feature.flag.web.internal.upgrade.registry.FeatureFlagUpgradeStepRegistrator))"
+	)
+	private static UpgradeStepRegistrator _upgradeStepRegistrator;
+
+	@Inject
+	private FeatureFlagsBagProvider _featureFlagsBagProvider;
+
+	@Inject
+	private PortalPreferencesLocalService _portalPreferencesLocalService;
+
+}

--- a/modules/apps/feature-flag/feature-flag-web-test/src/testIntegration/java/com/liferay/feature/flag/web/internal/upgrade/v1_0_0/test/FeatureFlagUpgradeProcessTest.java
+++ b/modules/apps/feature-flag/feature-flag-web-test/src/testIntegration/java/com/liferay/feature/flag/web/internal/upgrade/v1_0_0/test/FeatureFlagUpgradeProcessTest.java
@@ -53,7 +53,7 @@ public class FeatureFlagUpgradeProcessTest {
 
 		portalPreferences.setValue(
 			FeatureFlagConstants.PREFERENCE_NAMESPACE,
-			FeatureFlagConstants.PREFERENCE_KEY, "false");
+			FeatureFlagConstants.PREFERENCE_DEPRECATION_PROCESSED_KEY, "false");
 
 		_portalPreferencesLocalService.updatePreferences(
 			company.getCompanyId(), PortletKeys.PREFS_OWNER_TYPE_COMPANY,
@@ -79,7 +79,8 @@ public class FeatureFlagUpgradeProcessTest {
 			GetterUtil.getBoolean(
 				portalPreferences.getValue(
 					FeatureFlagConstants.PREFERENCE_NAMESPACE,
-					FeatureFlagConstants.PREFERENCE_KEY)));
+					FeatureFlagConstants.
+						PREFERENCE_DEPRECATION_PROCESSED_KEY)));
 	}
 
 	private PortalPreferences _getPortalPreferences(long companyId) {

--- a/modules/apps/feature-flag/feature-flag-web/build.gradle
+++ b/modules/apps/feature-flag/feature-flag-web/build.gradle
@@ -17,6 +17,7 @@ dependencies {
 	compileOnly project(":apps:portal:portal-instance-lifecycle-api")
 	compileOnly project(":apps:static:osgi:osgi-util")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
+	compileOnly project(":apps:static:portal:portal-upgrade-api")
 	compileOnly project(":core:osgi-service-tracker-collections")
 	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-lang")

--- a/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/manager/FeatureFlagPreferencesManager.java
+++ b/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/manager/FeatureFlagPreferencesManager.java
@@ -32,7 +32,8 @@ public class FeatureFlagPreferencesManager {
 
 		PortalPreferences portalPreferences = _getPortalPreferences(companyId);
 
-		String value = portalPreferences.getValue(_NAMESPACE, key);
+		String value = portalPreferences.getValue(
+			FeatureFlagConstants.PREFERENCE_NAMESPACE, key);
 
 		if (value == null) {
 			return null;
@@ -44,7 +45,9 @@ public class FeatureFlagPreferencesManager {
 	public void setEnabled(long companyId, String key, boolean enabled) {
 		PortalPreferences portalPreferences = _getPortalPreferences(companyId);
 
-		portalPreferences.setValue(_NAMESPACE, key, String.valueOf(enabled));
+		portalPreferences.setValue(
+			FeatureFlagConstants.PREFERENCE_NAMESPACE, key,
+			String.valueOf(enabled));
 
 		_portalPreferencesLocalService.updatePreferences(
 			companyId, PortletKeys.PREFS_OWNER_TYPE_COMPANY, portalPreferences);
@@ -58,8 +61,6 @@ public class FeatureFlagPreferencesManager {
 
 		return portalPreferencesWrapper.getPortalPreferencesImpl();
 	}
-
-	private static final String _NAMESPACE = FeatureFlagConstants.FEATURE_FLAG;
 
 	@Reference
 	private PortalPreferencesLocalService _portalPreferencesLocalService;

--- a/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/model/listener/CompanyModelListener.java
+++ b/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/model/listener/CompanyModelListener.java
@@ -60,7 +60,7 @@ public class CompanyModelListener extends BaseModelListener<Company> {
 		boolean processed = GetterUtil.getBoolean(
 			portalPreferences.getValue(
 				FeatureFlagConstants.PREFERENCE_NAMESPACE,
-				FeatureFlagConstants.PREFERENCE_KEY));
+				FeatureFlagConstants.PREFERENCE_DEPRECATION_PROCESSED_KEY));
 
 		if (processed) {
 			return;
@@ -80,7 +80,7 @@ public class CompanyModelListener extends BaseModelListener<Company> {
 
 		portalPreferences.setValue(
 			FeatureFlagConstants.PREFERENCE_NAMESPACE,
-			FeatureFlagConstants.PREFERENCE_KEY, "true");
+			FeatureFlagConstants.PREFERENCE_DEPRECATION_PROCESSED_KEY, "true");
 
 		_portalPreferencesLocalService.updatePreferences(
 			companyId, PortletKeys.PREFS_OWNER_TYPE_COMPANY, portalPreferences);

--- a/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/model/listener/CompanyModelListener.java
+++ b/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/model/listener/CompanyModelListener.java
@@ -10,13 +10,20 @@ import com.liferay.feature.flag.web.internal.feature.flag.FeatureFlagsBagProvide
 import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlag;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagType;
+import com.liferay.portal.kernel.feature.flag.constants.FeatureFlagConstants;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.ModelListener;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.portlet.PortalPreferences;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.PortalPreferencesLocalService;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.PortletKeys;
+import com.liferay.portlet.PortalPreferencesWrapper;
 
 import java.util.List;
 
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
@@ -29,29 +36,63 @@ public class CompanyModelListener extends BaseModelListener<Company> {
 
 	@Override
 	public void onAfterCreate(Company company) throws ModelListenerException {
-		TransactionCommitCallbackUtil.registerCallback(
-			() -> {
-				FeatureFlagsBag featureFlagsBag =
-					_featureFlagsBagProvider.getOrCreateFeatureFlagsBag(
-						company.getCompanyId());
+		_processDeprecationFeatureFlags(company.getCompanyId());
+	}
 
-				List<FeatureFlag> deprecationFeatureFlags =
-					featureFlagsBag.getFeatureFlags(
-						FeatureFlagType.DEPRECATION.getPredicate());
+	@Activate
+	protected void activate() {
+		_companyLocalService.forEachCompanyId(
+			this::_processDeprecationFeatureFlags);
+	}
 
-				for (FeatureFlag deprecationFeatureFlag :
-						deprecationFeatureFlags) {
+	private PortalPreferences _getPortalPreferences(long companyId) {
+		PortalPreferencesWrapper portalPreferencesWrapper =
+			(PortalPreferencesWrapper)
+				_portalPreferencesLocalService.getPreferences(
+					companyId, PortletKeys.PREFS_OWNER_TYPE_COMPANY);
 
-					_featureFlagsBagProvider.setEnabled(
-						company.getCompanyId(), deprecationFeatureFlag.getKey(),
-						false);
-				}
+		return portalPreferencesWrapper.getPortalPreferencesImpl();
+	}
 
-				return null;
-			});
+	private void _processDeprecationFeatureFlags(long companyId) {
+		PortalPreferences portalPreferences = _getPortalPreferences(companyId);
+
+		boolean processed = GetterUtil.getBoolean(
+			portalPreferences.getValue(
+				FeatureFlagConstants.PREFERENCE_NAMESPACE,
+				FeatureFlagConstants.PREFERENCE_KEY));
+
+		if (processed) {
+			return;
+		}
+
+		FeatureFlagsBag featureFlagsBag =
+			_featureFlagsBagProvider.getOrCreateFeatureFlagsBag(companyId);
+
+		List<FeatureFlag> deprecationFeatureFlags =
+			featureFlagsBag.getFeatureFlags(
+				FeatureFlagType.DEPRECATION.getPredicate());
+
+		for (FeatureFlag deprecationFeatureFlag : deprecationFeatureFlags) {
+			_featureFlagsBagProvider.setEnabled(
+				companyId, deprecationFeatureFlag.getKey(), false);
+		}
+
+		portalPreferences.setValue(
+			FeatureFlagConstants.PREFERENCE_NAMESPACE,
+			FeatureFlagConstants.PREFERENCE_KEY, "true");
+
+		_portalPreferencesLocalService.updatePreferences(
+			companyId, PortletKeys.PREFS_OWNER_TYPE_COMPANY, portalPreferences);
 	}
 
 	@Reference
+	private CompanyLocalService _companyLocalService;
+
+	@Reference
 	private FeatureFlagsBagProvider _featureFlagsBagProvider;
+
+	@Reference
+	private PortalPreferencesLocalService _portalPreferencesLocalService;
 
 }

--- a/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/model/listener/CompanyModelListener.java
+++ b/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/model/listener/CompanyModelListener.java
@@ -45,17 +45,14 @@ public class CompanyModelListener extends BaseModelListener<Company> {
 			this::_processDeprecationFeatureFlags);
 	}
 
-	private PortalPreferences _getPortalPreferences(long companyId) {
+	private void _processDeprecationFeatureFlags(long companyId) {
 		PortalPreferencesWrapper portalPreferencesWrapper =
 			(PortalPreferencesWrapper)
 				_portalPreferencesLocalService.getPreferences(
 					companyId, PortletKeys.PREFS_OWNER_TYPE_COMPANY);
 
-		return portalPreferencesWrapper.getPortalPreferencesImpl();
-	}
-
-	private void _processDeprecationFeatureFlags(long companyId) {
-		PortalPreferences portalPreferences = _getPortalPreferences(companyId);
+		PortalPreferences portalPreferences =
+			portalPreferencesWrapper.getPortalPreferencesImpl();
 
 		boolean processed = GetterUtil.getBoolean(
 			portalPreferences.getValue(

--- a/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/upgrade/registry/FeatureFlagUpgradeStepRegistrator.java
+++ b/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/upgrade/registry/FeatureFlagUpgradeStepRegistrator.java
@@ -1,0 +1,39 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.feature.flag.web.internal.upgrade.registry;
+
+import com.liferay.feature.flag.web.internal.upgrade.v1_0_0.FeatureFlagUpgradeProcess;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.PortalPreferencesLocalService;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Thiago Buarque
+ */
+@Component(service = UpgradeStepRegistrator.class)
+public class FeatureFlagUpgradeStepRegistrator
+	implements UpgradeStepRegistrator {
+
+	@Override
+	public void register(Registry registry) {
+		registry.registerInitialization();
+
+		registry.register(
+			"0.0.1", "1.0.0",
+			new FeatureFlagUpgradeProcess(
+				_companyLocalService, _portalPreferencesLocalService));
+	}
+
+	@Reference
+	private CompanyLocalService _companyLocalService;
+
+	@Reference
+	private PortalPreferencesLocalService _portalPreferencesLocalService;
+
+}

--- a/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/upgrade/v1_0_0/FeatureFlagUpgradeProcess.java
+++ b/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/upgrade/v1_0_0/FeatureFlagUpgradeProcess.java
@@ -40,7 +40,8 @@ public class FeatureFlagUpgradeProcess extends UpgradeProcess {
 
 				portalPreferences.setValue(
 					FeatureFlagConstants.PREFERENCE_NAMESPACE,
-					FeatureFlagConstants.PREFERENCE_KEY, "true");
+					FeatureFlagConstants.PREFERENCE_DEPRECATION_PROCESSED_KEY,
+					"true");
 
 				_portalPreferencesLocalService.updatePreferences(
 					companyId, PortletKeys.PREFS_OWNER_TYPE_COMPANY,

--- a/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/upgrade/v1_0_0/FeatureFlagUpgradeProcess.java
+++ b/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/upgrade/v1_0_0/FeatureFlagUpgradeProcess.java
@@ -1,0 +1,54 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.feature.flag.web.internal.upgrade.v1_0_0;
+
+import com.liferay.portal.kernel.feature.flag.constants.FeatureFlagConstants;
+import com.liferay.portal.kernel.portlet.PortalPreferences;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.PortalPreferencesLocalService;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.PortletKeys;
+import com.liferay.portlet.PortalPreferencesWrapper;
+
+/**
+ * @author Thiago Buarque
+ */
+public class FeatureFlagUpgradeProcess extends UpgradeProcess {
+
+	public FeatureFlagUpgradeProcess(
+		CompanyLocalService companyLocalService,
+		PortalPreferencesLocalService portalPreferencesLocalService) {
+
+		_companyLocalService = companyLocalService;
+		_portalPreferencesLocalService = portalPreferencesLocalService;
+	}
+
+	@Override
+	protected void doUpgrade() {
+		_companyLocalService.forEachCompanyId(
+			companyId -> {
+				PortalPreferencesWrapper portalPreferencesWrapper =
+					(PortalPreferencesWrapper)
+						_portalPreferencesLocalService.getPreferences(
+							companyId, PortletKeys.PREFS_OWNER_TYPE_COMPANY);
+
+				PortalPreferences portalPreferences =
+					portalPreferencesWrapper.getPortalPreferencesImpl();
+
+				portalPreferences.setValue(
+					FeatureFlagConstants.PREFERENCE_NAMESPACE,
+					FeatureFlagConstants.PREFERENCE_KEY, "true");
+
+				_portalPreferencesLocalService.updatePreferences(
+					companyId, PortletKeys.PREFS_OWNER_TYPE_COMPANY,
+					portalPreferences);
+			});
+	}
+
+	private final CompanyLocalService _companyLocalService;
+	private final PortalPreferencesLocalService _portalPreferencesLocalService;
+
+}

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
@@ -504,6 +504,11 @@ public class PortalUpgradeProcessRegistryImpl
 				}
 
 			});
+
+		upgradeVersionTreeMap.put(
+			new Version(31, 11, 1),
+			UpgradeModulesFactory.create(
+				new String[] {"com.liferay.feature.flag.web"}, null));
 	}
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/feature/flag/constants/FeatureFlagConstants.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/feature/flag/constants/FeatureFlagConstants.java
@@ -17,8 +17,8 @@ public class FeatureFlagConstants {
 
 	public static final String FEATURE_FLAG = "feature.flag";
 
-	public static final String PREFERENCE_KEY =
-		"deprecation.feature.flag.processed";
+	public static final String PREFERENCE_DEPRECATION_PROCESSED_KEY =
+		"deprecation.feature.flags.processed";
 
 	public static final String PREFERENCE_NAMESPACE = FEATURE_FLAG;
 

--- a/portal-kernel/src/com/liferay/portal/kernel/feature/flag/constants/FeatureFlagConstants.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/feature/flag/constants/FeatureFlagConstants.java
@@ -17,6 +17,11 @@ public class FeatureFlagConstants {
 
 	public static final String FEATURE_FLAG = "feature.flag";
 
+	public static final String PREFERENCE_KEY =
+		"deprecation.feature.flag.processed";
+
+	public static final String PREFERENCE_NAMESPACE = FEATURE_FLAG;
+
 	public static String getKey(String... parts) {
 		if (ArrayUtil.isEmpty(parts)) {
 			return FEATURE_FLAG;

--- a/portal-kernel/src/com/liferay/portal/kernel/feature/flag/constants/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/feature/flag/constants/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-40974

# Issue
Our `FeatureFlagsBagProvider` component is now starting after portal is up, which makes the [CompanyModelListener](https://github.com/liferay/liferay-portal/blob/e28af002a4badd99fd6df744074b74845590335f/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/model/listener/CompanyModelListener.java#L93) activate after the default instance is created. 

# Fix
Make the code that disable the deprecation feature flags re-runnable by having a portal preference to mark a company as processed.