### PR TITLE
LPD-48798 LPD- Add a way of persisting the theme type (OSGI or ThemeCSSCET) for StyleBookEntry

### DIFF
--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageSpecificationResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageSpecificationResourceTest.java
@@ -455,7 +455,8 @@ public class PageSpecificationResourceTest
 		return _styleBookEntryLocalService.addStyleBookEntry(
 			null, TestPropsValues.getUserId(), serviceContext.getScopeGroupId(),
 			false, null, RandomTestUtil.randomString(), null,
-			RandomTestUtil.randomString(), serviceContext);
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			serviceContext);
 	}
 
 	private void _assertContentPageSpecification(

--- a/modules/apps/layout/layout-admin-web-test/src/testIntegration/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/test/LayoutStagedModelDataHandlerTest.java
+++ b/modules/apps/layout/layout-admin-web-test/src/testIntegration/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/test/LayoutStagedModelDataHandlerTest.java
@@ -937,6 +937,7 @@ public class LayoutStagedModelDataHandlerTest
 				null, TestPropsValues.getUserId(), stagingGroup.getGroupId(),
 				false, StringPool.BLANK, RandomTestUtil.randomString(),
 				StringPool.BLANK, RandomTestUtil.randomString(),
+				RandomTestUtil.randomString(),
 				ServiceContextTestUtil.getServiceContext(
 					stagingGroup.getGroupId()));
 

