### PR TITLE
LPD-48216 Revert "LPS-171957 Show the portlet title if the state is max"

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/theme/PortletDisplay.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/theme/PortletDisplay.java
@@ -10,7 +10,6 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Layout;
-import com.liferay.portal.kernel.model.LayoutTypePortlet;
 import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIconMenu;
 import com.liferay.portal.kernel.portlet.toolbar.PortletToolbar;
 import com.liferay.portal.kernel.util.Constants;
@@ -463,15 +462,7 @@ public class PortletDisplay implements Cloneable, Serializable {
 
 		Layout layout = _themeDisplay.getLayout();
 
-		LayoutTypePortlet layoutTypePortlet =
-			_themeDisplay.getLayoutTypePortlet();
-
-		HttpServletRequest httpServletRequest = _themeDisplay.getRequest();
-
-		String ppid = ParamUtil.getString(httpServletRequest, "p_p_id");
-
-		if ((!layoutTypePortlet.hasStateMax() || Validator.isNull(ppid)) &&
-			Validator.isNull(portletSetupPortletDecoratorId) &&
+		if (Validator.isNull(portletSetupPortletDecoratorId) &&
 			(layout.isTypeAssetDisplay() || layout.isTypeContent())) {
 
 			return false;


### PR DESCRIPTION
This reverts commit 80b5425932a8e7286f8dea9f919bdf8b234c3873.
**Ticket**: https://liferay.atlassian.net/browse/LPD-48216

Hello Team,

I would like your review of this issue related to a Fire customer ticket https://liferay.atlassian.net/browse/LPP-57481. Also  related is https://liferay.atlassian.net/browse/PTR-6072.

## Motivation
Very simply, when Master Pages are used with a portlet in a maximized state, the portlet's name is always displayed. This is causing issue because in the customer's case is completely obfuscates the portlet itself.

I believe maximized portlets shouldn’t cause this behavior in general both because the portlet title is generally undesirable and also because there is no way to control this behavior. [Eudaldo agreed with this assessment as well on the PTR](https://liferay.atlassian.net/browse/PTR-6072?focusedCommentId=2840452).

The behavior originated with https://liferay.atlassian.net/browse/LPS-171957 and was specifically implemented in the reverted commit.

## Proposed Solution
Revert the logic that automatically displays portlet names when a portlet is maximized.

**Reproduction Steps**:
1. Create a Page Template
2. Add a Search Bar and a Language Selector Widget to the Page
3. Publish the Template
4. Create a new Page using the Template
5. Add a Search Results widget to the page
6. Publish the page
7. Create a Web Content article
8. Search for the Web Content article by typing in the Search Bar then selecting the suggestion that pops up.
**Expected Result**: The Web Content Article is displayed in the Search Results widget and the widgets' names don’t show.
**Actual Result**: All the Widget names are show


If this PR isn't possible, let me know ASAP so we can come up with a new plan for the customer.

Here's an example of what is displayed before this change:
![Master Search Page maximized](https://github.com/user-attachments/assets/0dae6de1-0127-4e8f-aa19-56e3e30c2cae)

Thank you
