### PR TITLE
LPD-47821 Add theme name and type in frontend token definition

### DIFF
--- a/modules/apps/frontend-token/frontend-token-definition-api/src/main/java/com/liferay/frontend/token/definition/FrontendTokenDefinition.java
+++ b/modules/apps/frontend-token/frontend-token-definition-api/src/main/java/com/liferay/frontend/token/definition/FrontendTokenDefinition.java
@@ -30,4 +30,6 @@ public interface FrontendTokenDefinition {
 
 	public String getThemeId();
 
+	public String getThemeName(Locale locale);
+
 }

--- a/modules/apps/frontend-token/frontend-token-definition-api/src/main/java/com/liferay/frontend/token/definition/FrontendTokenDefinition.java
+++ b/modules/apps/frontend-token/frontend-token-definition-api/src/main/java/com/liferay/frontend/token/definition/FrontendTokenDefinition.java
@@ -32,4 +32,6 @@ public interface FrontendTokenDefinition {
 
 	public String getThemeName(Locale locale);
 
+	public String getThemeType();
+
 }

--- a/modules/apps/frontend-token/frontend-token-definition-api/src/main/java/com/liferay/frontend/token/definition/constants/FrontendTokenDefinitionConstants.java
+++ b/modules/apps/frontend-token/frontend-token-definition-api/src/main/java/com/liferay/frontend/token/definition/constants/FrontendTokenDefinitionConstants.java
@@ -1,0 +1,17 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.frontend.token.definition.constants;
+
+/**
+ * @author Thiago Buarque
+ */
+public class FrontendTokenDefinitionConstants {
+
+	public static final String THEME_TYPE_BUNDLE = "bundle";
+
+	public static final String THEME_TYPE_THEME_CSS_CET = "themeCSSCET";
+
+}

