### PR TITLE
LPD-43929 Remove test step Then configuration iframe is present

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/usecase/UIInfrastructureUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/usecase/UIInfrastructureUsecase.testcase
@@ -87,15 +87,6 @@ definition {
 			IFrame.selectConfigurationFrame();
 		}
 
-		task ("Then configuration iframe is present") {
-			AssertTextEquals(
-				key_navItem = "Sharing",
-				locator1 = "NavBar#NAV_ITEM_LINK",
-				value1 = "Sharing");
-
-			IFrame.closeFrame();
-		}
-
 		task ("When viewing the Look and Feel configuration") {
 			Navigator.gotoPage(pageName = "Clay Sample Test Page");
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-43929

This failure is caused by https://liferay.atlassian.net/browse/LPD-42400,
 `/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/tabs1.jsp` is no longer outputting the Sharing tab/link. I believe the commits are e76eaa6e647f9cbaa7160231ae34fcf1966c757d..b710fa4eab9a20519d5d4fa0345f9f2e9d36ac74