--- a/modules/apps/layout/layout-admin-web-test/src/testIntegration/java/com/liferay/layout/admin/web/internal/portlet/action/test/EditLayoutDesignMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-admin-web-test/src/testIntegration/java/com/liferay/layout/admin/web/internal/portlet/action/test/EditLayoutDesignMVCActionCommandTest.java
@@ -190,7 +190,7 @@ public class EditLayoutDesignMVCActionCommandTest {
 				null, TestPropsValues.getUserId(), _group.getGroupId(), false,
 				StringPool.BLANK, RandomTestUtil.randomString(),
 				StringPool.BLANK, RandomTestUtil.randomString(),
-				serviceContext);
+				RandomTestUtil.randomString(), serviceContext);
 
 		FileEntry fileEntry = _dlAppLocalService.addFileEntry(
 			null, TestPropsValues.getUserId(), _group.getGroupId(),

--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/CreateLayoutPageTemplateEntryMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/CreateLayoutPageTemplateEntryMVCActionCommandTest.java
@@ -153,6 +153,7 @@ public class CreateLayoutPageTemplateEntryMVCActionCommandTest {
 				null, TestPropsValues.getUserId(), _group.getGroupId(), false,
 				StringPool.BLANK, RandomTestUtil.randomString(),
 				StringPool.BLANK, RandomTestUtil.randomString(),
+				RandomTestUtil.randomString(),
 				ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
 
 		draftLayout = _layoutLocalService.updateStyleBookEntryId(

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/importer/test/LayoutsImporterTest.java
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/importer/test/LayoutsImporterTest.java
@@ -1277,7 +1277,8 @@ public class LayoutsImporterTest {
 		return _styleBookEntryLocalService.addStyleBookEntry(
 			null, TestPropsValues.getUserId(), serviceContext.getScopeGroupId(),
 			false, StringPool.BLANK, RandomTestUtil.randomString(),
-			styleBookEntryKey, StringPool.BLANK, serviceContext);
+			styleBookEntryKey, StringPool.BLANK, RandomTestUtil.randomString(),
+			serviceContext);
 	}
 
 	private void _assertFragmentEntryLink(

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/test/LayoutPageTemplateEntryLocalServiceTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/test/LayoutPageTemplateEntryLocalServiceTest.java
@@ -373,7 +373,7 @@ public class LayoutPageTemplateEntryLocalServiceTest {
 				null, TestPropsValues.getUserId(), _group.getGroupId(), false,
 				StringPool.BLANK, RandomTestUtil.randomString(),
 				StringPool.BLANK, RandomTestUtil.randomString(),
-				_serviceContext);
+				RandomTestUtil.randomString(), _serviceContext);
 
 		Layout layout = _layoutLocalService.fetchLayout(
 			layoutPageTemplateEntry.getPlid());

--- a/modules/apps/style-book/style-book-api/bnd.bnd
+++ b/modules/apps/style-book/style-book-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Style Book API
 Bundle-SymbolicName: com.liferay.style.book.api
-Bundle-Version: 9.1.1
+Bundle-Version: 9.2.0
 Export-Package:\
 	com.liferay.style.book.constants,\
 	com.liferay.style.book.exception,\

--- a/modules/apps/style-book/style-book-api/bnd.bnd
+++ b/modules/apps/style-book/style-book-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Style Book API
 Bundle-SymbolicName: com.liferay.style.book.api
-Bundle-Version: 9.2.0
+Bundle-Version: 10.0.0
 Export-Package:\
 	com.liferay.style.book.constants,\
 	com.liferay.style.book.exception,\

--- a/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/constants/StyleBookConstants.java
+++ b/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/constants/StyleBookConstants.java
@@ -14,4 +14,8 @@ public class StyleBookConstants {
 
 	public static final String SERVICE_NAME = "com.liferay.style.book";
 
+	public static final String THEME_TYPE_BUNDLE = "bundle";
+
+	public static final String THEME_TYPE_THEME_CSS_CET = "themeCSSCET";
+
 }

--- a/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/exception/StyleBookEntryThemeTypeException.java
+++ b/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/exception/StyleBookEntryThemeTypeException.java
@@ -2,6 +2,7 @@
  * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
+
 package com.liferay.style.book.exception;
 
 import com.liferay.portal.kernel.exception.PortalException;
@@ -10,7 +11,6 @@ import com.liferay.portal.kernel.exception.PortalException;
  * @author Thiago Buarque
  */
 public class StyleBookEntryThemeTypeException extends PortalException {
-
 
 	public static class MustNotBeNull extends StyleBookEntryThemeTypeException {
 

--- a/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/exception/StyleBookEntryThemeTypeException.java
+++ b/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/exception/StyleBookEntryThemeTypeException.java
@@ -7,23 +7,21 @@ package com.liferay.style.book.exception;
 import com.liferay.portal.kernel.exception.PortalException;
 
 /**
- * @author Brian Wing Shun Chan
+ * @author Thiago Buarque
  */
 public class StyleBookEntryThemeTypeException extends PortalException {
 
-	public StyleBookEntryThemeTypeException() {
+
+	public static class MustNotBeNull extends StyleBookEntryThemeTypeException {
+
+		public MustNotBeNull() {
+			super("Theme type must not be null");
+		}
+
 	}
 
-	public StyleBookEntryThemeTypeException(String msg) {
+	private StyleBookEntryThemeTypeException(String msg) {
 		super(msg);
-	}
-
-	public StyleBookEntryThemeTypeException(String msg, Throwable throwable) {
-		super(msg, throwable);
-	}
-
-	public StyleBookEntryThemeTypeException(Throwable throwable) {
-		super(throwable);
 	}
 
 }

--- a/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/exception/StyleBookEntryThemeTypeException.java
+++ b/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/exception/StyleBookEntryThemeTypeException.java
@@ -1,0 +1,29 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+package com.liferay.style.book.exception;
+
+import com.liferay.portal.kernel.exception.PortalException;
+
+/**
+ * @author Brian Wing Shun Chan
+ */
+public class StyleBookEntryThemeTypeException extends PortalException {
+
+	public StyleBookEntryThemeTypeException() {
+	}
+
+	public StyleBookEntryThemeTypeException(String msg) {
+		super(msg);
+	}
+
+	public StyleBookEntryThemeTypeException(String msg, Throwable throwable) {
+		super(msg, throwable);
+	}
+
+	public StyleBookEntryThemeTypeException(Throwable throwable) {
+		super(throwable);
+	}
+
+}

--- a/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/model/StyleBookEntryModel.java
+++ b/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/model/StyleBookEntryModel.java
@@ -362,6 +362,21 @@ public interface StyleBookEntryModel
 	 */
 	public void setThemeId(String themeId);
 
+	/**
+	 * Returns the theme type of this style book entry.
+	 *
+	 * @return the theme type of this style book entry
+	 */
+	@AutoEscape
+	public String getThemeType();
+
+	/**
+	 * Sets the theme type of this style book entry.
+	 *
+	 * @param themeType the theme type of this style book entry
+	 */
+	public void setThemeType(String themeType);
+
 	@Override
 	public StyleBookEntry cloneWithOriginalValues();
 

--- a/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/model/StyleBookEntryTable.java
+++ b/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/model/StyleBookEntryTable.java
@@ -75,6 +75,8 @@ public class StyleBookEntryTable extends BaseTable<StyleBookEntryTable> {
 			Column.FLAG_DEFAULT);
 	public final Column<StyleBookEntryTable, String> themeId = createColumn(
 		"themeId", String.class, Types.VARCHAR, Column.FLAG_DEFAULT);
+	public final Column<StyleBookEntryTable, String> themeType = createColumn(
+		"themeType", String.class, Types.VARCHAR, Column.FLAG_DEFAULT);
 
 	private StyleBookEntryTable() {
 		super("StyleBookEntry", StyleBookEntryTable::new);

--- a/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/model/StyleBookEntryVersionModel.java
+++ b/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/model/StyleBookEntryVersionModel.java
@@ -373,6 +373,21 @@ public interface StyleBookEntryVersionModel
 	 */
 	public void setThemeId(String themeId);
 
+	/**
+	 * Returns the theme type of this style book entry version.
+	 *
+	 * @return the theme type of this style book entry version
+	 */
+	@AutoEscape
+	public String getThemeType();
+
+	/**
+	 * Sets the theme type of this style book entry version.
+	 *
+	 * @param themeType the theme type of this style book entry version
+	 */
+	public void setThemeType(String themeType);
+
 	@Override
 	public StyleBookEntryVersion cloneWithOriginalValues();
 

--- a/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/model/StyleBookEntryVersionTable.java
+++ b/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/model/StyleBookEntryVersionTable.java
@@ -85,6 +85,9 @@ public class StyleBookEntryVersionTable
 	public final Column<StyleBookEntryVersionTable, String> themeId =
 		createColumn(
 			"themeId", String.class, Types.VARCHAR, Column.FLAG_DEFAULT);
+	public final Column<StyleBookEntryVersionTable, String> themeType =
+		createColumn(
+			"themeType", String.class, Types.VARCHAR, Column.FLAG_DEFAULT);
 
 	private StyleBookEntryVersionTable() {
 		super("StyleBookEntryVersion", StyleBookEntryVersionTable::new);

--- a/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/model/StyleBookEntryVersionWrapper.java
+++ b/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/model/StyleBookEntryVersionWrapper.java
@@ -56,6 +56,7 @@ public class StyleBookEntryVersionWrapper
 		attributes.put("previewFileEntryId", getPreviewFileEntryId());
 		attributes.put("styleBookEntryKey", getStyleBookEntryKey());
 		attributes.put("themeId", getThemeId());
+		attributes.put("themeType", getThemeType());
 
 		return attributes;
 	}
@@ -178,6 +179,12 @@ public class StyleBookEntryVersionWrapper
 
 		if (themeId != null) {
 			setThemeId(themeId);
+		}
+
+		String themeType = (String)attributes.get("themeType");
+
+		if (themeType != null) {
+			setThemeType(themeType);
 		}
 	}
 
@@ -344,6 +351,16 @@ public class StyleBookEntryVersionWrapper
 	@Override
 	public String getThemeId() {
 		return model.getThemeId();
+	}
+
+	/**
+	 * Returns the theme type of this style book entry version.
+	 *
+	 * @return the theme type of this style book entry version
+	 */
+	@Override
+	public String getThemeType() {
+		return model.getThemeType();
 	}
 
 	/**
@@ -564,6 +581,16 @@ public class StyleBookEntryVersionWrapper
 	@Override
 	public void setThemeId(String themeId) {
 		model.setThemeId(themeId);
+	}
+
+	/**
+	 * Sets the theme type of this style book entry version.
+	 *
+	 * @param themeType the theme type of this style book entry version
+	 */
+	@Override
+	public void setThemeType(String themeType) {
+		model.setThemeType(themeType);
 	}
 
 	/**

--- a/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/model/StyleBookEntryWrapper.java
+++ b/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/model/StyleBookEntryWrapper.java
@@ -54,6 +54,7 @@ public class StyleBookEntryWrapper
 		attributes.put("previewFileEntryId", getPreviewFileEntryId());
 		attributes.put("styleBookEntryKey", getStyleBookEntryKey());
 		attributes.put("themeId", getThemeId());
+		attributes.put("themeType", getThemeType());
 
 		return attributes;
 	}
@@ -169,6 +170,12 @@ public class StyleBookEntryWrapper
 
 		if (themeId != null) {
 			setThemeId(themeId);
+		}
+
+		String themeType = (String)attributes.get("themeType");
+
+		if (themeType != null) {
+			setThemeType(themeType);
 		}
 	}
 
@@ -342,6 +349,16 @@ public class StyleBookEntryWrapper
 	@Override
 	public String getThemeId() {
 		return model.getThemeId();
+	}
+
+	/**
+	 * Returns the theme type of this style book entry.
+	 *
+	 * @return the theme type of this style book entry
+	 */
+	@Override
+	public String getThemeType() {
+		return model.getThemeType();
 	}
 
 	/**
@@ -565,6 +582,16 @@ public class StyleBookEntryWrapper
 	@Override
 	public void setThemeId(String themeId) {
 		model.setThemeId(themeId);
+	}
+
+	/**
+	 * Sets the theme type of this style book entry.
+	 *
+	 * @param themeType the theme type of this style book entry
+	 */
+	@Override
+	public void setThemeType(String themeType) {
+		model.setThemeType(themeType);
 	}
 
 	/**

--- a/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryLocalService.java
+++ b/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryLocalService.java
@@ -69,7 +69,7 @@ public interface StyleBookEntryLocalService
 			String externalReferenceCode, long userId, long groupId,
 			boolean defaultStyleBookEntry, String frontendTokensValues,
 			String name, String styleBookEntryKey, String themeId,
-			ServiceContext serviceContext)
+			String themeType, ServiceContext serviceContext)
 		throws PortalException;
 
 	/**

--- a/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryLocalServiceUtil.java
+++ b/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryLocalServiceUtil.java
@@ -40,12 +40,13 @@ public class StyleBookEntryLocalServiceUtil {
 			String externalReferenceCode, long userId, long groupId,
 			boolean defaultStyleBookEntry, String frontendTokensValues,
 			String name, String styleBookEntryKey, String themeId,
+			String themeType,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
 
 		return getService().addStyleBookEntry(
 			externalReferenceCode, userId, groupId, defaultStyleBookEntry,
-			frontendTokensValues, name, styleBookEntryKey, themeId,
+			frontendTokensValues, name, styleBookEntryKey, themeId, themeType,
 			serviceContext);
 	}
 

--- a/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryLocalServiceWrapper.java
+++ b/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryLocalServiceWrapper.java
@@ -37,12 +37,13 @@ public class StyleBookEntryLocalServiceWrapper
 			String externalReferenceCode, long userId, long groupId,
 			boolean defaultStyleBookEntry, String frontendTokensValues,
 			String name, String styleBookEntryKey, String themeId,
+			String themeType,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _styleBookEntryLocalService.addStyleBookEntry(
 			externalReferenceCode, userId, groupId, defaultStyleBookEntry,
-			frontendTokensValues, name, styleBookEntryKey, themeId,
+			frontendTokensValues, name, styleBookEntryKey, themeId, themeType,
 			serviceContext);
 	}
 

--- a/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryService.java
+++ b/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryService.java
@@ -45,14 +45,14 @@ public interface StyleBookEntryService extends BaseService {
 	 */
 	public StyleBookEntry addStyleBookEntry(
 			String externalReferenceCode, long groupId, String name,
-			String styleBookEntryKey, String themeId,
+			String styleBookEntryKey, String themeId, String themeType,
 			ServiceContext serviceContext)
 		throws PortalException;
 
 	public StyleBookEntry addStyleBookEntry(
 			String externalReferenceCode, long groupId,
 			String frontendTokensValues, String name, String styleBookEntryKey,
-			String themeId, ServiceContext serviceContext)
+			String themeId, String themeType, ServiceContext serviceContext)
 		throws PortalException;
 
 	public StyleBookEntry copyStyleBookEntry(

--- a/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryServiceUtil.java
+++ b/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryServiceUtil.java
@@ -30,25 +30,25 @@ public class StyleBookEntryServiceUtil {
 	 */
 	public static StyleBookEntry addStyleBookEntry(
 			String externalReferenceCode, long groupId, String name,
-			String styleBookEntryKey, String themeId,
+			String styleBookEntryKey, String themeId, String themeType,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
 
 		return getService().addStyleBookEntry(
 			externalReferenceCode, groupId, name, styleBookEntryKey, themeId,
-			serviceContext);
+			themeType, serviceContext);
 	}
 
 	public static StyleBookEntry addStyleBookEntry(
 			String externalReferenceCode, long groupId,
 			String frontendTokensValues, String name, String styleBookEntryKey,
-			String themeId,
+			String themeId, String themeType,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
 
 		return getService().addStyleBookEntry(
 			externalReferenceCode, groupId, frontendTokensValues, name,
-			styleBookEntryKey, themeId, serviceContext);
+			styleBookEntryKey, themeId, themeType, serviceContext);
 	}
 
 	public static StyleBookEntry copyStyleBookEntry(

--- a/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryServiceWrapper.java
+++ b/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryServiceWrapper.java
@@ -31,26 +31,26 @@ public class StyleBookEntryServiceWrapper
 	@Override
 	public StyleBookEntry addStyleBookEntry(
 			String externalReferenceCode, long groupId, String name,
-			String styleBookEntryKey, String themeId,
+			String styleBookEntryKey, String themeId, String themeType,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _styleBookEntryService.addStyleBookEntry(
 			externalReferenceCode, groupId, name, styleBookEntryKey, themeId,
-			serviceContext);
+			themeType, serviceContext);
 	}
 
 	@Override
 	public StyleBookEntry addStyleBookEntry(
 			String externalReferenceCode, long groupId,
 			String frontendTokensValues, String name, String styleBookEntryKey,
-			String themeId,
+			String themeId, String themeType,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _styleBookEntryService.addStyleBookEntry(
 			externalReferenceCode, groupId, frontendTokensValues, name,
-			styleBookEntryKey, themeId, serviceContext);
+			styleBookEntryKey, themeId, themeType, serviceContext);
 	}
 
 	@Override

--- a/modules/apps/style-book/style-book-api/src/main/resources/com/liferay/style/book/constants/packageinfo
+++ b/modules/apps/style-book/style-book-api/src/main/resources/com/liferay/style/book/constants/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/modules/apps/style-book/style-book-api/src/main/resources/com/liferay/style/book/exception/packageinfo
+++ b/modules/apps/style-book/style-book-api/src/main/resources/com/liferay/style/book/exception/packageinfo
@@ -1,1 +1,1 @@
-version 1.2.0
+version 1.3.0

--- a/modules/apps/style-book/style-book-api/src/main/resources/com/liferay/style/book/model/packageinfo
+++ b/modules/apps/style-book/style-book-api/src/main/resources/com/liferay/style/book/model/packageinfo
@@ -1,1 +1,1 @@
-version 2.3.0
+version 2.4.0

--- a/modules/apps/style-book/style-book-api/src/main/resources/com/liferay/style/book/service/packageinfo
+++ b/modules/apps/style-book/style-book-api/src/main/resources/com/liferay/style/book/service/packageinfo
@@ -1,1 +1,1 @@
-version 5.0.0
+version 6.0.0

--- a/modules/apps/style-book/style-book-service/bnd.bnd
+++ b/modules/apps/style-book/style-book-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Style Book Service
 Bundle-SymbolicName: com.liferay.style.book.service
 Bundle-Version: 2.0.55
-Liferay-Require-SchemaVersion: 1.6.0
+Liferay-Require-SchemaVersion: 1.7.0
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/style-book/style-book-service/service.xml
+++ b/modules/apps/style-book/style-book-service/service.xml
@@ -29,6 +29,7 @@
 		<column name="previewFileEntryId" type="long" />
 		<column name="styleBookEntryKey" type="String" />
 		<column name="themeId" type="String" />
+		<column name="themeType" type="String" />
 
 		<!-- Order -->
 
@@ -59,5 +60,6 @@
 		<exception>StyleBookEntryFile</exception>
 		<exception>StyleBookEntryName</exception>
 		<exception>StyleBookEntryThemeId</exception>
+		<exception>StyleBookEntryThemeType</exception>
 	</exceptions>
 </service-builder>

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/internal/exportimport/staged/model/repository/StylebookEntryStagedModelRepository.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/internal/exportimport/staged/model/repository/StylebookEntryStagedModelRepository.java
@@ -51,7 +51,7 @@ public class StylebookEntryStagedModelRepository
 			styleBookEntry.isDefaultStyleBookEntry(),
 			styleBookEntry.getFrontendTokensValues(), styleBookEntry.getName(),
 			styleBookEntry.getStyleBookEntryKey(), styleBookEntry.getThemeId(),
-			serviceContext);
+			styleBookEntry.getThemeType(), serviceContext);
 	}
 
 	@Override

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/internal/upgrade/registry/StyleBookServiceUpgradeStepRegistrator.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/internal/upgrade/registry/StyleBookServiceUpgradeStepRegistrator.java
@@ -81,6 +81,13 @@ public class StyleBookServiceUpgradeStepRegistrator
 				"StyleBookEntry", "themeId VARCHAR(255) null"),
 			UpgradeProcessFactory.addColumns(
 				"StyleBookEntryVersion", "themeId VARCHAR(255) null"));
+
+		registry.register(
+			"1.6.0", "1.7.0",
+			UpgradeProcessFactory.addColumns(
+				"StyleBookEntry", "themeType VARCHAR(75) null"),
+			UpgradeProcessFactory.addColumns(
+				"StyleBookEntryVersion", "themeType VARCHAR(75) null"));
 	}
 
 }

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/model/impl/StyleBookEntryCacheModel.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/model/impl/StyleBookEntryCacheModel.java
@@ -68,7 +68,7 @@ public class StyleBookEntryCacheModel
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler(37);
+		StringBundler sb = new StringBundler(39);
 
 		sb.append("{mvccVersion=");
 		sb.append(mvccVersion);
@@ -106,6 +106,8 @@ public class StyleBookEntryCacheModel
 		sb.append(styleBookEntryKey);
 		sb.append(", themeId=");
 		sb.append(themeId);