--- a/modules/apps/frontend-token/frontend-token-definition-impl/src/main/java/com/liferay/frontend/token/definition/internal/FrontendTokenDefinitionImpl.java
+++ b/modules/apps/frontend-token/frontend-token-definition-impl/src/main/java/com/liferay/frontend/token/definition/internal/FrontendTokenDefinitionImpl.java
@@ -15,6 +15,8 @@ import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.resource.bundle.ResourceBundleLoader;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.LocalizationUtil;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -27,11 +29,13 @@ public class FrontendTokenDefinitionImpl implements FrontendTokenDefinition {
 
 	public FrontendTokenDefinitionImpl(
 		JSONObject jsonObject, JSONFactory jsonFactory,
-		ResourceBundleLoader resourceBundleLoader, String themeId) {
+		ResourceBundleLoader resourceBundleLoader, String themeId,
+		String themeName) {
 
 		_jsonFactory = jsonFactory;
 		_resourceBundleLoader = resourceBundleLoader;
 		_themeId = themeId;
+		_themeName = themeName;
 
 		_jsonLocalizer = createJSONLocalizer(jsonObject);
 
@@ -89,6 +93,12 @@ public class FrontendTokenDefinitionImpl implements FrontendTokenDefinition {
 		return _themeId;
 	}
 
+	@Override
+	public String getThemeName(Locale locale) {
+		return LocalizationUtil.getLocalization(
+			_themeName, LocaleUtil.toLanguageId(locale));
+	}
+
 	protected JSONLocalizer createJSONLocalizer(JSONObject jsonObject) {
 		return new JSONLocalizer(
 			_jsonFactory.looseSerializeDeep(jsonObject), _jsonFactory,
@@ -106,5 +116,6 @@ public class FrontendTokenDefinitionImpl implements FrontendTokenDefinition {
 	private final JSONLocalizer _jsonLocalizer;
 	private final ResourceBundleLoader _resourceBundleLoader;
 	private final String _themeId;
+	private final String _themeName;
 
 }

--- a/modules/apps/frontend-token/frontend-token-definition-impl/src/main/java/com/liferay/frontend/token/definition/internal/FrontendTokenDefinitionImpl.java
+++ b/modules/apps/frontend-token/frontend-token-definition-impl/src/main/java/com/liferay/frontend/token/definition/internal/FrontendTokenDefinitionImpl.java
@@ -30,12 +30,13 @@ public class FrontendTokenDefinitionImpl implements FrontendTokenDefinition {
 	public FrontendTokenDefinitionImpl(
 		JSONObject jsonObject, JSONFactory jsonFactory,
 		ResourceBundleLoader resourceBundleLoader, String themeId,
-		String themeName) {
+		String themeName, String themeType) {
 
 		_jsonFactory = jsonFactory;
 		_resourceBundleLoader = resourceBundleLoader;
 		_themeId = themeId;
 		_themeName = themeName;
+		_themeType = themeType;
 
 		_jsonLocalizer = createJSONLocalizer(jsonObject);
 
@@ -99,6 +100,11 @@ public class FrontendTokenDefinitionImpl implements FrontendTokenDefinition {
 			_themeName, LocaleUtil.toLanguageId(locale));
 	}
 
+	@Override
+	public String getThemeType() {
+		return _themeType;
+	}
+
 	protected JSONLocalizer createJSONLocalizer(JSONObject jsonObject) {
 		return new JSONLocalizer(
 			_jsonFactory.looseSerializeDeep(jsonObject), _jsonFactory,
@@ -117,5 +123,6 @@ public class FrontendTokenDefinitionImpl implements FrontendTokenDefinition {
 	private final ResourceBundleLoader _resourceBundleLoader;
 	private final String _themeId;
 	private final String _themeName;
+	private final String _themeType;
 
 }

--- a/modules/apps/frontend-token/frontend-token-definition-impl/src/main/java/com/liferay/frontend/token/definition/internal/FrontendTokenDefinitionRegistryImpl.java
+++ b/modules/apps/frontend-token/frontend-token-definition-impl/src/main/java/com/liferay/frontend/token/definition/internal/FrontendTokenDefinitionRegistryImpl.java
@@ -11,6 +11,7 @@ import com.liferay.client.extension.service.ClientExtensionEntryRelLocalService;
 import com.liferay.client.extension.type.ThemeCSSCET;
 import com.liferay.frontend.token.definition.FrontendTokenDefinition;
 import com.liferay.frontend.token.definition.FrontendTokenDefinitionRegistry;
+import com.liferay.frontend.token.definition.constants.FrontendTokenDefinitionConstants;
 import com.liferay.frontend.token.definition.internal.validator.FrontendTokenDefinitionJSONValidator;
 import com.liferay.osgi.util.ServiceTrackerFactory;
 import com.liferay.petra.concurrent.DCLSingleton;
@@ -190,7 +191,7 @@ public class FrontendTokenDefinitionRegistryImpl
 				frontendTokenDefinitionImpls.add(
 					new FrontendTokenDefinitionImpl(
 						jsonFactory.createJSONObject(json), jsonFactory,
-						resourceBundleLoader, themeId, StringPool.BLANK));
+						resourceBundleLoader, themeId, StringPool.BLANK, FrontendTokenDefinitionConstants.THEME_TYPE_BUNDLE));
 			}
 
 			return frontendTokenDefinitionImpls;
@@ -285,7 +286,8 @@ public class FrontendTokenDefinitionRegistryImpl
 					jsonFactory,
 					ResourceBundleLoaderUtil.getPortalResourceBundleLoader(),
 					themeCSSCET.getExternalReferenceCode(),
-					StringPool.BLANK));
+					themeCSSCET.getName(),
+					FrontendTokenDefinitionConstants.THEME_TYPE_THEME_CSS_CET));
 		}
 		catch (JSONException | JSONValidatorException exception) {
 			_log.error(

--- a/modules/apps/frontend-token/frontend-token-definition-impl/src/main/java/com/liferay/frontend/token/definition/internal/FrontendTokenDefinitionRegistryImpl.java
+++ b/modules/apps/frontend-token/frontend-token-definition-impl/src/main/java/com/liferay/frontend/token/definition/internal/FrontendTokenDefinitionRegistryImpl.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.PortletConstants;
 import com.liferay.portal.kernel.resource.bundle.ResourceBundleLoader;
 import com.liferay.portal.kernel.resource.bundle.ResourceBundleLoaderUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.URLUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -187,11 +188,13 @@ public class FrontendTokenDefinitionRegistryImpl
 			List<FrontendTokenDefinitionImpl> frontendTokenDefinitionImpls =
 				new ArrayList<>();
 
-			for (String themeId : getThemeIds(bundle)) {
+			for (Map<String, String> themeData : getThemesData(bundle)) {
 				frontendTokenDefinitionImpls.add(
 					new FrontendTokenDefinitionImpl(
 						jsonFactory.createJSONObject(json), jsonFactory,
-						resourceBundleLoader, themeId, StringPool.BLANK, FrontendTokenDefinitionConstants.THEME_TYPE_BUNDLE));
+						resourceBundleLoader, themeData.get("id"),
+						themeData.get("name"),
+						FrontendTokenDefinitionConstants.THEME_TYPE_BUNDLE));
 			}
 
 			return frontendTokenDefinitionImpls;
@@ -223,7 +226,7 @@ public class FrontendTokenDefinitionRegistryImpl
 		return webContextPath;
 	}
 
