### PR TITLE
LPD-33047 Allow style books to be applied to a page based on the frontend token definition applied to the page

### DIFF
--- a/modules/apps/frontend-token/frontend-token-definition-api/bnd.bnd
+++ b/modules/apps/frontend-token/frontend-token-definition-api/bnd.bnd
@@ -1,4 +1,4 @@
 Bundle-Name: Liferay Frontend Token Definition API
 Bundle-SymbolicName: com.liferay.frontend.token.definition.api
-Bundle-Version: 6.0.1
+Bundle-Version: 7.0.0
 Export-Package: com.liferay.frontend.token.definition

--- a/modules/apps/frontend-token/frontend-token-definition-api/src/main/java/com/liferay/frontend/token/definition/FrontendTokenDefinitionRegistry.java
+++ b/modules/apps/frontend-token/frontend-token-definition-api/src/main/java/com/liferay/frontend/token/definition/FrontendTokenDefinitionRegistry.java
@@ -17,6 +17,9 @@ public interface FrontendTokenDefinitionRegistry {
 	public FrontendTokenDefinition getFrontendTokenDefinition(
 		LayoutSet layoutSet);
 
+	public FrontendTokenDefinition getFrontendTokenDefinition(
+		long companyId, long layoutId, String themeId);
+
 	public List<FrontendTokenDefinition> getFrontendTokenDefinitions(
 		long companyId);
 

--- a/modules/apps/frontend-token/frontend-token-definition-api/src/main/resources/com/liferay/frontend/token/definition/packageinfo
+++ b/modules/apps/frontend-token/frontend-token-definition-api/src/main/resources/com/liferay/frontend/token/definition/packageinfo
@@ -1,1 +1,1 @@
-version 6.0.0
+version 7.0.0

--- a/modules/apps/frontend-token/frontend-token-definition-impl/src/main/java/com/liferay/frontend/token/definition/internal/FrontendTokenDefinitionRegistryImpl.java
+++ b/modules/apps/frontend-token/frontend-token-definition-impl/src/main/java/com/liferay/frontend/token/definition/internal/FrontendTokenDefinitionRegistryImpl.java
@@ -71,6 +71,14 @@ public class FrontendTokenDefinitionRegistryImpl
 	}
 
 	@Override