+		sb.append(", themeType=");
+		sb.append(themeType);
 		sb.append("}");
 
 		return sb.toString();
@@ -192,6 +194,13 @@ public class StyleBookEntryCacheModel
 			styleBookEntryImpl.setThemeId(themeId);
 		}
 
+		if (themeType == null) {
+			styleBookEntryImpl.setThemeType("");
+		}
+		else {
+			styleBookEntryImpl.setThemeType(themeType);
+		}
+
 		styleBookEntryImpl.resetOriginalValues();
 
 		return styleBookEntryImpl;
@@ -229,6 +238,7 @@ public class StyleBookEntryCacheModel
 		previewFileEntryId = objectInput.readLong();
 		styleBookEntryKey = objectInput.readUTF();
 		themeId = objectInput.readUTF();
+		themeType = objectInput.readUTF();
 	}
 
 	@Override
@@ -304,6 +314,13 @@ public class StyleBookEntryCacheModel
 		else {
 			objectOutput.writeUTF(themeId);
 		}
+
+		if (themeType == null) {
+			objectOutput.writeUTF("");
+		}
+		else {
+			objectOutput.writeUTF(themeType);
+		}
 	}
 
 	public long mvccVersion;
@@ -325,5 +342,6 @@ public class StyleBookEntryCacheModel
 	public long previewFileEntryId;
 	public String styleBookEntryKey;
 	public String themeId;
+	public String themeType;
 
 }

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/model/impl/StyleBookEntryImpl.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/model/impl/StyleBookEntryImpl.java
@@ -8,6 +8,7 @@ package com.liferay.style.book.model.impl;
 import com.liferay.document.library.util.DLURLHelperUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.log.Log;
@@ -55,9 +56,15 @@ public class StyleBookEntryImpl extends StyleBookEntryBaseImpl {
 			"frontendTokensValuesPath", "frontend-tokens-values.json"
 		).put(
 			"name", getName()
-		).put(
-			"themeId", getThemeId()
 		);
+
+		if (FeatureFlagManagerUtil.isEnabled(getCompanyId(), "LPD-30204")) {
+			jsonObject.put(
+				"themeId", getThemeId()
+			).put(
+				"themeType", getThemeType()
+			);
+		}
 
 		FileEntry previewFileEntry = _getPreviewFileEntry();
 

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/model/impl/StyleBookEntryModelImpl.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/model/impl/StyleBookEntryModelImpl.java
@@ -76,7 +76,8 @@ public class StyleBookEntryModelImpl
 		{"defaultStyleBookEntry", Types.BOOLEAN},
 		{"frontendTokensValues", Types.CLOB}, {"name", Types.VARCHAR},
 		{"previewFileEntryId", Types.BIGINT},
-		{"styleBookEntryKey", Types.VARCHAR}, {"themeId", Types.VARCHAR}
+		{"styleBookEntryKey", Types.VARCHAR}, {"themeId", Types.VARCHAR},
+		{"themeType", Types.VARCHAR}
 	};
 
 	public static final Map<String, Integer> TABLE_COLUMNS_MAP =
@@ -102,10 +103,11 @@ public class StyleBookEntryModelImpl
 		TABLE_COLUMNS_MAP.put("previewFileEntryId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("styleBookEntryKey", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("themeId", Types.VARCHAR);
+		TABLE_COLUMNS_MAP.put("themeType", Types.VARCHAR);
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table StyleBookEntry (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,headId LONG,head BOOLEAN,styleBookEntryId LONG not null,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,defaultStyleBookEntry BOOLEAN,frontendTokensValues TEXT null,name VARCHAR(75) null,previewFileEntryId LONG,styleBookEntryKey VARCHAR(75) null,themeId VARCHAR(255) null,primary key (styleBookEntryId, ctCollectionId))";
+		"create table StyleBookEntry (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,headId LONG,head BOOLEAN,styleBookEntryId LONG not null,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,defaultStyleBookEntry BOOLEAN,frontendTokensValues TEXT null,name VARCHAR(75) null,previewFileEntryId LONG,styleBookEntryKey VARCHAR(75) null,themeId VARCHAR(255) null,themeType VARCHAR(75) null,primary key (styleBookEntryId, ctCollectionId))";
 
 	public static final String TABLE_SQL_DROP = "drop table StyleBookEntry";
 
@@ -325,6 +327,8 @@ public class StyleBookEntryModelImpl
 			attributeGetterFunctions.put(
 				"styleBookEntryKey", StyleBookEntry::getStyleBookEntryKey);
 			attributeGetterFunctions.put("themeId", StyleBookEntry::getThemeId);
+			attributeGetterFunctions.put(
+				"themeType", StyleBookEntry::getThemeType);
 
 			_attributeGetterFunctions = Collections.unmodifiableMap(
 				attributeGetterFunctions);
@@ -407,6 +411,10 @@ public class StyleBookEntryModelImpl
 			attributeSetterBiConsumers.put(
 				"themeId",
 				(BiConsumer<StyleBookEntry, String>)StyleBookEntry::setThemeId);
+			attributeSetterBiConsumers.put(
+				"themeType",
+				(BiConsumer<StyleBookEntry, String>)
+					StyleBookEntry::setThemeType);
 
 			_attributeSetterBiConsumers = Collections.unmodifiableMap(
 				(Map)attributeSetterBiConsumers);
@@ -436,6 +444,7 @@ public class StyleBookEntryModelImpl
 		styleBookEntryVersion.setPreviewFileEntryId(getPreviewFileEntryId());
 		styleBookEntryVersion.setStyleBookEntryKey(getStyleBookEntryKey());
 		styleBookEntryVersion.setThemeId(getThemeId());
+		styleBookEntryVersion.setThemeType(getThemeType());
 	}
 
 	@JSON
@@ -880,6 +889,26 @@ public class StyleBookEntryModelImpl
 		_themeId = themeId;
 	}
 
+	@JSON
+	@Override
+	public String getThemeType() {
+		if (_themeType == null) {
+			return "";
+		}
+		else {
+			return _themeType;
+		}
+	}
+
+	@Override
+	public void setThemeType(String themeType) {
+		if (_columnOriginalValues == Collections.EMPTY_MAP) {
+			_setColumnOriginalValues();
+		}
+
+		_themeType = themeType;
+	}
+
 	@Override
 	public StagedModelType getStagedModelType() {
 		return new StagedModelType(
@@ -960,6 +989,7 @@ public class StyleBookEntryModelImpl
 		styleBookEntryImpl.setPreviewFileEntryId(getPreviewFileEntryId());
 		styleBookEntryImpl.setStyleBookEntryKey(getStyleBookEntryKey());
 		styleBookEntryImpl.setThemeId(getThemeId());
+		styleBookEntryImpl.setThemeType(getThemeType());
 
 		styleBookEntryImpl.resetOriginalValues();
 
@@ -1005,6 +1035,8 @@ public class StyleBookEntryModelImpl
 			this.<String>getColumnOriginalValue("styleBookEntryKey"));
 		styleBookEntryImpl.setThemeId(
 			this.<String>getColumnOriginalValue("themeId"));
+		styleBookEntryImpl.setThemeType(
+			this.<String>getColumnOriginalValue("themeType"));
 
 		return styleBookEntryImpl;
 	}
@@ -1187,6 +1219,14 @@ public class StyleBookEntryModelImpl
 			styleBookEntryCacheModel.themeId = null;
 		}
 
+		styleBookEntryCacheModel.themeType = getThemeType();
+
+		String themeType = styleBookEntryCacheModel.themeType;
+
+		if ((themeType != null) && (themeType.length() == 0)) {
+			styleBookEntryCacheModel.themeType = null;
+		}
+
 		return styleBookEntryCacheModel;
 	}
 
@@ -1268,6 +1308,7 @@ public class StyleBookEntryModelImpl
 	private long _previewFileEntryId;
 	private String _styleBookEntryKey;
 	private String _themeId;
+	private String _themeType;
 
 	public <T> T getColumnValue(String columnName) {
 		if (columnName.equals("head")) {
@@ -1325,6 +1366,7 @@ public class StyleBookEntryModelImpl
 		_columnOriginalValues.put("previewFileEntryId", _previewFileEntryId);
 		_columnOriginalValues.put("styleBookEntryKey", _styleBookEntryKey);
 		_columnOriginalValues.put("themeId", _themeId);
+		_columnOriginalValues.put("themeType", _themeType);
 	}
 
 	private static final Map<String, String> _attributeNames;
@@ -1385,6 +1427,8 @@ public class StyleBookEntryModelImpl
 		columnBitmasks.put("styleBookEntryKey", 131072L);
 
 		columnBitmasks.put("themeId", 262144L);
+
+		columnBitmasks.put("themeType", 524288L);
 
 		_columnBitmasks = Collections.unmodifiableMap(columnBitmasks);
 	}

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/model/impl/StyleBookEntryVersionCacheModel.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/model/impl/StyleBookEntryVersionCacheModel.java
@@ -69,7 +69,7 @@ public class StyleBookEntryVersionCacheModel
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler(39);
+		StringBundler sb = new StringBundler(41);
 
 		sb.append("{mvccVersion=");
 		sb.append(mvccVersion);
@@ -109,6 +109,8 @@ public class StyleBookEntryVersionCacheModel
 		sb.append(styleBookEntryKey);
 		sb.append(", themeId=");
 		sb.append(themeId);
+		sb.append(", themeType=");
+		sb.append(themeType);
 		sb.append("}");
 
 		return sb.toString();
@@ -200,6 +202,13 @@ public class StyleBookEntryVersionCacheModel
 			styleBookEntryVersionImpl.setThemeId(themeId);
 		}
 
+		if (themeType == null) {
+			styleBookEntryVersionImpl.setThemeType("");
+		}
+		else {
+			styleBookEntryVersionImpl.setThemeType(themeType);
+		}
+
 		styleBookEntryVersionImpl.resetOriginalValues();
 
 		return styleBookEntryVersionImpl;
@@ -237,6 +246,7 @@ public class StyleBookEntryVersionCacheModel
 		previewFileEntryId = objectInput.readLong();
 		styleBookEntryKey = objectInput.readUTF();
 		themeId = objectInput.readUTF();
+		themeType = objectInput.readUTF();
 	}
 
 	@Override
@@ -312,6 +322,13 @@ public class StyleBookEntryVersionCacheModel
 		else {
 			objectOutput.writeUTF(themeId);
 		}
+
+		if (themeType == null) {
+			objectOutput.writeUTF("");
+		}
+		else {
+			objectOutput.writeUTF(themeType);
+		}
 	}
 
 	public long mvccVersion;
@@ -333,5 +350,6 @@ public class StyleBookEntryVersionCacheModel
 	public long previewFileEntryId;
 	public String styleBookEntryKey;
 	public String themeId;
+	public String themeType;
 
 }

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/model/impl/StyleBookEntryVersionModelImpl.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/model/impl/StyleBookEntryVersionModelImpl.java
@@ -72,7 +72,8 @@ public class StyleBookEntryVersionModelImpl
 		{"defaultStyleBookEntry", Types.BOOLEAN},
 		{"frontendTokensValues", Types.CLOB}, {"name", Types.VARCHAR},
 		{"previewFileEntryId", Types.BIGINT},