-	protected List<String> getThemeIds(Bundle bundle) {
+	protected List<Map<String, String>> getThemesData(Bundle bundle) {
 		URL url = bundle.getEntry("WEB-INF/liferay-look-and-feel.xml");
 
 		if (url == null) {
@@ -231,29 +234,33 @@ public class FrontendTokenDefinitionRegistryImpl
 		}
 
 		try {
-			List<String> themeIds = new ArrayList<>();
-
-			String servletContextName = getServletContextName(bundle);
+			List<Map<String, String>> themesData = new ArrayList<>();
 
 			String xml = URLUtil.toString(url);
 
 			xml = xml.replaceAll(StringPool.NEW_LINE, StringPool.SPACE);
 
-			Matcher matcher = _themeIdPattern.matcher(xml);
+			Matcher matcher = _themePattern.matcher(xml);
+
+			String servletContextName = getServletContextName(bundle);
 
 			while (matcher.find()) {
 				String themeId = matcher.group(1);
 
 				if (servletContextName != null) {
-					themeId =
-						themeId + PortletConstants.WAR_SEPARATOR +
-							servletContextName;
+					themeId +=
+						PortletConstants.WAR_SEPARATOR + servletContextName;
 				}
 
-				themeIds.add(portal.getJsSafePortletId(themeId));
+				themesData.add(
+					HashMapBuilder.put(
+						"id", portal.getJsSafePortletId(themeId)
+					).put(
+						"name", matcher.group(2)
+					).build());
 			}
 
-			return themeIds;
+			return themesData;
 		}
 		catch (IOException ioException) {
 			throw new RuntimeException(
@@ -370,8 +377,8 @@ public class FrontendTokenDefinitionRegistryImpl
 	private static final Log _log = LogFactoryUtil.getLog(
 		FrontendTokenDefinitionRegistryImpl.class);
 
-	private static final Pattern _themeIdPattern = Pattern.compile(
-		"<theme id=\"([^\"]*)\"[^>]*>");
+	private static final Pattern _themePattern = Pattern.compile(
+		"<theme id=\"([^\"]*)\"[^>]* name=\"([^\"]*)\"[^>]*>");
 
 	private BundleTracker<List<FrontendTokenDefinitionImpl>> _bundleTracker;
 

--- a/modules/apps/frontend-token/frontend-token-definition-impl/src/main/java/com/liferay/frontend/token/definition/internal/FrontendTokenDefinitionRegistryImpl.java
+++ b/modules/apps/frontend-token/frontend-token-definition-impl/src/main/java/com/liferay/frontend/token/definition/internal/FrontendTokenDefinitionRegistryImpl.java
@@ -190,7 +190,7 @@ public class FrontendTokenDefinitionRegistryImpl
 				frontendTokenDefinitionImpls.add(
 					new FrontendTokenDefinitionImpl(
 						jsonFactory.createJSONObject(json), jsonFactory,
-						resourceBundleLoader, themeId));
+						resourceBundleLoader, themeId, StringPool.BLANK));
 			}
 
 			return frontendTokenDefinitionImpls;
@@ -284,7 +284,8 @@ public class FrontendTokenDefinitionRegistryImpl
 						themeCSSCET.getFrontendTokenDefinitionJSON()),
 					jsonFactory,
 					ResourceBundleLoaderUtil.getPortalResourceBundleLoader(),
