### PR TITLE
LPD-46550 - Fix failing test on poshi

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/controlmenu/ControlMenuWithPermissions.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/controlmenu/ControlMenuWithPermissions.testcase
@@ -77,6 +77,8 @@ definition {
 			Check.checkToggleSwitch(
 				checkboxName = "Show Control Menu by Role",
 				locator1 = "Checkbox#ANY_CHECKBOX");
+
+			PortletEntry.save();
 		}
 
 		task ("When the site administrator selects new role to see control menu") {
@@ -155,6 +157,8 @@ definition {
 			Check.checkToggleSwitch(
 				checkboxName = "Show Control Menu by Role",
 				locator1 = "Checkbox#ANY_CHECKBOX");
+
+			PortletEntry.save();
 		}
 
 		task ("Then the site administrator cannot remove Administrator and Site Administrator from Roles that can see the control menu") {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/controlmenu/ControlMenuWithPermissions.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/controlmenu/ControlMenuWithPermissions.testcase
@@ -129,6 +129,7 @@ definition {
 
 	@description = "This is for LPS-176136. Verify is possible to hide or show Control Menu of a Role and that Administrator and Site Administrator cannot be deleted."
 	@priority = 4
+	@uitest
 	test ShowControlMenuByOOTBRoles {
 		task ("Given the site administrator accesses to the Site Configuration") {
 			Permissions.definePermissionViaJSONAPI(
@@ -223,6 +224,7 @@ definition {
 
 	@description = "This is for LPS-176136. Verify that users accessing the admin Page directly will see the Control Menu."
 	@priority = 4
+	@uitest
 	test ViewControlMenuInWebContentAdminAsUserWithRoleOutsideRolesThatCanSeeTheControlMenu {
 		var randomRoleKey = StringUtil.randomString(8);
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/controlmenu/productmenu/ProductMenuWithStaging.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/controlmenu/productmenu/ProductMenuWithStaging.testcase
@@ -37,6 +37,7 @@ definition {
 
 	@description = "This is a test for LPS-112994. The Product Menu icon should not be shown when the user is in the Control Panel Apps even though enable Live"
 	@priority = 4
+	@uitest
 	test ViewProductMenuIconInvisibleInGlobalAppAfterEnableLive {
 		task ("View product menu icon is not shown in Control Panel apps") {
 			User.openUsersAdmin();

--- a/test.properties
+++ b/test.properties
@@ -6086,8 +6086,7 @@
         **/portal-instances/**/*Test.java,\
         **/portal-language-override-test/**/*Test.java,\
         **/product-navigation/**/*Test.java,\
-        **/style-book/**/*Test.java\
-        /portal-web/tests/enduser/wem/controlmenu/**/*Test.java,\
+        **/style-book/**/*Test.java
 
     test.batch.dist.app.servers[platform-experience]=tomcat
 

--- a/test.properties
+++ b/test.properties
@@ -6086,7 +6086,8 @@
         **/portal-instances/**/*Test.java,\
         **/portal-language-override-test/**/*Test.java,\
         **/product-navigation/**/*Test.java,\
-        **/style-book/**/*Test.java
+        **/style-book/**/*Test.java\
+        /portal-web/tests/enduser/wem/controlmenu/**/*Test.java,\
 
     test.batch.dist.app.servers[platform-experience]=tomcat
 


### PR DESCRIPTION
Resent from: https://github.com/liferay-platform-experience/liferay-portal/pull/924

Ticket: https://liferay.atlassian.net/browse/LPD-46550

Motivation
Test failing on [ControlMenuWithPermissions#ShowControlMenuByNewRole](https://testray.liferay.com/#/project/35392/routines/82964/build/112474738/case-result/112577116) and [ControlMenuWithPermissions#ShowControlMenuByOOTBRoles](https://testray.liferay.com/#/project/35392/routines/82964/build/112474738/case-result/112512332)

Proposed Solution
The select button to open the modal is disabled until the checkbox is updated. The solution was to add a new click on save