-		{"styleBookEntryKey", Types.VARCHAR}, {"themeId", Types.VARCHAR}
+		{"styleBookEntryKey", Types.VARCHAR}, {"themeId", Types.VARCHAR},
+		{"themeType", Types.VARCHAR}
 	};
 
 	public static final Map<String, Integer> TABLE_COLUMNS_MAP =
@@ -98,10 +99,11 @@ public class StyleBookEntryVersionModelImpl
 		TABLE_COLUMNS_MAP.put("previewFileEntryId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("styleBookEntryKey", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("themeId", Types.VARCHAR);
+		TABLE_COLUMNS_MAP.put("themeType", Types.VARCHAR);
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table StyleBookEntryVersion (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,styleBookEntryVersionId LONG not null,version INTEGER,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,styleBookEntryId LONG,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,defaultStyleBookEntry BOOLEAN,frontendTokensValues TEXT null,name VARCHAR(75) null,previewFileEntryId LONG,styleBookEntryKey VARCHAR(75) null,themeId VARCHAR(255) null,primary key (styleBookEntryVersionId, ctCollectionId))";
+		"create table StyleBookEntryVersion (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,styleBookEntryVersionId LONG not null,version INTEGER,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,styleBookEntryId LONG,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,defaultStyleBookEntry BOOLEAN,frontendTokensValues TEXT null,name VARCHAR(75) null,previewFileEntryId LONG,styleBookEntryKey VARCHAR(75) null,themeId VARCHAR(255) null,themeType VARCHAR(75) null,primary key (styleBookEntryVersionId, ctCollectionId))";
 
 	public static final String TABLE_SQL_DROP =
 		"drop table StyleBookEntryVersion";
@@ -322,6 +324,8 @@ public class StyleBookEntryVersionModelImpl
 				StyleBookEntryVersion::getStyleBookEntryKey);
 			attributeGetterFunctions.put(
 				"themeId", StyleBookEntryVersion::getThemeId);
+			attributeGetterFunctions.put(
+				"themeType", StyleBookEntryVersion::getThemeType);
 
 			_attributeGetterFunctions = Collections.unmodifiableMap(
 				attributeGetterFunctions);
@@ -417,6 +421,10 @@ public class StyleBookEntryVersionModelImpl
 				"themeId",
 				(BiConsumer<StyleBookEntryVersion, String>)
 					StyleBookEntryVersion::setThemeId);
+			attributeSetterBiConsumers.put(
+				"themeType",
+				(BiConsumer<StyleBookEntryVersion, String>)
+					StyleBookEntryVersion::setThemeType);
 
 			_attributeSetterBiConsumers = Collections.unmodifiableMap(
 				(Map)attributeSetterBiConsumers);
@@ -446,6 +454,7 @@ public class StyleBookEntryVersionModelImpl
 		styleBookEntry.setPreviewFileEntryId(getPreviewFileEntryId());
 		styleBookEntry.setStyleBookEntryKey(getStyleBookEntryKey());
 		styleBookEntry.setThemeId(getThemeId());
+		styleBookEntry.setThemeType(getThemeType());
 	}
 
 	@Override
@@ -869,6 +878,25 @@ public class StyleBookEntryVersionModelImpl
 		_themeId = themeId;
 	}
 
+	@Override
+	public String getThemeType() {
+		if (_themeType == null) {
+			return "";
+		}
+		else {
+			return _themeType;
+		}
+	}
+
+	@Override
+	public void setThemeType(String themeType) {
+		if (_columnOriginalValues == Collections.EMPTY_MAP) {
+			_setColumnOriginalValues();
+		}
+
+		_themeType = themeType;
+	}
+
 	public long getColumnBitmask() {
 		if (_columnBitmask > 0) {
 			return _columnBitmask;
@@ -951,6 +979,7 @@ public class StyleBookEntryVersionModelImpl
 			getPreviewFileEntryId());
 		styleBookEntryVersionImpl.setStyleBookEntryKey(getStyleBookEntryKey());
 		styleBookEntryVersionImpl.setThemeId(getThemeId());
+		styleBookEntryVersionImpl.setThemeType(getThemeType());
 
 		styleBookEntryVersionImpl.resetOriginalValues();
 
@@ -1000,6 +1029,8 @@ public class StyleBookEntryVersionModelImpl
 			this.<String>getColumnOriginalValue("styleBookEntryKey"));
 		styleBookEntryVersionImpl.setThemeId(
 			this.<String>getColumnOriginalValue("themeId"));
+		styleBookEntryVersionImpl.setThemeType(
+			this.<String>getColumnOriginalValue("themeType"));
 
 		return styleBookEntryVersionImpl;
 	}
@@ -1196,6 +1227,14 @@ public class StyleBookEntryVersionModelImpl
 			styleBookEntryVersionCacheModel.themeId = null;
 		}
 
+		styleBookEntryVersionCacheModel.themeType = getThemeType();
+
+		String themeType = styleBookEntryVersionCacheModel.themeType;
+
+		if ((themeType != null) && (themeType.length() == 0)) {
+			styleBookEntryVersionCacheModel.themeType = null;
+		}
+
 		return styleBookEntryVersionCacheModel;
 	}
 
@@ -1278,6 +1317,7 @@ public class StyleBookEntryVersionModelImpl
 	private long _previewFileEntryId;
 	private String _styleBookEntryKey;
 	private String _themeId;
+	private String _themeType;
 
 	public <T> T getColumnValue(String columnName) {
 		columnName = _attributeNames.getOrDefault(columnName, columnName);
@@ -1332,6 +1372,7 @@ public class StyleBookEntryVersionModelImpl
 		_columnOriginalValues.put("previewFileEntryId", _previewFileEntryId);
 		_columnOriginalValues.put("styleBookEntryKey", _styleBookEntryKey);
 		_columnOriginalValues.put("themeId", _themeId);
+		_columnOriginalValues.put("themeType", _themeType);
 	}
 
 	private static final Map<String, String> _attributeNames;
@@ -1392,6 +1433,8 @@ public class StyleBookEntryVersionModelImpl
 		columnBitmasks.put("styleBookEntryKey", 131072L);
 
 		columnBitmasks.put("themeId", 262144L);
+
+		columnBitmasks.put("themeType", 524288L);
 
 		_columnBitmasks = Collections.unmodifiableMap(columnBitmasks);
 	}

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/base/StyleBookEntryLocalServiceBaseImpl.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/base/StyleBookEntryLocalServiceBaseImpl.java
@@ -898,6 +898,8 @@ public abstract class StyleBookEntryLocalServiceBaseImpl
 		draftStyleBookEntry.setStyleBookEntryKey(
 			publishedStyleBookEntry.getStyleBookEntryKey());
 		draftStyleBookEntry.setThemeId(publishedStyleBookEntry.getThemeId());
+		draftStyleBookEntry.setThemeType(
+			publishedStyleBookEntry.getThemeType());
 
 		draftStyleBookEntry.resetOriginalValues();
 

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/http/StyleBookEntryServiceHttp.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/http/StyleBookEntryServiceHttp.java
@@ -44,6 +44,7 @@ public class StyleBookEntryServiceHttp {
 	public static com.liferay.style.book.model.StyleBookEntry addStyleBookEntry(
 			HttpPrincipal httpPrincipal, String externalReferenceCode,
 			long groupId, String name, String styleBookEntryKey, String themeId,
+			String themeType,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
@@ -54,7 +55,7 @@ public class StyleBookEntryServiceHttp {
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, externalReferenceCode, groupId, name,
-				styleBookEntryKey, themeId, serviceContext);
+				styleBookEntryKey, themeId, themeType, serviceContext);
 
 			Object returnObj = null;
 
@@ -87,7 +88,7 @@ public class StyleBookEntryServiceHttp {
 	public static com.liferay.style.book.model.StyleBookEntry addStyleBookEntry(
 			HttpPrincipal httpPrincipal, String externalReferenceCode,
 			long groupId, String frontendTokensValues, String name,
-			String styleBookEntryKey, String themeId,
+			String styleBookEntryKey, String themeId, String themeType,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
@@ -98,7 +99,7 @@ public class StyleBookEntryServiceHttp {
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, externalReferenceCode, groupId, frontendTokensValues,
-				name, styleBookEntryKey, themeId, serviceContext);
+				name, styleBookEntryKey, themeId, themeType, serviceContext);
 
 			Object returnObj = null;
 
@@ -634,12 +635,13 @@ public class StyleBookEntryServiceHttp {
 	private static final Class<?>[] _addStyleBookEntryParameterTypes0 =
 		new Class[] {
 			String.class, long.class, String.class, String.class, String.class,
-			com.liferay.portal.kernel.service.ServiceContext.class
+			String.class, com.liferay.portal.kernel.service.ServiceContext.class
 		};
 	private static final Class<?>[] _addStyleBookEntryParameterTypes1 =
 		new Class[] {
 			String.class, long.class, String.class, String.class, String.class,
-			String.class, com.liferay.portal.kernel.service.ServiceContext.class
+			String.class, String.class,
+			com.liferay.portal.kernel.service.ServiceContext.class
 		};
 	private static final Class<?>[] _copyStyleBookEntryParameterTypes2 =
 		new Class[] {

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/impl/StyleBookEntryLocalServiceImpl.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/impl/StyleBookEntryLocalServiceImpl.java
@@ -12,6 +12,7 @@ import com.liferay.portal.aop.AopService;
 import com.liferay.portal.dao.orm.custom.sql.CustomSQL;
 import com.liferay.portal.kernel.dao.orm.WildcardMode;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.ModelHintsUtil;
 import com.liferay.portal.kernel.model.Repository;
@@ -27,6 +28,8 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.style.book.constants.StyleBookPortletKeys;
 import com.liferay.style.book.exception.DuplicateStyleBookEntryKeyException;
 import com.liferay.style.book.exception.StyleBookEntryNameException;
+import com.liferay.style.book.exception.StyleBookEntryThemeIdException;
+import com.liferay.style.book.exception.StyleBookEntryThemeTypeException;
 import com.liferay.style.book.model.StyleBookEntry;
 import com.liferay.style.book.service.base.StyleBookEntryLocalServiceBaseImpl;
 
@@ -52,7 +55,7 @@ public class StyleBookEntryLocalServiceImpl
 			String externalReferenceCode, long userId, long groupId,
 			boolean defaultStyleBookEntry, String frontendTokensValues,
 			String name, String styleBookEntryKey, String themeId,
-			ServiceContext serviceContext)
+			String themeType, ServiceContext serviceContext)
 		throws PortalException {
 
 		User user = _userLocalService.getUser(userId);
@@ -66,7 +69,7 @@ public class StyleBookEntryLocalServiceImpl
 			serviceContext = new ServiceContext();
 		}
 
-		_validate(name);
+		_validate(companyId, name, themeId, themeType);
 
 		if (Validator.isNull(styleBookEntryKey)) {
 			styleBookEntryKey = generateStyleBookEntryKey(groupId, name);
@@ -96,6 +99,7 @@ public class StyleBookEntryLocalServiceImpl
 		styleBookEntry.setName(name);
 		styleBookEntry.setStyleBookEntryKey(styleBookEntryKey);
 		styleBookEntry.setThemeId(themeId);
+		styleBookEntry.setThemeType(themeType);
 
 		return publishDraft(styleBookEntry);
 	}
@@ -115,7 +119,7 @@ public class StyleBookEntryLocalServiceImpl
 			null, userId, groupId, false,
 			sourceStyleBookEntry.getFrontendTokensValues(), name,
 			StringPool.BLANK, sourceStyleBookEntry.getThemeId(),
-			serviceContext);
+			sourceStyleBookEntry.getThemeType(), serviceContext);
 
 		long previewFileEntryId = _copyStyleBookEntryPreviewFileEntry(
 			userId, groupId, sourceStyleBookEntry, targetStyleBookEntry);