-					themeCSSCET.getExternalReferenceCode()));
+					themeCSSCET.getExternalReferenceCode(),
+					StringPool.BLANK));
 		}
 		catch (JSONException | JSONValidatorException exception) {
 			_log.error(

--- a/modules/apps/frontend-token/frontend-token-definition-impl/src/main/java/com/liferay/frontend/token/definition/internal/jaxrs/application/FrontendTokenDefinitionApplication.java
+++ b/modules/apps/frontend-token/frontend-token-definition-impl/src/main/java/com/liferay/frontend/token/definition/internal/jaxrs/application/FrontendTokenDefinitionApplication.java
@@ -114,7 +114,7 @@ public class FrontendTokenDefinitionApplication extends Application {
 
 		return new FrontendTokenDefinitionImpl(
 			_jsonFactory.createJSONObject(json), _jsonFactory, null,
-			StringPool.BLANK, StringPool.BLANK);
+			StringPool.BLANK, StringPool.BLANK, StringPool.BLANK);
 	}
 
 	private Response _getResponse(File file, Locale locale)

--- a/modules/apps/frontend-token/frontend-token-definition-impl/src/main/java/com/liferay/frontend/token/definition/internal/jaxrs/application/FrontendTokenDefinitionApplication.java
+++ b/modules/apps/frontend-token/frontend-token-definition-impl/src/main/java/com/liferay/frontend/token/definition/internal/jaxrs/application/FrontendTokenDefinitionApplication.java
@@ -114,7 +114,7 @@ public class FrontendTokenDefinitionApplication extends Application {
 
 		return new FrontendTokenDefinitionImpl(
 			_jsonFactory.createJSONObject(json), _jsonFactory, null,
-			StringPool.BLANK);
+			StringPool.BLANK, StringPool.BLANK);
 	}
 
 	private Response _getResponse(File file, Locale locale)

--- a/modules/apps/frontend-token/frontend-token-definition-impl/src/test/java/com/liferay/frontend/token/definition/internal/FrontendTokenDefinitionImplTest.java
+++ b/modules/apps/frontend-token/frontend-token-definition-impl/src/test/java/com/liferay/frontend/token/definition/internal/FrontendTokenDefinitionImplTest.java
@@ -52,7 +52,8 @@ public class FrontendTokenDefinitionImplTest {
 		FrontendTokenDefinition frontendTokenDefinition =
 			new FrontendTokenDefinitionImpl(
 				jsonFactory.createJSONObject(_FRONTEND_TOKEN_DEFINITION_JSON),
-				jsonFactory, null, "theme_id", RandomTestUtil.randomString());
+				jsonFactory, null, "theme_id", RandomTestUtil.randomString(),
+				RandomTestUtil.randomString());
 
 		Collection<FrontendTokenCategory> frontendTokenCategories =
 			frontendTokenDefinition.getFrontendTokenCategories();
@@ -111,7 +112,8 @@ public class FrontendTokenDefinitionImplTest {
 		FrontendTokenDefinition frontendTokenDefinition =
 			new FrontendTokenDefinitionImpl(
 				jsonFactory.createJSONObject(_FRONTEND_TOKEN_DEFINITION_JSON),
-				jsonFactory, null, "theme_id", RandomTestUtil.randomString());
+				jsonFactory, null, "theme_id", RandomTestUtil.randomString(),
+				RandomTestUtil.randomString());
 
 		Collection<FrontendTokenCategory> frontendTokenCategories =
 			frontendTokenDefinition.getFrontendTokenCategories();
@@ -168,7 +170,8 @@ public class FrontendTokenDefinitionImplTest {
 		FrontendTokenDefinition frontendTokenDefinition =
 			new FrontendTokenDefinitionImpl(
 				jsonFactory.createJSONObject(_FRONTEND_TOKEN_DEFINITION_JSON),
-				jsonFactory, null, "theme_id", RandomTestUtil.randomString());
+				jsonFactory, null, "theme_id", RandomTestUtil.randomString(),
+				RandomTestUtil.randomString());
 
 		Collection<FrontendTokenCategory> frontendTokenCategories =
 			frontendTokenDefinition.getFrontendTokenCategories();
