### PR TITLE
LPD-47645 Do not grant control menu acess automatically when role created

### DIFF
--- a/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/model/listener/RoleModelListener.java
+++ b/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/model/listener/RoleModelListener.java
@@ -24,21 +24,6 @@ import org.osgi.service.component.annotations.Reference;
 public class RoleModelListener extends BaseModelListener<Role> {
 
 	@Override
-	public void onAfterCreate(Role role) throws ModelListenerException {
-		if ((role.getType() == RoleConstants.TYPE_REGULAR) ||
-			(role.getType() == RoleConstants.TYPE_SITE)) {
-
-			try {
-				_menuAccessConfigurationManager.addAccessRoleToControlMenu(
-					role);
-			}
-			catch (Exception exception) {
-				_log.error(exception);
-			}
-		}
-	}
-
-	@Override
 	public void onAfterRemove(Role role) throws ModelListenerException {
 		if ((role.getType() == RoleConstants.TYPE_REGULAR) ||
 			(role.getType() == RoleConstants.TYPE_SITE)) {

--- a/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/internal/model/listener/test/RoleModelListenerTest.java
+++ b/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/internal/model/listener/test/RoleModelListenerTest.java
@@ -99,34 +99,28 @@ public class RoleModelListenerTest {
 
 	@Test
 	public void testAddRole() throws Exception {
-		Role role = _roleLocalService.addRole(
+		_roleLocalService.addRole(
 			RandomTestUtil.randomString(), TestPropsValues.getUserId(), null, 0,
 			StringUtil.randomString(), null, null, RoleConstants.TYPE_SITE,
 			null, _serviceContext);
 
-		_assertConfiguration(new String[] {String.valueOf(role.getRoleId())});
+		_assertConfiguration(new String[0]);
 	}
 
 	@Test
 	public void testDeleteRole() throws Exception {
-		Role role1 = _roleLocalService.addRole(
+		Role role = _roleLocalService.addRole(
 			RandomTestUtil.randomString(), TestPropsValues.getUserId(), null, 0,
 			StringUtil.randomString(), null, null, RoleConstants.TYPE_REGULAR,
 			null, _serviceContext);
-		Role role2 = _roleLocalService.addRole(
-			RandomTestUtil.randomString(), TestPropsValues.getUserId(), null, 0,
-			StringUtil.randomString(), null, null, RoleConstants.TYPE_SITE,
-			null, _serviceContext);
 
-		_assertConfiguration(
-			new String[] {
-				String.valueOf(role1.getRoleId()),
-				String.valueOf(role2.getRoleId())
-			});
+		_menuAccessConfigurationManager.addAccessRoleToControlMenu(role);
 
-		_roleLocalService.deleteRole(role1);
+		_assertConfiguration(new String[] {String.valueOf(role.getRoleId())});
 
-		_assertConfiguration(new String[] {String.valueOf(role2.getRoleId())});
+		_roleLocalService.deleteRole(role);
+
+		_assertConfiguration(new String[0]);
 	}
 
 	private void _assertConfiguration(String[] expectedRolesCanSeeControlMenu)


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPD-47645

## Motivation
We will enhance the user experience of the “Show Control Menu by Role” feature, as its current behaviour is both unintuitive and causing performance issues.

To address this, new roles will no longer be automatically added to the list of roles that can see the Control Menu. Instead, administrators will need to assign access manually as needed.

## Proposed Solution
Remove RoleModelListener class

## Steps to Verify

1. Navigate to Site Settings > Site Configuration > Menu Access. 
2. Enable Show Control Menu by Role and save the configuration.
3. Navigate to Control Panel > Roles.
4. Add a new Regular Role.
5. Return to Site Settings > Site Configuration > Menu Access.

**Current behavior:** The new role has been added to the list of roles that can see the Control Menu.
**Expected behavior**: The new role has not been automatically added to the list of roles that can see the Control Menu. Administrator will have to manually add.