@@ -335,7 +339,9 @@ public class StyleBookEntryLocalServiceImpl
 		StyleBookEntry styleBookEntry =
 			styleBookEntryPersistence.findByPrimaryKey(styleBookEntryId);
 
-		_validate(name);
+		_validate(
+			styleBookEntry.getCompanyId(), name, styleBookEntry.getThemeId(),
+			styleBookEntry.getThemeType());
 
 		styleBookEntry.setModifiedDate(new Date());
 		styleBookEntry.setName(name);
@@ -385,7 +391,9 @@ public class StyleBookEntryLocalServiceImpl
 		StyleBookEntry styleBookEntry =
 			styleBookEntryPersistence.findByPrimaryKey(styleBookEntryId);
 
-		_validate(name);
+		_validate(
+			styleBookEntry.getCompanyId(), name, styleBookEntry.getThemeId(),
+			styleBookEntry.getThemeType());
 
 		if (Validator.isNull(styleBookEntryKey)) {
 			styleBookEntryKey = generateStyleBookEntryKey(
@@ -421,7 +429,9 @@ public class StyleBookEntryLocalServiceImpl
 		StyleBookEntry styleBookEntry =
 			styleBookEntryPersistence.findByPrimaryKey(styleBookEntryId);
 
-		_validate(name);
+		_validate(
+			styleBookEntry.getCompanyId(), name, styleBookEntry.getThemeId(),
+			styleBookEntry.getThemeType());
 
 		styleBookEntry.setModifiedDate(new Date());
 		styleBookEntry.setFrontendTokensValues(frontendTokensValues);
@@ -514,7 +524,10 @@ public class StyleBookEntryLocalServiceImpl
 		return name;
 	}
 
-	private void _validate(String name) throws PortalException {
+	private void _validate(
+			long companyId, String name, String themeId, String themeType)
+		throws PortalException {
+
 		if (Validator.isNull(name)) {
 			throw new StyleBookEntryNameException("Name must not be null");
 		}
@@ -532,6 +545,18 @@ public class StyleBookEntryLocalServiceImpl
 		if (name.length() > nameMaxLength) {
 			throw new StyleBookEntryNameException(
 				"Maximum length of name exceeded");
+		}
+
+		if (!FeatureFlagManagerUtil.isEnabled(companyId, "LPD-30204")) {
+			return;
+		}
+
+		if (Validator.isNull(themeId)) {
+			throw new StyleBookEntryThemeIdException.MustNotBeNull();
+		}
+
+		if (Validator.isNull(themeType)) {
+			throw new StyleBookEntryThemeTypeException.MustNotBeNull();
 		}
 	}
 

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/impl/StyleBookEntryLocalServiceImpl.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/impl/StyleBookEntryLocalServiceImpl.java
@@ -339,9 +339,7 @@ public class StyleBookEntryLocalServiceImpl
 		StyleBookEntry styleBookEntry =
 			styleBookEntryPersistence.findByPrimaryKey(styleBookEntryId);
 
-		_validate(
-			styleBookEntry.getCompanyId(), name, styleBookEntry.getThemeId(),
-			styleBookEntry.getThemeType());
+		_validateName(name);
 
 		styleBookEntry.setModifiedDate(new Date());
 		styleBookEntry.setName(name);
@@ -391,9 +389,7 @@ public class StyleBookEntryLocalServiceImpl
 		StyleBookEntry styleBookEntry =
 			styleBookEntryPersistence.findByPrimaryKey(styleBookEntryId);
 
-		_validate(
-			styleBookEntry.getCompanyId(), name, styleBookEntry.getThemeId(),
-			styleBookEntry.getThemeType());
+		_validateName(name);
 
 		if (Validator.isNull(styleBookEntryKey)) {
 			styleBookEntryKey = generateStyleBookEntryKey(
@@ -429,9 +425,7 @@ public class StyleBookEntryLocalServiceImpl
 		StyleBookEntry styleBookEntry =
 			styleBookEntryPersistence.findByPrimaryKey(styleBookEntryId);
 
-		_validate(
-			styleBookEntry.getCompanyId(), name, styleBookEntry.getThemeId(),
-			styleBookEntry.getThemeType());
+		_validateName(name);
 
 		styleBookEntry.setModifiedDate(new Date());
 		styleBookEntry.setFrontendTokensValues(frontendTokensValues);
@@ -528,6 +522,22 @@ public class StyleBookEntryLocalServiceImpl
 			long companyId, String name, String themeId, String themeType)
 		throws PortalException {
 
+		_validateName(name);
+
+		if (!FeatureFlagManagerUtil.isEnabled(companyId, "LPD-30204")) {
+			return;
+		}
+
+		if (Validator.isNull(themeId)) {
+			throw new StyleBookEntryThemeIdException.MustNotBeNull();
+		}
+
+		if (Validator.isNull(themeType)) {
+			throw new StyleBookEntryThemeTypeException.MustNotBeNull();
+		}
+	}
+
+	private void _validateName(String name) throws StyleBookEntryNameException {
 		if (Validator.isNull(name)) {
 			throw new StyleBookEntryNameException("Name must not be null");
 		}
@@ -545,18 +555,6 @@ public class StyleBookEntryLocalServiceImpl
 		if (name.length() > nameMaxLength) {
 			throw new StyleBookEntryNameException(
 				"Maximum length of name exceeded");
-		}
-
-		if (!FeatureFlagManagerUtil.isEnabled(companyId, "LPD-30204")) {
-			return;
-		}
-
-		if (Validator.isNull(themeId)) {
-			throw new StyleBookEntryThemeIdException.MustNotBeNull();
-		}
-
-		if (Validator.isNull(themeType)) {
-			throw new StyleBookEntryThemeTypeException.MustNotBeNull();
 		}
 	}
 

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/impl/StyleBookEntryServiceImpl.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/impl/StyleBookEntryServiceImpl.java
@@ -34,20 +34,20 @@ public class StyleBookEntryServiceImpl extends StyleBookEntryServiceBaseImpl {
 	@Override
 	public StyleBookEntry addStyleBookEntry(
 			String externalReferenceCode, long groupId, String name,
-			String styleBookEntryKey, String themeId,
+			String styleBookEntryKey, String themeId, String themeType,
 			ServiceContext serviceContext)
 		throws PortalException {
 
 		return addStyleBookEntry(
 			externalReferenceCode, groupId, StringPool.BLANK, name,
-			styleBookEntryKey, themeId, serviceContext);
+			styleBookEntryKey, themeId, themeType, serviceContext);
 	}
 
 	@Override
 	public StyleBookEntry addStyleBookEntry(
 			String externalReferenceCode, long groupId,
 			String frontendTokensValues, String name, String styleBookEntryKey,
-			String themeId, ServiceContext serviceContext)
+			String themeId, String themeType, ServiceContext serviceContext)
 		throws PortalException {
 
 		_portletResourcePermission.check(
@@ -56,7 +56,7 @@ public class StyleBookEntryServiceImpl extends StyleBookEntryServiceBaseImpl {
 
 		return styleBookEntryLocalService.addStyleBookEntry(
 			externalReferenceCode, getUserId(), groupId, false,
-			frontendTokensValues, name, styleBookEntryKey, themeId,
+			frontendTokensValues, name, styleBookEntryKey, themeId, themeType,
 			serviceContext);
 	}
 

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/persistence/impl/StyleBookEntryPersistenceImpl.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/persistence/impl/StyleBookEntryPersistenceImpl.java
@@ -9468,6 +9468,7 @@ public class StyleBookEntryPersistenceImpl
 		ctMergeColumnNames.add("previewFileEntryId");
 		ctMergeColumnNames.add("styleBookEntryKey");
 		ctMergeColumnNames.add("themeId");
+		ctMergeColumnNames.add("themeType");
 
 		_ctColumnNamesMap.put(
 			CTColumnResolutionType.CONTROL, ctControlColumnNames);

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/persistence/impl/StyleBookEntryVersionPersistenceImpl.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/persistence/impl/StyleBookEntryVersionPersistenceImpl.java
@@ -9281,6 +9281,7 @@ public class StyleBookEntryVersionPersistenceImpl
 		ctMergeColumnNames.add("previewFileEntryId");
 		ctMergeColumnNames.add("styleBookEntryKey");
 		ctMergeColumnNames.add("themeId");
+		ctMergeColumnNames.add("themeType");
 
 		_ctColumnNamesMap.put(
 			CTColumnResolutionType.CONTROL, ctControlColumnNames);

--- a/modules/apps/style-book/style-book-service/src/main/resources/META-INF/module-hbm.xml
+++ b/modules/apps/style-book/style-book-service/src/main/resources/META-INF/module-hbm.xml
@@ -26,6 +26,7 @@
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="previewFileEntryId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="styleBookEntryKey" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="themeId" type="com.liferay.portal.dao.orm.hibernate.StringType" />
+		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="themeType" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 	</class>
 	<class dynamic-update="true" name="com.liferay.style.book.model.impl.StyleBookEntryVersionImpl" table="StyleBookEntryVersion">
 		<id access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="styleBookEntryVersionId" type="long">
@@ -49,5 +50,6 @@
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="previewFileEntryId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="styleBookEntryKey" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="themeId" type="com.liferay.portal.dao.orm.hibernate.StringType" />
+		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="themeType" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 	</class>
 </hibernate-mapping>

--- a/modules/apps/style-book/style-book-service/src/main/resources/META-INF/portlet-model-hints.xml
+++ b/modules/apps/style-book/style-book-service/src/main/resources/META-INF/portlet-model-hints.xml
@@ -24,6 +24,7 @@
 		<field name="themeId" type="String">
 			<hint name="max-length">255</hint>
 		</field>
+		<field name="themeType" type="String" />
 	</model>
 	<model name="com.liferay.style.book.model.StyleBookEntryVersion">
 		<field name="mvccVersion" type="long" />
@@ -49,5 +50,6 @@
 		<field name="themeId" type="String">
 			<hint name="max-length">255</hint>
 		</field>
+		<field name="themeType" type="String" />
 	</model>
 </model-hints>

--- a/modules/apps/style-book/style-book-service/src/main/resources/META-INF/sql/tables.sql
+++ b/modules/apps/style-book/style-book-service/src/main/resources/META-INF/sql/tables.sql
@@ -18,6 +18,7 @@ create table StyleBookEntry (
 	previewFileEntryId LONG,
 	styleBookEntryKey VARCHAR(75) null,
 	themeId VARCHAR(255) null,
+	themeType VARCHAR(75) null,
 	primary key (styleBookEntryId, ctCollectionId)
 );
 
@@ -41,5 +42,6 @@ create table StyleBookEntryVersion (
 	previewFileEntryId LONG,
 	styleBookEntryKey VARCHAR(75) null,
 	themeId VARCHAR(255) null,
+	themeType VARCHAR(75) null,
 	primary key (styleBookEntryVersionId, ctCollectionId)
 );

--- a/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/change/tracking/test/StyleBookEntryTableReferenceDefinitionTest.java
+++ b/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/change/tracking/test/StyleBookEntryTableReferenceDefinitionTest.java
@@ -42,6 +42,7 @@ public class StyleBookEntryTableReferenceDefinitionTest
 			null, TestPropsValues.getUserId(), TestPropsValues.getGroupId(),
 			false, StringPool.BLANK, RandomTestUtil.randomString(),
 			StringPool.BLANK, RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(),
 			ServiceContextTestUtil.getServiceContext());
 	}
 

--- a/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/change/tracking/test/StyleBookEntryVersionTableReferenceDefinitionTest.java
+++ b/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/change/tracking/test/StyleBookEntryVersionTableReferenceDefinitionTest.java
@@ -47,6 +47,7 @@ public class StyleBookEntryVersionTableReferenceDefinitionTest
 			null, TestPropsValues.getUserId(), TestPropsValues.getGroupId(),
 			false, StringPool.BLANK, RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(),
 			ServiceContextTestUtil.getServiceContext());
 	}
 

