### PR TITLE
LPD-46548 - Remove enable feature flag and change deprecaetd component

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/layout/stylebooks/StyleBooks.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/layout/stylebooks/StyleBooks.macro
@@ -153,7 +153,7 @@ definition {
 	macro selectStyleBook(styleBookName = null) {
 		SelectFrame(locator1 = "IFrame#MODAL_BODY");
 
-		LexiconCard.clickCardTitle(card = ${styleBookName});
+		LexiconCard.clickCard(card = ${styleBookName});
 
 		SelectFrameTop();
 	}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/stylebooks/staging/StyleBooksWithStaging.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/stylebooks/staging/StyleBooksWithStaging.testcase
@@ -81,7 +81,7 @@ definition {
 				type = "content");
 		}
 
-		task ("Add a Banner Center fragment to page") {
+		task ("Add a heading fragment to page") {
 			ContentPagesNavigator.openEditContentPage(
 				pageName = "Test Page Name",
 				siteName = "Test Site Name Staging");
@@ -155,7 +155,7 @@ definition {
 				value1 = "rgba(0, 255, 0, 1)");
 
 			AssertCssValue(
-				key_content = "Banner Title Example",
+				key_content = "Heading Example",
 				key_element = "h1",
 				key_id = "element-text",
 				key_type = "text",
@@ -225,7 +225,7 @@ definition {
 				value1 = "rgba(11, 95, 255, 1)");
 
 			AssertCssValue(
-				key_content = "Banner Title Example",
+				key_content = "Heading Example",
 				key_element = "h1",
 				key_id = "element-text",
 				key_type = "text",
@@ -335,7 +335,7 @@ definition {
 				value1 = "rgba(0, 255, 0, 1)");
 
 			AssertCssValue(
-				key_content = "Banner Title Example",
+				key_content = "Heading Example",
 				key_element = "h1",
 				key_id = "element-text",
 				key_type = "text",
@@ -391,7 +391,7 @@ definition {
 				value1 = "rgba(11, 95, 255, 1)");
 
 			AssertCssValue(
-				key_content = "Banner Title Example",
+				key_content = "Heading Example",
 				key_element = "h1",
 				key_id = "element-text",
 				key_type = "text",
@@ -594,7 +594,7 @@ definition {
 				type = "content");
 		}
 
-		task ("Add a Banner Center to page") {
+		task ("Add a Heading to page") {
 			ContentPagesNavigator.openEditContentPage(
 				pageName = "Test Page Name",
 				siteName = "Test Site Name Staging");
@@ -632,7 +632,7 @@ definition {
 				value1 = "rgba(255, 0, 0, 1)");
 
 			AssertCssValue(
-				key_content = "Banner Title Example",
+				key_content = "Heading Example",
 				key_element = "h1",
 				key_id = "element-text",
 				key_type = "text",
@@ -694,7 +694,7 @@ definition {
 				type = "content");
 		}
 
-		task ("Add a Banner Center to page") {
+		task ("Add a Basic Components to page") {
 			ContentPagesNavigator.openEditContentPage(
 				pageName = "Test Page Name",
 				siteName = "Test Site Name Staging");
@@ -754,7 +754,7 @@ definition {
 				value1 = "rgba(0, 255, 0, 1)");
 
 			AssertCssValue(
-				key_content = "Banner Title Example",
+				key_content = "Heading Example",
 				key_element = "h1",
 				key_id = "element-text",
 				key_type = "text",
@@ -784,7 +784,7 @@ definition {
 				value1 = "rgba(0, 255, 0, 1)");
 
 			AssertCssValue(
-				key_content = "Banner Title Example",
+				key_content = "Heading Example",
 				key_element = "h1",
 				key_id = "element-text",
 				key_type = "text",
@@ -847,7 +847,7 @@ definition {
 				value1 = "rgba(255, 0, 0, 1)");
 
 			AssertCssValue(
-				key_content = "Banner Title Example",
+				key_content = "Heading Example",
 				key_element = "h1",
 				key_id = "element-text",
 				key_type = "text",


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPD-46548

## Motivation
We were having these test failures:

> java.lang.Exception: TEST_SETUP_ERROR: Element is not present at "//*[contains(@class,'list-group')]//*[@class='list-group-card-item-text' and normalize-space(./text())='Feature Flags']"

## Proposed Solution
Removed the test associated with a feature flag that is no longer in use and replaced the deprecated component previously displayed by the feature flag.

