### PR TITLE
LPD-41336 disable deprecation feature flags for the system when initializing Liferay for the first time

### DIFF
--- a/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/model/listener/CompanyModelListener.java
+++ b/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/model/listener/CompanyModelListener.java
@@ -13,6 +13,7 @@ import com.liferay.portal.kernel.feature.flag.FeatureFlagType;
 import com.liferay.portal.kernel.feature.flag.constants.FeatureFlagConstants;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.model.ModelListener;
 import com.liferay.portal.kernel.portlet.PortalPreferences;
 import com.liferay.portal.kernel.service.CompanyLocalService;
@@ -49,6 +50,8 @@ public class CompanyModelListener extends BaseModelListener<Company> {
 	protected void activate() {
 		_companyLocalService.forEachCompanyId(
 			this::_processDeprecationFeatureFlags);
+
+		_processDeprecationFeatureFlags(CompanyConstants.SYSTEM);
 	}
 
 	private PortalPreferences _getPortalPreferences(long companyId) {

--- a/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/upgrade/v1_0_0/FeatureFlagUpgradeProcess.java
+++ b/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/upgrade/v1_0_0/FeatureFlagUpgradeProcess.java
@@ -6,6 +6,7 @@
 package com.liferay.feature.flag.web.internal.upgrade.v1_0_0;
 
 import com.liferay.portal.kernel.feature.flag.constants.FeatureFlagConstants;
+import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.PortalPreferencesLocalService;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
@@ -30,41 +31,42 @@ public class FeatureFlagUpgradeProcess extends UpgradeProcess {
 
 	@Override
 	protected void doUpgrade() {
-		_companyLocalService.forEachCompanyId(
-			companyId -> {
-				PortalPreferencesWrapper portalPreferencesWrapper =
-					(PortalPreferencesWrapper)
-						_portalPreferencesLocalService.getPreferences(
-							companyId, PortletKeys.PREFS_OWNER_TYPE_COMPANY);
+		_companyLocalService.forEachCompanyId(this::_doUpgrade);
 
-				PortalPreferencesImpl portalPreferencesImpl =
-					portalPreferencesWrapper.getPortalPreferencesImpl();
+		_doUpgrade(CompanyConstants.SYSTEM);
+	}
 
-				Enumeration<String> enumeration =
-					portalPreferencesImpl.getNames(_OLD_NAMESPACE);
+	private void _doUpgrade(long companyId) {
+		PortalPreferencesWrapper portalPreferencesWrapper =
+			(PortalPreferencesWrapper)
+				_portalPreferencesLocalService.getPreferences(
+					companyId, PortletKeys.PREFS_OWNER_TYPE_COMPANY);
 
-				while (enumeration.hasMoreElements()) {
-					String featureFlag = enumeration.nextElement();
+		PortalPreferencesImpl portalPreferencesImpl =
+			portalPreferencesWrapper.getPortalPreferencesImpl();
 
-					String value = portalPreferencesImpl.getValue(
-						_OLD_NAMESPACE, featureFlag);
+		Enumeration<String> enumeration = portalPreferencesImpl.getNames(
+			_OLD_NAMESPACE);
 
-					portalPreferencesImpl.reset(_OLD_NAMESPACE, featureFlag);
+		while (enumeration.hasMoreElements()) {
+			String featureFlag = enumeration.nextElement();
 
-					portalPreferencesImpl.setValue(
-						FeatureFlagConstants.PREFERENCE_NAMESPACE, featureFlag,
-						value);
-				}
+			String value = portalPreferencesImpl.getValue(
+				_OLD_NAMESPACE, featureFlag);
 
-				portalPreferencesImpl.setValue(
-					FeatureFlagConstants.PREFERENCE_NAMESPACE,
-					FeatureFlagConstants.PREFERENCE_KEY_DEPRECATION_PROCESSED,
-					"true");
+			portalPreferencesImpl.reset(_OLD_NAMESPACE, featureFlag);
 
-				_portalPreferencesLocalService.updatePreferences(
-					companyId, PortletKeys.PREFS_OWNER_TYPE_COMPANY,
-					portalPreferencesImpl);
-			});
+			portalPreferencesImpl.setValue(
+				FeatureFlagConstants.PREFERENCE_NAMESPACE, featureFlag, value);
+		}
+
+		portalPreferencesImpl.setValue(
+			FeatureFlagConstants.PREFERENCE_NAMESPACE,
+			FeatureFlagConstants.PREFERENCE_KEY_DEPRECATION_PROCESSED, "true");
+
+		_portalPreferencesLocalService.updatePreferences(
+			companyId, PortletKeys.PREFS_OWNER_TYPE_COMPANY,
+			portalPreferencesImpl);
 	}
 
 	private static final String _OLD_NAMESPACE =


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-41336

## Context
Currently only company’s deprecation feature flags are disabled automatically when creating a new company. 

For system, if Liferay is being set up for the first time, the deprecation feature flags remain enabled.

## Approach

Just call the method that disables the deprecation feature flags for other companies passing `0` as the `companyId` (which represents the system)

## Test coverage

This scenario is already covered by `FeatureFlagUpgradeProcessTest`