--- a/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/service/persistence/test/StyleBookEntryPersistenceTest.java
+++ b/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/service/persistence/test/StyleBookEntryPersistenceTest.java
@@ -153,6 +153,8 @@ public class StyleBookEntryPersistenceTest {
 
 		newStyleBookEntry.setThemeId(RandomTestUtil.randomString());
 
+		newStyleBookEntry.setThemeType(RandomTestUtil.randomString());
+
 		_styleBookEntries.add(_persistence.update(newStyleBookEntry));
 
 		StyleBookEntry existingStyleBookEntry = _persistence.findByPrimaryKey(
@@ -208,6 +210,9 @@ public class StyleBookEntryPersistenceTest {
 		Assert.assertEquals(
 			existingStyleBookEntry.getThemeId(),
 			newStyleBookEntry.getThemeId());
+		Assert.assertEquals(
+			existingStyleBookEntry.getThemeType(),
+			newStyleBookEntry.getThemeType());
 	}
 
 	@Test
@@ -241,6 +246,7 @@ public class StyleBookEntryPersistenceTest {
 		draftStyleBookEntry.setStyleBookEntryKey(
 			styleBookEntry.getStyleBookEntryKey());
 		draftStyleBookEntry.setThemeId(styleBookEntry.getThemeId());
+		draftStyleBookEntry.setThemeType(styleBookEntry.getThemeType());
 
 		_styleBookEntries.add(_persistence.update(draftStyleBookEntry));
 
@@ -287,6 +293,8 @@ public class StyleBookEntryPersistenceTest {
 			draftStyleBookEntry.getStyleBookEntryKey());
 		Assert.assertEquals(
 			styleBookEntry.getThemeId(), draftStyleBookEntry.getThemeId());
+		Assert.assertEquals(
+			styleBookEntry.getThemeType(), draftStyleBookEntry.getThemeType());
 	}
 
 	@Test(
@@ -336,6 +344,8 @@ public class StyleBookEntryPersistenceTest {
 		styleBookEntry2.setStyleBookEntryKey(RandomTestUtil.randomString());
 
 		styleBookEntry2.setThemeId(RandomTestUtil.randomString());
+
+		styleBookEntry2.setThemeType(RandomTestUtil.randomString());
 
 		_styleBookEntries.add(_persistence.update(styleBookEntry2));
 	}
@@ -557,7 +567,7 @@ public class StyleBookEntryPersistenceTest {
 			"userId", true, "userName", true, "createDate", true,
 			"modifiedDate", true, "defaultStyleBookEntry", true, "name", true,
 			"previewFileEntryId", true, "styleBookEntryKey", true, "themeId",
-			true);
+			true, "themeType", true);
 	}
 
 	@Test
@@ -903,6 +913,8 @@ public class StyleBookEntryPersistenceTest {
 		styleBookEntry.setStyleBookEntryKey(RandomTestUtil.randomString());
 
 		styleBookEntry.setThemeId(RandomTestUtil.randomString());
+
+		styleBookEntry.setThemeType(RandomTestUtil.randomString());
 
 		_styleBookEntries.add(_persistence.update(styleBookEntry));
 

--- a/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/service/persistence/test/StyleBookEntryVersionPersistenceTest.java
+++ b/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/service/persistence/test/StyleBookEntryVersionPersistenceTest.java
@@ -157,6 +157,8 @@ public class StyleBookEntryVersionPersistenceTest {
 
 		newStyleBookEntryVersion.setThemeId(RandomTestUtil.randomString());
 
+		newStyleBookEntryVersion.setThemeType(RandomTestUtil.randomString());
+
 		_styleBookEntryVersions.add(
 			_persistence.update(newStyleBookEntryVersion));
 
@@ -223,6 +225,9 @@ public class StyleBookEntryVersionPersistenceTest {
 		Assert.assertEquals(
 			existingStyleBookEntryVersion.getThemeId(),
 			newStyleBookEntryVersion.getThemeId());
+		Assert.assertEquals(
+			existingStyleBookEntryVersion.getThemeType(),
+			newStyleBookEntryVersion.getThemeType());
 	}
 
 	@Test
@@ -400,7 +405,8 @@ public class StyleBookEntryVersionPersistenceTest {
 			"groupId", true, "companyId", true, "userId", true, "userName",
 			true, "createDate", true, "modifiedDate", true,
 			"defaultStyleBookEntry", true, "name", true, "previewFileEntryId",
-			true, "styleBookEntryKey", true, "themeId", true);
+			true, "styleBookEntryKey", true, "themeId", true, "themeType",
+			true);
 	}
 
 	@Test
@@ -759,6 +765,8 @@ public class StyleBookEntryVersionPersistenceTest {
 			RandomTestUtil.randomString());
 
 		styleBookEntryVersion.setThemeId(RandomTestUtil.randomString());
+
+		styleBookEntryVersion.setThemeType(RandomTestUtil.randomString());
 
 		_styleBookEntryVersions.add(_persistence.update(styleBookEntryVersion));
 

--- a/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/service/test/StyleBookEntryLocalServiceTest.java
+++ b/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/service/test/StyleBookEntryLocalServiceTest.java
@@ -6,6 +6,7 @@
 package com.liferay.style.book.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -15,10 +16,13 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.style.book.exception.DuplicateStyleBookEntryExternalReferenceCodeException;
+import com.liferay.style.book.exception.StyleBookEntryThemeIdException;
+import com.liferay.style.book.exception.StyleBookEntryThemeTypeException;
 import com.liferay.style.book.model.StyleBookEntry;
 import com.liferay.style.book.service.StyleBookEntryLocalService;
 
@@ -50,6 +54,7 @@ public class StyleBookEntryLocalServiceTest {
 			_group, TestPropsValues.getUserId());
 	}
 
+	@FeatureFlags("LPD-30204")
 	@Test
 	public void testAddStyleBookEntry() throws Exception {
 		StyleBookEntry styleBookEntry =
@@ -61,6 +66,40 @@ public class StyleBookEntryLocalServiceTest {
 
 		Assert.assertTrue(
 			Validator.isNotNull(styleBookEntry.getExternalReferenceCode()));
+
+		try {
+			_styleBookEntryLocalService.addStyleBookEntry(
+				RandomTestUtil.randomString(), TestPropsValues.getUserId(),
+				_group.getGroupId(), false, null, RandomTestUtil.randomString(),
+				null, StringPool.BLANK, RandomTestUtil.randomString(),
+				_serviceContext);
+
+			Assert.fail();
+		}
+		catch (StyleBookEntryThemeIdException.MustNotBeNull
+					styleBookEntryThemeIdException) {
+
+			Assert.assertEquals(
+				"Theme ID must not be null",
+				styleBookEntryThemeIdException.getMessage());
+		}
+
+		try {
+			_styleBookEntryLocalService.addStyleBookEntry(
+				RandomTestUtil.randomString(), TestPropsValues.getUserId(),
+				_group.getGroupId(), false, null, RandomTestUtil.randomString(),
+				null, RandomTestUtil.randomString(), StringPool.BLANK,
+				_serviceContext);
+
+			Assert.fail();
+		}
+		catch (StyleBookEntryThemeTypeException.MustNotBeNull
+					styleBookEntryThemeTypeException) {
+
+			Assert.assertEquals(
+				"Theme type must not be null",
+				styleBookEntryThemeTypeException.getMessage());
+		}
 	}
 
 	@Test(

--- a/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/service/test/StyleBookEntryLocalServiceTest.java
+++ b/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/service/test/StyleBookEntryLocalServiceTest.java
@@ -56,7 +56,8 @@ public class StyleBookEntryLocalServiceTest {
 			_styleBookEntryLocalService.addStyleBookEntry(
 				RandomTestUtil.randomString(), TestPropsValues.getUserId(),
 				_group.getGroupId(), false, null, RandomTestUtil.randomString(),
-				null, RandomTestUtil.randomString(), _serviceContext);
+				null, RandomTestUtil.randomString(),
+				RandomTestUtil.randomString(), _serviceContext);
 
 		Assert.assertTrue(
 			Validator.isNotNull(styleBookEntry.getExternalReferenceCode()));
@@ -73,11 +74,13 @@ public class StyleBookEntryLocalServiceTest {
 		_styleBookEntryLocalService.addStyleBookEntry(
 			externalReferenceCode, TestPropsValues.getUserId(),
 			_group.getGroupId(), false, null, RandomTestUtil.randomString(),
-			null, RandomTestUtil.randomString(), _serviceContext);
+			null, RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			_serviceContext);
 		_styleBookEntryLocalService.addStyleBookEntry(
 			externalReferenceCode, TestPropsValues.getUserId(),
 			_group.getGroupId(), false, null, RandomTestUtil.randomString(),
-			null, RandomTestUtil.randomString(), _serviceContext);
+			null, RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			_serviceContext);
 	}
 
 	@Test
@@ -88,7 +91,8 @@ public class StyleBookEntryLocalServiceTest {
 			_styleBookEntryLocalService.addStyleBookEntry(
 				RandomTestUtil.randomString(), TestPropsValues.getUserId(),
 				_group.getGroupId(), false, null, RandomTestUtil.randomString(),
-				null, RandomTestUtil.randomString(), _serviceContext);
+				null, RandomTestUtil.randomString(),
+				RandomTestUtil.randomString(), _serviceContext);
 
 		_styleBookEntryLocalService.deleteStyleBookEntry(
 			styleBookEntry.getExternalReferenceCode(),

--- a/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/service/test/StyleBookEntryServiceTest.java
+++ b/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/service/test/StyleBookEntryServiceTest.java
@@ -64,7 +64,8 @@ public class StyleBookEntryServiceTest {
 			_styleBookEntryService.addStyleBookEntry(
 				RandomTestUtil.randomString(), _group.getGroupId(),
 				RandomTestUtil.randomString(), null,
-				RandomTestUtil.randomString(), _serviceContext);
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+				_serviceContext);
 
 			Assert.fail();
 		}