+	public FrontendTokenDefinition getFrontendTokenDefinition(
+		long companyId, long layoutId, String themeId) {
+
+		return _getFrontendTokenDefinition(
+			companyId, _getCETExternalReferenceCode(layoutId), themeId);
+	}
+
+	@Override
 	public List<FrontendTokenDefinition> getFrontendTokenDefinitions(
 		long companyId) {
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
@@ -665,6 +665,12 @@ public class ContentPageEditorDisplayContext {
 			).put(
 				"styleBookEnabled",
 				() -> {
+					if (FeatureFlagManagerUtil.isEnabled(
+							themeDisplay.getCompanyId(), "LPD-30204")) {
+
+						return true;
+					}
+
 					Layout layout = themeDisplay.getLayout();
 
 					Theme theme = layout.getTheme();
@@ -691,6 +697,8 @@ public class ContentPageEditorDisplayContext {
 				"styleBooks", _getStyleBooks()
 			).put(
 				"themeColorsCssClasses", _getThemeColorsCssClasses()
+			).put(
+				"themeName", _getThemeName()
 			).put(
 				"undoUpdateFormConfigURL",
 				getFragmentEntryActionURL(
@@ -1936,6 +1944,12 @@ public class ContentPageEditorDisplayContext {
 			"primary", "success", "danger", "warning", "info", "dark",
 			"gray-dark", "secondary", "light", "lighter", "white"
 		};
+	}
+
+	private String _getThemeName() {
+		Theme theme = themeDisplay.getTheme();
+
+		return theme.getName();
 	}
 
 	private ItemSelectorCriterion _getURLItemSelectorCriterion() {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
@@ -67,6 +67,7 @@ import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.editor.configuration.EditorConfiguration;
 import com.liferay.portal.kernel.editor.configuration.EditorConfigurationFactoryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
@@ -1888,6 +1889,24 @@ public class ContentPageEditorDisplayContext {
 				_staging.getLiveGroupId(themeDisplay.getScopeGroupId()),
 				QueryUtil.ALL_POS, QueryUtil.ALL_POS,
 				StyleBookEntryNameComparator.getInstance(true));
+
+		if (FeatureFlagManagerUtil.isEnabled(
+				themeDisplay.getCompanyId(), "LPD-30204")) {
+
+			FrontendTokenDefinition frontendTokenDefinition =
+				_frontendTokenDefinitionRegistry.getFrontendTokenDefinition(
+					themeDisplay.getCompanyId(),
+					_staging.getLiveGroupId(themeDisplay.getScopeGroupId()),
+					themeDisplay.getThemeId());
+
+			if (frontendTokenDefinition != null) {
+				styleBookEntries = ListUtil.filter(
+					styleBookEntries,
+					styleBookEntry -> Objects.equals(
+						styleBookEntry.getThemeId(),
+						frontendTokenDefinition.getThemeId()));
+			}
+		}
 
 		for (StyleBookEntry styleBookEntry : styleBookEntries) {
 			styleBooks.add(

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page_design_options/components/PageDesignOptionsSidebar.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page_design_options/components/PageDesignOptionsSidebar.js
@@ -198,82 +198,97 @@ const OptionList = ({options = [], icon, type}) => {
 	}
 
 	return (
-		<ul className="list-unstyled mt-4">
-			{options.map(
-				(
-					{imagePreviewURL, isActive, name, onClick, subtitle},
-					index
-				) => (
-					<li key={index}>
-						<ClayCard
-							aria-label={name}
-							className={classNames({
-								'page-editor__sidebar__design-options__tab-card--active':
-									isActive,
-							})}
-							displayType="file"
-							onClick={() => {
-								if (!isActive) {
-									onClick();
-								}
-							}}
-							onKeyDown={(event) => {
-								if (event.key === 'Enter' && !isActive) {
-									onClick();
-								}
-							}}
-							role="button"
-							selectable
-							tabIndex="0"
-						>
-							<ClayCard.AspectRatio
-								className="card-item-first"
-								containerAspectRatio="16/9"
+		<div>
+			{Liferay.FeatureFlags['LPD-30204'] &&
+				type === OPTIONS_TYPES.styleBook &&
+				!!options.length && (
+					<ClayAlert className="mt-3" displayType="info" title="Info">
+						{sub(
+							Liferay.Language.get(
+								'only-style-books-based-on-the-frontend-token-definition-provided-by-x-theme-are-visible'
+							),
+							config.themeName
+						)}
+					</ClayAlert>
+				)}
+
+			<ul className="list-unstyled mt-4">
+				{options.map(
+					(
+						{imagePreviewURL, isActive, name, onClick, subtitle},
+						index
+					) => (
+						<li key={index}>
+							<ClayCard
+								aria-label={name}
+								className={classNames({
+									'page-editor__sidebar__design-options__tab-card--active':
+										isActive,
+								})}
+								displayType="file"
+								onClick={() => {
+									if (!isActive) {
+										onClick();
+									}
+								}}
+								onKeyDown={(event) => {
+									if (event.key === 'Enter' && !isActive) {
+										onClick();
+									}
+								}}
+								role="button"
+								selectable
+								tabIndex="0"
 							>
-								{imagePreviewURL ? (
-									<img
-										alt="thumbnail"
-										className="aspect-ratio-item aspect-ratio-item-center-middle aspect-ratio-item-fluid"
-										src={imagePreviewURL}
-									/>
-								) : (
-									<div className="aspect-ratio-item aspect-ratio-item-center-middle aspect-ratio-item-fluid card-type-asset-icon">
-										<ClayIcon symbol={icon} />
-									</div>
-								)}
+								<ClayCard.AspectRatio
+									className="card-item-first"
+									containerAspectRatio="16/9"
+								>
+									{imagePreviewURL ? (
+										<img
+											alt="thumbnail"
+											className="aspect-ratio-item aspect-ratio-item-center-middle aspect-ratio-item-fluid"
+											src={imagePreviewURL}
+										/>
+									) : (
+										<div className="aspect-ratio-item aspect-ratio-item-center-middle aspect-ratio-item-fluid card-type-asset-icon">
+											<ClayIcon symbol={icon} />
+										</div>
+									)}
 
-								{isActive && (
-									<ClaySticker
-										displayType="primary"
-										position="bottom-left"
-									>
-										<ClayIcon symbol="check-circle" />
-									</ClaySticker>
-								)}
-							</ClayCard.AspectRatio>
+									{isActive && (
+										<ClaySticker
+											displayType="primary"
+											position="bottom-left"
+										>
+											<ClayIcon symbol="check-circle" />
+										</ClaySticker>
+									)}
+								</ClayCard.AspectRatio>
 
-							<ClayCard.Body>
-								<ClayCard.Row>
-									<div className="autofit-col autofit-col-expand">
-										<section className="autofit-section">
-											<ClayCard.Description displayType="title">
-												{name}
-											</ClayCard.Description>
-
-											{subtitle && (
-												<ClayCard.Description displayType="subtitle">
-													{subtitle}
+								<ClayCard.Body>
+									<ClayCard.Row>
+										<div className="autofit-col autofit-col-expand">
+											<section className="autofit-section">
+												<ClayCard.Description displayType="title">
+													{name}
 												</ClayCard.Description>
-											)}
-										</section>
-									</div>
-								</ClayCard.Row>
-							</ClayCard.Body>
-						</ClayCard>
-					</li>
-				)
-			)}
-		</ul>
+
+												{subtitle && (
+													<ClayCard.Description displayType="subtitle">
+														{subtitle}
+													</ClayCard.Description>
+												)}
+											</section>
+										</div>
+									</ClayCard.Row>
+								</ClayCard.Body>
+							</ClayCard>
+						</li>
+					)
+				)}
+			</ul>
+		</div>
 	);
 };
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/test/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContextTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/test/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContextTest.java
@@ -1,0 +1,155 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.content.page.editor.web.internal.display.context;
+
+import com.liferay.exportimport.kernel.staging.Staging;
+import com.liferay.frontend.token.definition.FrontendTokenDefinition;
+import com.liferay.frontend.token.definition.FrontendTokenDefinitionRegistry;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.style.book.model.StyleBookEntry;
+import com.liferay.style.book.service.StyleBookEntryLocalService;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * @author Anderson Luiz
+ */
+public class ContentPageEditorDisplayContextTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@FeatureFlags("LPD-30204")
+	@Test
+	public void testGetStyleBooks() {
+		String themeId = RandomTestUtil.randomString();
+
+		FrontendTokenDefinition frontendTokenDefinition = Mockito.mock(
+			FrontendTokenDefinition.class);
+
+		Mockito.when(
+			frontendTokenDefinition.getThemeId()
+		).thenReturn(
+			themeId
+		);
+
+		FrontendTokenDefinitionRegistry frontendTokenDefinitionRegistry =
+			Mockito.mock(FrontendTokenDefinitionRegistry.class);
+
+		Mockito.when(
+			frontendTokenDefinitionRegistry.getFrontendTokenDefinition(
+				Mockito.anyLong(), Mockito.anyLong(), Mockito.anyString())
+		).thenReturn(
+			frontendTokenDefinition
+		);
+
+		StyleBookEntry styleBookEntry1 = Mockito.mock(StyleBookEntry.class);
+
+		Mockito.when(
+			styleBookEntry1.getThemeId()
+		).thenReturn(
+			RandomTestUtil.randomString()
+		);
+
+		ThemeDisplay themeDisplay = Mockito.mock(ThemeDisplay.class);
+
+		Mockito.when(
+			themeDisplay.getCompanyId()
+		).thenReturn(
+			RandomTestUtil.randomLong()
+		);
+
+		Mockito.when(
+			themeDisplay.getScopeGroupId()
+		).thenReturn(
+			RandomTestUtil.randomLong()
+		);
+
+		Mockito.when(
+			themeDisplay.getThemeId()
+		).thenReturn(
+			RandomTestUtil.randomString()
+		);
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, themeDisplay);
+
+		String name = RandomTestUtil.randomString();
+
+		StyleBookEntry styleBookEntry2 = Mockito.mock(StyleBookEntry.class);
+
+		Mockito.when(
+			styleBookEntry2.getThemeId()
+		).thenReturn(
+			themeId
+		);
+
+		Mockito.when(
+			styleBookEntry2.getName()
+		).thenReturn(
+			name
+		);
+
+		Staging staging = Mockito.mock(Staging.class);
+
+		Mockito.when(
+			staging.getLiveGroupId(Mockito.anyLong())
+		).thenReturn(
+			RandomTestUtil.randomLong()
+		);
+
+		StyleBookEntryLocalService styleBookEntryLocalService = Mockito.mock(
+			StyleBookEntryLocalService.class);
+
+		Mockito.when(
+			styleBookEntryLocalService.getStyleBookEntries(
+				Mockito.anyLong(), Mockito.anyInt(), Mockito.anyInt(),
+				Mockito.any())
+		).thenReturn(
+			ListUtil.fromArray(styleBookEntry1, styleBookEntry2)
+		);
+
+		ContentPageEditorDisplayContext contentPageEditorDisplayContext =
+			new ContentPageEditorDisplayContext(
+				null, null, null, null, null, null,
+				frontendTokenDefinitionRegistry, mockHttpServletRequest, null,
+				null, null, null, null, null, null, null, null, null, null,
+				null, null, null, null, null, null, null, null, null, null,
+				staging, null, styleBookEntryLocalService, null, null);
+
+		List<Map<String, Object>> result = ReflectionTestUtil.invoke(
+			contentPageEditorDisplayContext, "_getStyleBooks", new Class<?>[0]);
+
+		Assert.assertEquals(result.toString(), 1, result.size());
+
+		Map<String, Object> firstEntry = result.get(0);
+
+		Assert.assertEquals(name, firstEntry.get("name"));
+	}
+
+}

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
@@ -12803,6 +12803,7 @@ only-one-sku-can-be-approved=Only one SKU can be approved.
 only-one-value-is-allowed-in-single-selection-mode=Only one value is allowed in "Single" selection mode.
 only-required-in-this-asset-library=Only Required in This Asset Library
 only-show-results-for-web-content-listed-in-a-web-content-display-widget=Only show results for web content listed in a web content display widget.
+only-style-books-based-on-the-frontend-token-definition-provided-by-x-theme-are-visible=Only style books based on the frontend token definition provided by {0} theme are visible.
 only-the-first-tab-will-be-used-when-creating-a-new-entry=Only the first tab will be used when creating a new entry. The remaining Tabs can be accessed while updating the entry.
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Only this event will be modified. The rest of the series will not change.
 only-this-instance=Only This Instance


### PR DESCRIPTION
## Re-sent from #790 

Ticket: https://liferay.atlassian.net/browse/LPD-33047

## Motivation
The user only applies a style book if the theme applied to a page is the same as the one applied to Public Pages. We want the user to be able to assign style books based on different token definitions to different pages of the same site.

## Proposed Solution
It filters the style books based on the frontend token definition applied to the page.