@@ -248,7 +251,7 @@ public class FrontendTokenDefinitionImplTest {
 			new FrontendTokenDefinitionImpl(
 				jsonFactory.createJSONObject(_FRONTEND_TOKEN_DEFINITION_JSON),
 				jsonFactory, resourceBundleLoader, "theme_id",
-				RandomTestUtil.randomString());
+				RandomTestUtil.randomString(), RandomTestUtil.randomString());
 
 		JSONObject jsonObject = frontendTokenDefinitionImpl.getJSONObject(
 			LocaleUtil.ENGLISH);

--- a/modules/apps/frontend-token/frontend-token-definition-impl/src/test/java/com/liferay/frontend/token/definition/internal/FrontendTokenDefinitionImplTest.java
+++ b/modules/apps/frontend-token/frontend-token-definition-impl/src/test/java/com/liferay/frontend/token/definition/internal/FrontendTokenDefinitionImplTest.java
@@ -15,6 +15,7 @@ import com.liferay.portal.kernel.json.JSONException;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.resource.bundle.ResourceBundleLoader;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.URLUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
@@ -51,7 +52,7 @@ public class FrontendTokenDefinitionImplTest {
 		FrontendTokenDefinition frontendTokenDefinition =
 			new FrontendTokenDefinitionImpl(
 				jsonFactory.createJSONObject(_FRONTEND_TOKEN_DEFINITION_JSON),
-				jsonFactory, null, "theme_id");
+				jsonFactory, null, "theme_id", RandomTestUtil.randomString());
 
 		Collection<FrontendTokenCategory> frontendTokenCategories =
 			frontendTokenDefinition.getFrontendTokenCategories();
@@ -110,7 +111,7 @@ public class FrontendTokenDefinitionImplTest {
 		FrontendTokenDefinition frontendTokenDefinition =
 			new FrontendTokenDefinitionImpl(
 				jsonFactory.createJSONObject(_FRONTEND_TOKEN_DEFINITION_JSON),
-				jsonFactory, null, "theme_id");
+				jsonFactory, null, "theme_id", RandomTestUtil.randomString());
 
 		Collection<FrontendTokenCategory> frontendTokenCategories =
 			frontendTokenDefinition.getFrontendTokenCategories();
@@ -167,7 +168,7 @@ public class FrontendTokenDefinitionImplTest {
 		FrontendTokenDefinition frontendTokenDefinition =
 			new FrontendTokenDefinitionImpl(
 				jsonFactory.createJSONObject(_FRONTEND_TOKEN_DEFINITION_JSON),
-				jsonFactory, null, "theme_id");
+				jsonFactory, null, "theme_id", RandomTestUtil.randomString());
 
 		Collection<FrontendTokenCategory> frontendTokenCategories =
 			frontendTokenDefinition.getFrontendTokenCategories();
@@ -246,7 +247,8 @@ public class FrontendTokenDefinitionImplTest {
 		FrontendTokenDefinitionImpl frontendTokenDefinitionImpl =
 			new FrontendTokenDefinitionImpl(
 				jsonFactory.createJSONObject(_FRONTEND_TOKEN_DEFINITION_JSON),
-				jsonFactory, resourceBundleLoader, "theme_id");
+				jsonFactory, resourceBundleLoader, "theme_id",
+				RandomTestUtil.randomString());
 
 		JSONObject jsonObject = frontendTokenDefinitionImpl.getJSONObject(
 			LocaleUtil.ENGLISH);

--- a/modules/apps/frontend-token/frontend-token-definition-impl/src/test/java/com/liferay/frontend/token/definition/internal/FrontendTokenDefinitionRegistryImplTest.java
+++ b/modules/apps/frontend-token/frontend-token-definition-impl/src/test/java/com/liferay/frontend/token/definition/internal/FrontendTokenDefinitionRegistryImplTest.java
@@ -21,6 +21,7 @@ import java.net.URL;
 
 import java.util.Dictionary;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -141,21 +142,21 @@ public class FrontendTokenDefinitionRegistryImplTest {
 	}
 
 	@Test
