### PR TITLE
LPD-48104 - Button Not Readable in Dialect Theme

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-dialect/src/css/dialect/variables/_buttons.scss
+++ b/modules/apps/frontend-theme/frontend-theme-dialect/src/css/dialect/variables/_buttons.scss
@@ -37,7 +37,9 @@ $btn-disabled-opacity: 1;
 $inline-item-spacer-x: var(--btn-inline-item-spacer-x);
 
 $btn: (
+	--btn-active-color: $white,
 	--btn-default-border-color: transparent,
+	--btn-default-color: $white,
 	active: (
 		background-color:
 			var(
@@ -121,5 +123,57 @@ $btn-link: (
 	),
 	disabled: (
 		color: var(--color-action-primary-disabled),
+	),
+);
+
+$btn-danger: (
+	active: (
+		color: c-unset,
+	),
+	color: c-unset,
+	focus: (
+		color: c-unset,
+	),
+	hover: (
+		color: c-unset,
+	),
+);
+
+$btn-info: (
+	active: (
+		color: c-unset,
+	),
+	color: c-unset,
+	focus: (
+		color: c-unset,
+	),
+	hover: (
+		color: c-unset,
+	),
+);
+
+$btn-success: (
+	active: (
+		color: c-unset,
+	),
+	color: c-unset,
+	focus: (
+		color: c-unset,
+	),
+	hover: (
+		color: c-unset,
+	),
+);
+
+$btn-warning: (
+	active: (
+		color: c-unset,
+	),
+	color: c-unset,
+	focus: (
+		color: c-unset,
+	),
+	hover: (
+		color: c-unset,
 	),
 );


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPD-48104

## Motivation
On dialect theme, button variants were not readable

## Proposed Solution
Dialect is setting `$danger: var(--color-state-error);` in Clay we use the function `color-yiq($danger)`  (color-yiq gives the inverse color) for the button color. Sass doesn't know what `--color-state-error` is so we return the variable.
Adding the variant variables on dialect solves the issue.


## Steps to Verify
See steps on [LPP ticket](https://liferay.atlassian.net/browse/LPP-57594)

## Screenshots/videos
![image](https://github.com/user-attachments/assets/42508130-426a-44cd-849e-8253daa23a11)