@@ -83,7 +84,8 @@ public class StyleBookEntryServiceTest {
 			_styleBookEntryService.addStyleBookEntry(
 				RandomTestUtil.randomString(), _group.getGroupId(),
 				RandomTestUtil.randomString(), null,
-				RandomTestUtil.randomString(), _serviceContext);
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+				_serviceContext);
 
 		_styleBookEntryService.deleteStyleBookEntry(
 			styleBookEntry.getExternalReferenceCode(),
@@ -102,7 +104,8 @@ public class StyleBookEntryServiceTest {
 			_styleBookEntryService.addStyleBookEntry(
 				RandomTestUtil.randomString(), _group.getGroupId(),
 				RandomTestUtil.randomString(), null,
-				RandomTestUtil.randomString(), _serviceContext);
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+				_serviceContext);
 
 		try {
 			UserTestUtil.setUser(
@@ -129,7 +132,8 @@ public class StyleBookEntryServiceTest {
 			_styleBookEntryService.addStyleBookEntry(
 				RandomTestUtil.randomString(), _group.getGroupId(),
 				RandomTestUtil.randomString(), null,
-				RandomTestUtil.randomString(), _serviceContext);
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+				_serviceContext);
 
 		StyleBookEntry curStyleBookEntry =
 			_styleBookEntryService.getStyleBookEntryByExternalReferenceCode(
@@ -149,7 +153,8 @@ public class StyleBookEntryServiceTest {
 			_styleBookEntryService.addStyleBookEntry(
 				RandomTestUtil.randomString(), _group.getGroupId(),
 				RandomTestUtil.randomString(), null,
-				RandomTestUtil.randomString(), _serviceContext);
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+				_serviceContext);
 
 		RoleTestUtil.removeResourcePermission(
 			RoleConstants.GUEST, StyleBookEntry.class.getName(),

--- a/modules/apps/style-book/style-book-web-test/src/testIntegration/java/com/liferay/style/book/web/internal/portlet/action/test/DeleteStyleBookEntryMVCActionCommandTest.java
+++ b/modules/apps/style-book/style-book-web-test/src/testIntegration/java/com/liferay/style/book/web/internal/portlet/action/test/DeleteStyleBookEntryMVCActionCommandTest.java
@@ -66,14 +66,14 @@ public class DeleteStyleBookEntryMVCActionCommandTest {
 				null, TestPropsValues.getUserId(), _group.getGroupId(), false,
 				StringPool.BLANK, RandomTestUtil.randomString(),
 				StringPool.BLANK, RandomTestUtil.randomString(),
-				_serviceContext);
+				RandomTestUtil.randomString(), _serviceContext);
 
 		StyleBookEntry styleBookEntry2 =
 			_styleBookEntryLocalService.addStyleBookEntry(
 				null, TestPropsValues.getUserId(), _group.getGroupId(), false,
 				StringPool.BLANK, RandomTestUtil.randomString(),
 				StringPool.BLANK, RandomTestUtil.randomString(),
-				_serviceContext);
+				RandomTestUtil.randomString(), _serviceContext);
 
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
 			new MockLiferayPortletActionRequest();
@@ -102,7 +102,8 @@ public class DeleteStyleBookEntryMVCActionCommandTest {
 			_styleBookEntryLocalService.addStyleBookEntry(
 				null, TestPropsValues.getUserId(), _group.getGroupId(), false,
 				StringPool.BLANK, name, StringPool.BLANK,
-				RandomTestUtil.randomString(), _serviceContext);
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+				_serviceContext);
 
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
 			new MockLiferayPortletActionRequest();
@@ -133,7 +134,7 @@ public class DeleteStyleBookEntryMVCActionCommandTest {
 				null, TestPropsValues.getUserId(), _group.getGroupId(), false,
 				StringPool.BLANK, RandomTestUtil.randomString(),
 				StringPool.BLANK, RandomTestUtil.randomString(),
-				_serviceContext);
+				RandomTestUtil.randomString(), _serviceContext);
 
 		FileEntry fileEntry = _addFileEntry(styleBookEntry);
 

--- a/modules/apps/style-book/style-book-web-test/src/testIntegration/java/com/liferay/style/book/web/internal/portlet/action/test/DeleteStyleBookEntryPreviewMVCActionCommandTest.java
+++ b/modules/apps/style-book/style-book-web-test/src/testIntegration/java/com/liferay/style/book/web/internal/portlet/action/test/DeleteStyleBookEntryPreviewMVCActionCommandTest.java
@@ -65,7 +65,7 @@ public class DeleteStyleBookEntryPreviewMVCActionCommandTest {
 				null, TestPropsValues.getUserId(), _group.getGroupId(), false,
 				StringPool.BLANK, RandomTestUtil.randomString(),
 				StringPool.BLANK, RandomTestUtil.randomString(),
-				_serviceContext);
+				RandomTestUtil.randomString(), _serviceContext);
 
 		FileEntry fileEntry = _addFileEntry(styleBookEntry);
 

--- a/modules/apps/style-book/style-book-web-test/src/testIntegration/java/com/liferay/style/book/web/internal/portlet/action/test/ExportImportStyleBookEntriesMVCResourceCommandTest.java
+++ b/modules/apps/style-book/style-book-web-test/src/testIntegration/java/com/liferay/style/book/web/internal/portlet/action/test/ExportImportStyleBookEntriesMVCResourceCommandTest.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -118,6 +119,7 @@ public class ExportImportStyleBookEntriesMVCResourceCommandTest {
 				_targetGroup.getGroupId(), styleBookEntryKey2));
 	}
 
+	@FeatureFlags("LPD-30204")
 	@Test
 	public void testExportImportSingleStyleBookEntry() throws Exception {
 		String name = RandomTestUtil.randomString();

--- a/modules/apps/style-book/style-book-web-test/src/testIntegration/java/com/liferay/style/book/web/internal/portlet/action/test/ExportImportStyleBookEntriesMVCResourceCommandTest.java
+++ b/modules/apps/style-book/style-book-web-test/src/testIntegration/java/com/liferay/style/book/web/internal/portlet/action/test/ExportImportStyleBookEntriesMVCResourceCommandTest.java
@@ -79,7 +79,8 @@ public class ExportImportStyleBookEntriesMVCResourceCommandTest {
 				null, TestPropsValues.getUserId(), _sourceGroup.getGroupId(),
 				false, _read("frontend-tokens-values.json"),
 				RandomTestUtil.randomString(), styleBookEntryKey1,
-				RandomTestUtil.randomString(), serviceContext);
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+				serviceContext);
 
 		String styleBookEntryKey2 = RandomTestUtil.randomString();
 
@@ -88,7 +89,8 @@ public class ExportImportStyleBookEntriesMVCResourceCommandTest {
 				null, TestPropsValues.getUserId(), _sourceGroup.getGroupId(),
 				false, _read("frontend-tokens-values.json"),
 				RandomTestUtil.randomString(), styleBookEntryKey2,
-				RandomTestUtil.randomString(), serviceContext);
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+				serviceContext);
 
 		File file = ReflectionTestUtil.invoke(
 			_exportStyleBookEntriesMVCResourceCommand,
@@ -130,7 +132,8 @@ public class ExportImportStyleBookEntriesMVCResourceCommandTest {
 			_styleBookEntryLocalService.addStyleBookEntry(
 				null, TestPropsValues.getUserId(), _sourceGroup.getGroupId(),
 				false, _read("frontend-tokens-values.json"), name,
-				styleBookEntryKey, themeId, serviceContext);
+				styleBookEntryKey, themeId, RandomTestUtil.randomString(),
+				serviceContext);
 
 		File file = ReflectionTestUtil.invoke(
 			_exportStyleBookEntriesMVCResourceCommand,
@@ -182,7 +185,8 @@ public class ExportImportStyleBookEntriesMVCResourceCommandTest {
 				null, TestPropsValues.getUserId(), _sourceGroup.getGroupId(),
 				false, _read("frontend-tokens-values.json"),
 				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-				RandomTestUtil.randomString(), serviceContext);
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+				serviceContext);
 
 		File file = ReflectionTestUtil.invoke(
 			_exportStyleBookEntriesMVCResourceCommand,
@@ -228,7 +232,8 @@ public class ExportImportStyleBookEntriesMVCResourceCommandTest {
 				null, TestPropsValues.getUserId(), _sourceGroup.getGroupId(),
 				false, _read("frontend-tokens-values.json"),
 				RandomTestUtil.randomString(), styleBookEntryKey,
-				RandomTestUtil.randomString(), serviceContext);
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+				serviceContext);
 
 		File file = ReflectionTestUtil.invoke(
 			_exportStyleBookEntriesMVCResourceCommand,
@@ -292,7 +297,8 @@ public class ExportImportStyleBookEntriesMVCResourceCommandTest {
 				null, TestPropsValues.getUserId(), _sourceGroup.getGroupId(),
 				false, _read("frontend-tokens-values.json"),
 				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-				RandomTestUtil.randomString(), serviceContext);
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+				serviceContext);
 
 		FileEntry fileEntry = _addFileEntry(styleBookEntry);
 

--- a/modules/apps/style-book/style-book-web-test/src/testIntegration/java/com/liferay/style/book/web/internal/portlet/action/test/StyleBookEntryServiceTest.java
+++ b/modules/apps/style-book/style-book-web-test/src/testIntegration/java/com/liferay/style/book/web/internal/portlet/action/test/StyleBookEntryServiceTest.java
@@ -53,6 +53,7 @@ public class StyleBookEntryServiceTest {
 			_styleBookEntryService.addStyleBookEntry(
 				null, _group.getGroupId(), RandomTestUtil.randomString(),
 				"STYLE_BOOK_ENTRY_KEY", RandomTestUtil.randomString(),
+				RandomTestUtil.randomString(),
 				ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
 
 		StyleBookEntry targetStyleBookEntry =

--- a/modules/apps/style-book/style-book-web-test/src/testIntegration/java/com/liferay/style/book/web/internal/portlet/action/test/UpdateStyleBookEntryDefaultMVCActionCommandTest.java
+++ b/modules/apps/style-book/style-book-web-test/src/testIntegration/java/com/liferay/style/book/web/internal/portlet/action/test/UpdateStyleBookEntryDefaultMVCActionCommandTest.java
@@ -78,7 +78,7 @@ public class UpdateStyleBookEntryDefaultMVCActionCommandTest {
 				null, TestPropsValues.getUserId(), _group.getGroupId(), false,
 				StringPool.BLANK, RandomTestUtil.randomString(),
 				StringPool.BLANK, RandomTestUtil.randomString(),
-				_serviceContext);
+				RandomTestUtil.randomString(), _serviceContext);
 
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
 			new MockLiferayPortletActionRequest();
@@ -109,7 +109,7 @@ public class UpdateStyleBookEntryDefaultMVCActionCommandTest {
 				null, TestPropsValues.getUserId(), _group.getGroupId(), false,
 				StringPool.BLANK, RandomTestUtil.randomString(),
 				StringPool.BLANK, RandomTestUtil.randomString(),
-				_serviceContext);
+				RandomTestUtil.randomString(), _serviceContext);
 
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
 			new MockLiferayPortletActionRequest();
@@ -137,7 +137,7 @@ public class UpdateStyleBookEntryDefaultMVCActionCommandTest {
 				null, TestPropsValues.getUserId(), _group.getGroupId(), false,
 				StringPool.BLANK, RandomTestUtil.randomString(),
 				StringPool.BLANK, RandomTestUtil.randomString(),
-				_serviceContext);
+				RandomTestUtil.randomString(), _serviceContext);
 
 		mockLiferayPortletActionRequest = new MockLiferayPortletActionRequest();
 
@@ -171,7 +171,7 @@ public class UpdateStyleBookEntryDefaultMVCActionCommandTest {
 				null, TestPropsValues.getUserId(), _group.getGroupId(), false,
 				StringPool.BLANK, RandomTestUtil.randomString(),
 				StringPool.BLANK, RandomTestUtil.randomString(),
-				_serviceContext);
+				RandomTestUtil.randomString(), _serviceContext);
 
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
 			new MockLiferayPortletActionRequest();

