### PR TITLE
LPD-46190 - Fix failing test for SystemSettings#CheckSystemSettingsScopeIsCorrected

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/administration/portalconfiguration/systemmanagement/SystemSettings.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/administration/portalconfiguration/systemmanagement/SystemSettings.testcase
@@ -375,13 +375,13 @@ definition {
 				portlet = "System Settings");
 		}
 
-		task ("Enable OpenSSO Configuration") {
+		task ("Enable Accessibility Menu Configuration") {
 			SystemSettings.gotoConfiguration(
-				configurationCategory = "SSO",
-				configurationName = "OpenSSO",
-				configurationScope = "System Scope");
+				configurationCategory = "Accessibility",
+				configurationName = "Accessibility Menu",
+				configurationScope = "Site Scope");
 
-			FormFields.enableCheckbox(fieldName = "Enabled");
+			FormFields.enableCheckbox(fieldName = "Enable Accessibility Menu");
 
 			SystemSettings.saveConfiguration();
 		}
@@ -390,13 +390,13 @@ definition {
 			PortalSettings.openInstanceSettingsAdmin();
 		}
 
-		task ("Disable OpenSSO Configuration") {
+		task ("Disable Accessibility Menu Configuration") {
 			SystemSettings.gotoConfiguration(
-				configurationCategory = "SSO",
-				configurationName = "OpenSSO",
-				configurationScope = "Virtual Instance Scope");
+				configurationCategory = "Accessibility",
+				configurationName = "Accessibility Menu",
+				configurationScope = "Site Scope");
 
-			FormFields.disableCheckbox(fieldName = "enabled");
+			FormFields.disableCheckbox(fieldName = "Enable Accessibility Menu");
 
 			SystemSettings.saveConfiguration();
 		}
@@ -408,11 +408,11 @@ definition {
 				portlet = "System Settings");
 
 			SystemSettings.gotoConfiguration(
-				configurationCategory = "SSO",
-				configurationName = "OpenSSO",
-				configurationScope = "System Scope");
+				configurationCategory = "Accessibility",
+				configurationName = "Accessibility Menu",
+				configurationScope = "Site Scope");
 
-			FormFields.viewCheckboxChecked(fieldName = "Enabled");
+			FormFields.viewCheckboxChecked(fieldName = "Enable Accessibility Menu");
 		}
 	}
 


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPD-46190

## Motivation
Poshi test was failing due to using a deprecated OpenSSO item

## Proposed Solution
Modify the component to one that is owned by the team, such as the accessibility menu. This change will facilitate easier tracking of any modifications that occur.
