### PR TITLE
LPD-46550 - Fix failing test on poshi

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/controlmenu/ControlMenuWithPermissions.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/controlmenu/ControlMenuWithPermissions.testcase
@@ -77,6 +77,8 @@ definition {
 			Check.checkToggleSwitch(
 				checkboxName = "Show Control Menu by Role",
 				locator1 = "Checkbox#ANY_CHECKBOX");
+
+			PortletEntry.save();
 		}
 
 		task ("When the site administrator selects new role to see control menu") {
@@ -155,6 +157,8 @@ definition {
 			Check.checkToggleSwitch(
 				checkboxName = "Show Control Menu by Role",
 				locator1 = "Checkbox#ANY_CHECKBOX");
+
+			PortletEntry.save();
 		}
 
 		task ("Then the site administrator cannot remove Administrator and Site Administrator from Roles that can see the control menu") {

--- a/test.properties
+++ b/test.properties
@@ -6104,7 +6104,8 @@
         **/portal-instances/**/*Test.java,\
         **/portal-language-override-test/**/*Test.java,\
         **/product-navigation/**/*Test.java,\
-        **/style-book/**/*Test.java
+        **/style-book/**/*Test.java\
+        /portal-web/tests/enduser/wem/controlmenu/**/*Test.java,\
 
     test.batch.dist.app.servers[platform-experience]=tomcat
 


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPD-46550

## Motivation
Test failing on [ControlMenuWithPermissions#ShowControlMenuByNewRole](https://testray.liferay.com/#/project/35392/routines/82964/build/112474738/case-result/112577116) and [ControlMenuWithPermissions#ShowControlMenuByOOTBRoles](https://testray.liferay.com/#/project/35392/routines/82964/build/112474738/case-result/112512332)

## Proposed Solution
The select button to open the modal is disabled until the checkbox is updated. The solution was to add a new click on save 