-	public void testGetThemeIdsWithNontheme() {
+	public void testGetThemesDataWithNontheme() {
 		FrontendTokenDefinitionRegistryImpl
 			frontendTokenDefinitionRegistryImpl =
 				new FrontendTokenDefinitionRegistryImpl();
 
 		Bundle bundle = Mockito.mock(Bundle.class);
 
-		List<String> themeIds = frontendTokenDefinitionRegistryImpl.getThemeIds(
-			bundle);
+		List<Map<String, String>> themesData =
+			frontendTokenDefinitionRegistryImpl.getThemesData(bundle);
 
-		Assert.assertTrue(themeIds.isEmpty());
+		Assert.assertTrue(themesData.isEmpty());
 	}
 
 	@Test
-	public void testGetThemeIdsWithoutServletContext() {
+	public void testGetThemesDataWithoutServletContext() {
 		FrontendTokenDefinitionRegistryImpl
 			frontendTokenDefinitionRegistryImpl =
 				new FrontendTokenDefinitionRegistryImpl();
@@ -176,16 +177,25 @@ public class FrontendTokenDefinitionRegistryImplTest {
 
 		frontendTokenDefinitionRegistryImpl.portal = new PortalImpl();
 
-		List<String> themeIds = frontendTokenDefinitionRegistryImpl.getThemeIds(
-			bundle);
+		List<Map<String, String>> themesDataList =
+			frontendTokenDefinitionRegistryImpl.getThemesData(bundle);
 
-		Assert.assertEquals(themeIds.toString(), 2, themeIds.size());
-		Assert.assertEquals("classic", themeIds.get(0));
-		Assert.assertEquals("modern", themeIds.get(1));
+		Assert.assertEquals(
+			themesDataList.toString(), 2, themesDataList.size());
+
+		Map<String, String> themesData1 = themesDataList.get(0);
+
+		Assert.assertEquals("classic", themesData1.get("id"));
+		Assert.assertEquals("Classic", themesData1.get("name"));
+
+		Map<String, String> themesData2 = themesDataList.get(1);
+
+		Assert.assertEquals("modern", themesData2.get("id"));
+		Assert.assertEquals("Modern", themesData2.get("name"));
 	}
 
 	@Test
-	public void testGetThemeIdsWithServletContext() {
+	public void testGetThemesDataWithServletContext() {
 		FrontendTokenDefinitionRegistryImpl
 			frontendTokenDefinitionRegistryImpl =
 				new FrontendTokenDefinitionRegistryImpl();
@@ -210,13 +220,21 @@ public class FrontendTokenDefinitionRegistryImplTest {
 
 		frontendTokenDefinitionRegistryImpl.portal = new PortalImpl();
 
-		List<String> themeIds = frontendTokenDefinitionRegistryImpl.getThemeIds(
-			bundle);
+		List<Map<String, String>> themesDataList =
+			frontendTokenDefinitionRegistryImpl.getThemesData(bundle);
 
-		Assert.assertEquals(themeIds.toString(), 2, themeIds.size());
+		Assert.assertEquals(
+			themesDataList.toString(), 2, themesDataList.size());
 
-		Assert.assertEquals("classic_WAR_twothemes", themeIds.get(0));
-		Assert.assertEquals("modern_WAR_twothemes", themeIds.get(1));
+		Map<String, String> themesData1 = themesDataList.get(0);
+
+		Assert.assertEquals("classic_WAR_twothemes", themesData1.get("id"));
+		Assert.assertEquals("Classic", themesData1.get("name"));
+
+		Map<String, String> themesData2 = themesDataList.get(1);
+
+		Assert.assertEquals("modern_WAR_twothemes", themesData2.get("id"));
+		Assert.assertEquals("Modern", themesData2.get("name"));
 	}
 
 	private static final URL _frontendTokenDefinitionJSONURL =


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPD-47821

## Motivation
Currently, we only pass `themeId` when creating frontend token definition. Based on this info only, we can not know if a frontend token definition comes from a Theme or a Theme Css client extension. This PR is adding two more properties: `themeName` and `themeType`, which will allows to show some warnings with proper messages based on theme type and name. I created this PR to make it smaller.

