### PR TITLE
LPD-37518 Add "scope" field to the "GlobalCSSCET" and validate it at build time

### DIFF
--- a/modules/apps/client-extension/client-extension-type-api/bnd.bnd
+++ b/modules/apps/client-extension/client-extension-type-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Client Extension Type API
 Bundle-SymbolicName: com.liferay.client.extension.type.api
-Bundle-Version: 10.2.1
+Bundle-Version: 10.3.0
 Export-Package:\
 	com.liferay.client.extension.type,\
 	com.liferay.client.extension.type.annotation,\

--- a/modules/apps/client-extension/client-extension-type-api/src/main/java/com/liferay/client/extension/type/GlobalCSSCET.java
+++ b/modules/apps/client-extension/client-extension-type-api/src/main/java/com/liferay/client/extension/type/GlobalCSSCET.java
@@ -17,6 +17,11 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface GlobalCSSCET extends CET {
 
+	@CETProperty(
+		defaultValue = "layout", name = "scope", type = CETProperty.Type.String
+	)
+	public String getScope();
+
 	@CETProperty(defaultValue = "", name = "url", type = CETProperty.Type.URL)
 	public String getURL();
 

--- a/modules/apps/client-extension/client-extension-type-api/src/main/resources/com/liferay/client/extension/type/dependencies/client-extension-types.json
+++ b/modules/apps/client-extension/client-extension-type-api/src/main/resources/com/liferay/client/extension/type/dependencies/client-extension-types.json
@@ -252,6 +252,11 @@
 				"type": "CETProperty.Type.String"
 			},
 			{
+				"default": "layout",
+				"name": "scope",
+				"type": "CETProperty.Type.String"
+			},
+			{
 				"default": "https://www.liferay.com",
 				"name": "sourceCodeURL",
 				"type": "CETProperty.Type.String"

--- a/modules/apps/client-extension/client-extension-type-api/src/main/resources/com/liferay/client/extension/type/packageinfo
+++ b/modules/apps/client-extension/client-extension-type-api/src/main/resources/com/liferay/client/extension/type/packageinfo
@@ -1,1 +1,1 @@
-version 5.2.0
+version 5.3.0

--- a/modules/apps/client-extension/client-extension-type-impl/src/main/java/com/liferay/client/extension/type/internal/GlobalCSSCETImpl.java
+++ b/modules/apps/client-extension/client-extension-type-impl/src/main/java/com/liferay/client/extension/type/internal/GlobalCSSCETImpl.java
@@ -35,6 +35,11 @@ public class GlobalCSSCETImpl extends BaseCETImpl implements GlobalCSSCET {
 	}
 
 	@Override
+	public String getScope() {
+		return getString("scope");
+	}
+
+	@Override
 	public String getType() {
 		return ClientExtensionEntryConstants.TYPE_GLOBAL_CSS;
 	}

--- a/modules/apps/client-extension/client-extension-web/src/main/resources/META-INF/resources/admin/view_client_extension_entry.jsp
+++ b/modules/apps/client-extension/client-extension-web/src/main/resources/META-INF/resources/admin/view_client_extension_entry.jsp
@@ -44,7 +44,13 @@ renderResponse.setTitle(viewClientExtensionEntryDisplayContext.getTitle());
 				for (Method method : methods) {
 					CETProperty cetProperty = method.getAnnotation(CETProperty.class);
 					String label = viewClientExtensionEntryDisplayContext.getLabel(method);
+					String name = cetProperty.name();
+					String type = viewClientExtensionEntryDisplayContext.getType();
 					Object value = viewClientExtensionEntryDisplayContext.getValue(method);
+
+					if (!FeatureFlagManagerUtil.isEnabled("LPD-34650") && type.equals(ClientExtensionEntryConstants.TYPE_GLOBAL_CSS) && name.equals("scope")) {
+						continue;
+					}
 				%>
 
 					<c:choose>

--- a/modules/apps/client-extension/client-extension-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/client-extension/client-extension-web/src/main/resources/META-INF/resources/init.jsp
@@ -19,7 +19,8 @@ taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %><%@
 taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
 
-<%@ page import="com.liferay.client.extension.model.ClientExtensionEntry" %><%@
+<%@ page import="com.liferay.client.extension.constants.ClientExtensionEntryConstants" %><%@
+page import="com.liferay.client.extension.model.ClientExtensionEntry" %><%@
 page import="com.liferay.portal.kernel.util.Constants" %>
 
 <liferay-frontend:defineObjects />

--- a/modules/sdk/gradle-plugins-workspace/src/gradleTest/clientExtensionTypeGlobalCSSShouldFail/settings.gradle
+++ b/modules/sdk/gradle-plugins-workspace/src/gradleTest/clientExtensionTypeGlobalCSSShouldFail/settings.gradle
@@ -1,0 +1,7 @@
+buildscript {
+	dependencies {
+		classpath fileTree(dir: pluginClasspathDir, exclude: "biz.aQute.bnd-6.4.0.jar", include: "*.jar")
+	}
+}
+
+apply plugin: "com.liferay.workspace"

--- a/modules/sdk/gradle-plugins-workspace/src/gradleTest/clientExtensionTypeGlobalCSSShouldFail/testWhenScopeIsInvalid.gradle
+++ b/modules/sdk/gradle-plugins-workspace/src/gradleTest/clientExtensionTypeGlobalCSSShouldFail/testWhenScopeIsInvalid.gradle
@@ -1,0 +1,4 @@
+ext.expectedErrorMessage = "Client extension with-invalid-scope-global-css-client-extension has an invalid value \"foo\" for the property \"scope\". Valid values are: company, layout."
+ext.taskPath = ":with-invalid-scope-global-css-client-extension:validateClientExtensions"
+
+apply from: project.property("commonScript.shouldFailTestCase.gradle")

--- a/modules/sdk/gradle-plugins-workspace/src/gradleTest/clientExtensionTypeGlobalCSSShouldFail/with-invalid-scope-global-css-client-extension/client-extension.yaml
+++ b/modules/sdk/gradle-plugins-workspace/src/gradleTest/clientExtensionTypeGlobalCSSShouldFail/with-invalid-scope-global-css-client-extension/client-extension.yaml
@@ -1,0 +1,3 @@
+with-invalid-scope-global-css-client-extension:
+    scope: foo
+    type: globalCSS

--- a/modules/sdk/gradle-plugins-workspace/src/main/java/com/liferay/gradle/plugins/workspace/configurator/ClientExtensionProjectConfigurator.java
+++ b/modules/sdk/gradle-plugins-workspace/src/main/java/com/liferay/gradle/plugins/workspace/configurator/ClientExtensionProjectConfigurator.java
@@ -1198,6 +1198,10 @@ public class ClientExtensionProjectConfigurator
 			_validateRequiredTypeSettingsKeys(
 				clientExtension, "oAuthApplicationHeadlessServer");
 		}
+		else if (Objects.equals(clientExtension.type, "globalCSS")) {
+			_validateTypeSettingsValues(
+				clientExtension, "scope", "company", "layout");
+		}
 		else if (Objects.equals(clientExtension.type, "globalJS")) {
 			_validateGlobalJSScriptElementAttributes(clientExtension);
 			_validateTypeSettingsValues(

--- a/modules/sdk/gradle-plugins-workspace/src/main/resources/schemas/client-extension.schema.json
+++ b/modules/sdk/gradle-plugins-workspace/src/main/resources/schemas/client-extension.schema.json
@@ -209,6 +209,17 @@
 					"allOf": [
 						{
 							"$ref": "#/definitions/propertySets/properties/url"
+						},
+						{
+							"properties": {
+								"scope": {
+									"default": "layout",
+									"enum": [
+										"company",
+										"layout"
+									]
+								}
+							}
 						}
 					],
 					"description": "Description for globalCSS"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-37518

# Goal
Scope the GlobalCSSCET to the instance (company) level

# Approach

- Add the `scope` field to `GlobalCSSCET.java`
- Field validation performed at build time in `ClientExtensionProjectConfigurator.java`
- Put this feature behind the epic’s feature flag https://liferay.atlassian.net/browse/LPD-36701 

# Up next
Next PR will be injecting the GlobalCSSCET into the page. The ticket will be https://liferay.atlassian.net/browse/LPD-37520