--- a/modules/apps/style-book/style-book-web-test/src/testIntegration/java/com/liferay/style/book/web/internal/portlet/action/test/UpdateStyleBookEntryNameMVCActionCommandTest.java
+++ b/modules/apps/style-book/style-book-web-test/src/testIntegration/java/com/liferay/style/book/web/internal/portlet/action/test/UpdateStyleBookEntryNameMVCActionCommandTest.java
@@ -93,7 +93,8 @@ public class UpdateStyleBookEntryNameMVCActionCommandTest {
 			_styleBookEntryLocalService.addStyleBookEntry(
 				null, TestPropsValues.getUserId(), _group.getGroupId(), false,
 				StringPool.BLANK, oldName, StringPool.BLANK,
-				RandomTestUtil.randomString(), _serviceContext);
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+				_serviceContext);
 
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
 			new MockLiferayPortletActionRequest();
@@ -136,7 +137,7 @@ public class UpdateStyleBookEntryNameMVCActionCommandTest {
 				null, TestPropsValues.getUserId(), _group.getGroupId(), false,
 				StringPool.BLANK, RandomTestUtil.randomString(),
 				StringPool.BLANK, RandomTestUtil.randomString(),
-				_serviceContext);
+				RandomTestUtil.randomString(), _serviceContext);
 
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
 			new MockLiferayPortletActionRequest();
@@ -163,7 +164,7 @@ public class UpdateStyleBookEntryNameMVCActionCommandTest {
 				null, TestPropsValues.getUserId(), _group.getGroupId(), false,
 				StringPool.BLANK, RandomTestUtil.randomString(),
 				StringPool.BLANK, RandomTestUtil.randomString(),
-				_serviceContext);
+				RandomTestUtil.randomString(), _serviceContext);
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
 			new MockLiferayPortletActionRequest();
 
@@ -189,7 +190,7 @@ public class UpdateStyleBookEntryNameMVCActionCommandTest {
 				null, TestPropsValues.getUserId(), _group.getGroupId(), false,
 				StringPool.BLANK, RandomTestUtil.randomString(),
 				StringPool.BLANK, RandomTestUtil.randomString(),
-				_serviceContext);
+				RandomTestUtil.randomString(), _serviceContext);
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
 			new MockLiferayPortletActionRequest();
 
@@ -215,7 +216,7 @@ public class UpdateStyleBookEntryNameMVCActionCommandTest {
 				null, TestPropsValues.getUserId(), _group.getGroupId(), false,
 				StringPool.BLANK, RandomTestUtil.randomString(),
 				StringPool.BLANK, RandomTestUtil.randomString(),
-				_serviceContext);
+				RandomTestUtil.randomString(), _serviceContext);
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
 			new MockLiferayPortletActionRequest();
 

--- a/modules/apps/style-book/style-book-web-test/src/testIntegration/java/com/liferay/style/book/web/internal/portlet/action/test/UpdateStyleBookEntryPreviewMVCActionCommandTest.java
+++ b/modules/apps/style-book/style-book-web-test/src/testIntegration/java/com/liferay/style/book/web/internal/portlet/action/test/UpdateStyleBookEntryPreviewMVCActionCommandTest.java
@@ -76,7 +76,8 @@ public class UpdateStyleBookEntryPreviewMVCActionCommandTest {
 		_styleBookEntry = _styleBookEntryLocalService.addStyleBookEntry(
 			null, TestPropsValues.getUserId(), _group.getGroupId(), false,
 			StringPool.BLANK, RandomTestUtil.randomString(), StringPool.BLANK,
-			RandomTestUtil.randomString(), serviceContext);
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			serviceContext);
 
 		_themeDisplay = new ThemeDisplay();
 

--- a/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/portlet/action/AddStyleBookEntryMVCActionCommand.java
+++ b/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/portlet/action/AddStyleBookEntryMVCActionCommand.java
@@ -5,7 +5,6 @@
 
 package com.liferay.style.book.web.internal.portlet.action;
 
-import com.liferay.client.extension.type.ThemeCSSCET;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
@@ -24,6 +23,7 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.style.book.constants.StyleBookConstants;
 import com.liferay.style.book.constants.StyleBookPortletKeys;
 import com.liferay.style.book.model.StyleBookEntry;
 import com.liferay.style.book.service.StyleBookEntryService;
@@ -91,13 +91,13 @@ public class AddStyleBookEntryMVCActionCommand extends BaseMVCActionCommand {
 		if (FeatureFlagManagerUtil.isEnabled(
 				themeDisplay.getCompanyId(), "LPD-30204")) {
 
-			themeType = ThemeCSSCET.class.getName();
+			themeType = StyleBookConstants.THEME_TYPE_THEME_CSS_CET;
 
 			Theme theme = _themeLocalService.fetchTheme(
 				themeDisplay.getCompanyId(), themeId);
 
 			if (theme != null) {
-				themeType = Theme.class.getName();
+				themeType = StyleBookConstants.THEME_TYPE_BUNDLE;
 			}
 		}
 

--- a/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/portlet/action/AddStyleBookEntryMVCActionCommand.java
+++ b/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/portlet/action/AddStyleBookEntryMVCActionCommand.java
@@ -5,19 +5,25 @@
 
 package com.liferay.style.book.web.internal.portlet.action;
 
+import com.liferay.client.extension.type.ThemeCSSCET;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.model.Theme;
 import com.liferay.portal.kernel.portlet.JSONPortletResponseUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextFactory;
+import com.liferay.portal.kernel.service.ThemeLocalService;
 import com.liferay.portal.kernel.servlet.SessionErrors;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.style.book.constants.StyleBookPortletKeys;
 import com.liferay.style.book.model.StyleBookEntry;
 import com.liferay.style.book.service.StyleBookEntryService;
@@ -77,12 +83,30 @@ public class AddStyleBookEntryMVCActionCommand extends BaseMVCActionCommand {
 		String name = ParamUtil.getString(actionRequest, "name");
 		String themeId = ParamUtil.getString(actionRequest, "themeId");
 
+		String themeType = StringPool.BLANK;
+
+		ThemeDisplay themeDisplay = (ThemeDisplay)actionRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		if (FeatureFlagManagerUtil.isEnabled(
+				themeDisplay.getCompanyId(), "LPD-30204")) {
+
+			themeType = ThemeCSSCET.class.getName();
+
+			Theme theme = _themeLocalService.fetchTheme(
+				themeDisplay.getCompanyId(), themeId);
+
+			if (theme != null) {
+				themeType = Theme.class.getName();
+			}
+		}
+
 		ServiceContext serviceContext = ServiceContextFactory.getInstance(
 			actionRequest);
 
 		return _styleBookEntryService.addStyleBookEntry(
 			null, serviceContext.getScopeGroupId(), name, StringPool.BLANK,
-			themeId, serviceContext);
+			themeId, themeType, serviceContext);
 	}
 
 	private String _getRedirectURL(
@@ -102,5 +126,8 @@ public class AddStyleBookEntryMVCActionCommand extends BaseMVCActionCommand {
 
 	@Reference
 	private StyleBookEntryService _styleBookEntryService;
+
+	@Reference
+	private ThemeLocalService _themeLocalService;
 
 }

--- a/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/zip/processor/StyleBookEntryZipProcessorImpl.java
+++ b/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/zip/processor/StyleBookEntryZipProcessorImpl.java
@@ -8,17 +8,14 @@ package com.liferay.style.book.web.internal.zip.processor;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.model.Company;
-import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Repository;
 import com.liferay.portal.kernel.portletfilerepository.PortletFileRepositoryUtil;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.service.CompanyLocalService;
-import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.util.FileUtil;
@@ -29,7 +26,6 @@ import com.liferay.portal.kernel.zip.ZipWriter;
 import com.liferay.portal.kernel.zip.ZipWriterFactory;
 import com.liferay.style.book.constants.StyleBookPortletKeys;
 import com.liferay.style.book.exception.DuplicateStyleBookEntryKeyException;
-import com.liferay.style.book.exception.StyleBookEntryThemeIdException;
 import com.liferay.style.book.model.StyleBookEntry;
 import com.liferay.style.book.service.StyleBookEntryLocalService;
 import com.liferay.style.book.service.StyleBookEntryService;
@@ -110,17 +106,9 @@ public class StyleBookEntryZipProcessorImpl
 
 	private StyleBookEntry _addStyleBookEntry(
 			long groupId, String frontendTokensValues, String name,
-			boolean overwrite, String styleBookEntryKey, String themeId)
+			boolean overwrite, String styleBookEntryKey, String themeId,
+			String themeType)
 		throws Exception {
-
-		Group group = _groupLocalService.getGroup(groupId);
-
-		if (FeatureFlagManagerUtil.isEnabled(
-				group.getCompanyId(), "LPD-30204") &&
-			Validator.isBlank(themeId)) {
-
-			throw new StyleBookEntryThemeIdException.MustNotBeNull();
-		}
 
 		StyleBookEntry styleBookEntry =
 			_styleBookEntryEntryLocalService.fetchStyleBookEntry(
@@ -134,7 +122,7 @@ public class StyleBookEntryZipProcessorImpl
 			if (styleBookEntry == null) {
 				styleBookEntry = _styleBookEntryEntryService.addStyleBookEntry(
 					null, groupId, frontendTokensValues, name,
-					styleBookEntryKey, themeId,
+					styleBookEntryKey, themeId, themeType,
 					ServiceContextThreadLocal.getServiceContext());
 			}
 			else {
@@ -318,6 +306,7 @@ public class StyleBookEntryZipProcessorImpl
 		String styleBookEntryContent = _getContent(zipFile, fileName);
 
 		String themeId = StringPool.BLANK;
+		String themeType = StringPool.BLANK;
 
 		if (Validator.isNotNull(styleBookEntryContent)) {
 			JSONObject styleBookEntryJSONObject = _jsonFactory.createJSONObject(
@@ -330,11 +319,12 @@ public class StyleBookEntryZipProcessorImpl
 				styleBookEntryJSONObject.getString("frontendTokensValuesPath"));
 			name = styleBookEntryJSONObject.getString("name");
 			themeId = styleBookEntryJSONObject.getString("themeId");
+			themeType = styleBookEntryJSONObject.getString("themeType");
 		}
 
 		StyleBookEntry styleBookEntry = _addStyleBookEntry(
 			groupId, frontendTokensValues, name, overwrite, styleBookEntryKey,
-			themeId);
+			themeId, themeType);
 
 		if (styleBookEntry == null) {
 			return;
@@ -378,9 +368,6 @@ public class StyleBookEntryZipProcessorImpl
 
 	@Reference
 	private CompanyLocalService _companyLocalService;
-
-	@Reference
-	private GroupLocalService _groupLocalService;
 
 	private List<StyleBookEntryZipProcessorImportResultEntry>
 		_importResultEntries;


### PR DESCRIPTION
Ticket https://liferay.atlassian.net/browse/LPD-48798

## Issue

This ticket came up after we notice it is valuable to have the theme type stored in the `StyleBookEntry`. That way we can assertively check whether a theme/themeCSSCET is available or not.

## Approach

Add a new field called `themeType` to `StyleBookEntry`.

@ethib137 @SelenaAungst @algobob 