### PR TITLE
LPD-47819 Show list of compatible style books on Page Design Options -> Style Books tab

### DIFF
--- a/modules/apps/frontend-token/frontend-token-definition-api/src/main/java/com/liferay/frontend/token/definition/FrontendTokenDefinitionRegistry.java
+++ b/modules/apps/frontend-token/frontend-token-definition-api/src/main/java/com/liferay/frontend/token/definition/FrontendTokenDefinitionRegistry.java
@@ -5,6 +5,7 @@
 
 package com.liferay.frontend.token.definition;
 
+import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutSet;
 
 import java.util.List;
@@ -13,6 +14,8 @@ import java.util.List;
  * @author Iván Zaera
  */
 public interface FrontendTokenDefinitionRegistry {
+
+	public FrontendTokenDefinition getFrontendTokenDefinition(Layout layout);
 
 	public FrontendTokenDefinition getFrontendTokenDefinition(
 		LayoutSet layoutSet);

--- a/modules/apps/frontend-token/frontend-token-definition-impl/src/main/java/com/liferay/frontend/token/definition/internal/FrontendTokenDefinitionRegistryImpl.java
+++ b/modules/apps/frontend-token/frontend-token-definition-impl/src/main/java/com/liferay/frontend/token/definition/internal/FrontendTokenDefinitionRegistryImpl.java
@@ -16,12 +16,15 @@ import com.liferay.osgi.util.ServiceTrackerFactory;
 import com.liferay.petra.concurrent.DCLSingleton;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.json.validator.JSONValidatorException;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONException;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.PortletConstants;
+import com.liferay.portal.kernel.model.Theme;
 import com.liferay.portal.kernel.resource.bundle.ResourceBundleLoader;
 import com.liferay.portal.kernel.resource.bundle.ResourceBundleLoaderUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -62,6 +65,21 @@ public class FrontendTokenDefinitionRegistryImpl
 	implements FrontendTokenDefinitionRegistry {
 
 	@Override
+	public FrontendTokenDefinition getFrontendTokenDefinition(Layout layout) {
+		try {
+			Theme theme = layout.getTheme();
+
+			return _getFrontendTokenDefinition(
+				layout.getCompanyId(),
+				_getCETExternalReferenceCode(
+					layout.getClassNameId(), layout.getClassPK()),
+				theme.getThemeId());
+		}
+		catch (PortalException portalException) {
+			throw new RuntimeException(portalException);
+		}
+	}
+
 	public FrontendTokenDefinition getFrontendTokenDefinition(
 		LayoutSet layoutSet) {
 

--- a/modules/apps/frontend-token/frontend-token-definition-impl/src/main/java/com/liferay/frontend/token/definition/internal/FrontendTokenDefinitionRegistryImpl.java
+++ b/modules/apps/frontend-token/frontend-token-definition-impl/src/main/java/com/liferay/frontend/token/definition/internal/FrontendTokenDefinitionRegistryImpl.java
@@ -67,7 +67,9 @@ public class FrontendTokenDefinitionRegistryImpl
 
 		return _getFrontendTokenDefinition(
 			layoutSet.getCompanyId(),
-			_getCETExternalReferenceCode(layoutSet.getLayoutSetId()),
+			_getCETExternalReferenceCode(
+				_portal.getClassNameId(LayoutSet.class),
+				layoutSet.getLayoutSetId()),
 			layoutSet.getThemeId());
 	}
 
@@ -294,10 +296,12 @@ public class FrontendTokenDefinitionRegistryImpl
 		}
 	}
 
-	private String _getCETExternalReferenceCode(long layoutSetId) {
+	private String _getCETExternalReferenceCode(
+		long classNameId, long classPK) {
+
 		ClientExtensionEntryRel clientExtensionEntryRel =
 			_clientExtensionEntryRelLocalService.fetchClientExtensionEntryRel(
-				_portal.getClassNameId(LayoutSet.class), layoutSetId,
+				classNameId, classPK,
 				ClientExtensionEntryConstants.TYPE_THEME_CSS);
 
 		if (clientExtensionEntryRel == null) {

--- a/modules/apps/layout/layout-admin-web/build.gradle
+++ b/modules/apps/layout/layout-admin-web/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-form-navigator")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-react")
+	compileOnly project(":apps:frontend-token:frontend-token-definition-api")
 	compileOnly project(":apps:headless:headless-delivery:headless-delivery-api")
 	compileOnly project(":apps:info:info-api")
 	compileOnly project(":apps:info:info-list-provider-item-selector-api")

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/item/selector/StyleBookEntryItemSelectorView.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/item/selector/StyleBookEntryItemSelectorView.java
@@ -5,11 +5,13 @@
 
 package com.liferay.layout.admin.web.internal.item.selector;
 
+import com.liferay.frontend.token.definition.FrontendTokenDefinitionRegistry;
 import com.liferay.item.selector.ItemSelectorReturnType;
 import com.liferay.item.selector.ItemSelectorView;
 import com.liferay.item.selector.ItemSelectorViewDescriptorRenderer;
 import com.liferay.item.selector.criteria.UUIDItemSelectorReturnType;
 import com.liferay.portal.kernel.language.Language;
+import com.liferay.style.book.service.StyleBookEntryLocalService;
 
 import java.io.IOException;
 
@@ -64,13 +66,18 @@ public class StyleBookEntryItemSelectorView
 			styleBookEntryItemSelectorCriterion, portletURL,
 			itemSelectedEventName, search,
 			new StyleBookEntryItemSelectorViewDescriptor(
+				_frontendTokenDefinitionRegistry,
 				(HttpServletRequest)servletRequest, portletURL,
-				styleBookEntryItemSelectorCriterion));
+				styleBookEntryItemSelectorCriterion,
+				_styleBookEntryLocalService));
 	}
 
 	private static final List<ItemSelectorReturnType>
 		_supportedItemSelectorReturnTypes = Collections.singletonList(
 			new UUIDItemSelectorReturnType());
+
+	@Reference
+	private FrontendTokenDefinitionRegistry _frontendTokenDefinitionRegistry;
 
 	@Reference
 	private ItemSelectorViewDescriptorRenderer
@@ -79,5 +86,8 @@ public class StyleBookEntryItemSelectorView
 
 	@Reference
 	private Language _language;
+
+	@Reference
+	private StyleBookEntryLocalService _styleBookEntryLocalService;
 
 }

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/item/selector/StyleBookEntryItemSelectorViewDescriptor.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/item/selector/StyleBookEntryItemSelectorViewDescriptor.java
@@ -95,27 +95,8 @@ public class StyleBookEntryItemSelectorViewDescriptor
 					JavaConstants.JAVAX_PORTLET_REQUEST),
 				_portletURL, null, "there-are-no-style-books");
 
-		StyleBookEntry styleFromThemeStyleBookEntry =
-			StyleBookEntryLocalServiceUtil.create();
-
-		styleFromThemeStyleBookEntry.setStyleBookEntryId(0);
-		styleFromThemeStyleBookEntry.setName(
-			LanguageUtil.get(_httpServletRequest, "styles-from-theme"));
-
-		StyleBookEntry defaultStyleBookEntry =
-			StyleBookEntryLocalServiceUtil.fetchDefaultStyleBookEntry(
-				_themeDisplay.getScopeGroupId());
-
-		if (defaultStyleBookEntry == null) {
-			styleFromThemeStyleBookEntry.setDefaultStyleBookEntry(true);
-		}
-
-		List<StyleBookEntry> styleBookEntries = ListUtil.fromArray(
-			styleFromThemeStyleBookEntry);
-
-		styleBookEntries.addAll(_getStyleBookEntries());
-
-		styleBookEntrySearchContainer.setResultsAndTotal(styleBookEntries);
+		styleBookEntrySearchContainer.setResultsAndTotal(
+			_getStyleBookEntries());
 
 		return styleBookEntrySearchContainer;
 	}
@@ -146,13 +127,34 @@ public class StyleBookEntryItemSelectorViewDescriptor
 	}
 
 	private List<StyleBookEntry> _getStyleBookEntries() {
+		StyleBookEntry styleFromThemeStyleBookEntry =
+			StyleBookEntryLocalServiceUtil.create();
+
+		styleFromThemeStyleBookEntry.setStyleBookEntryId(0);
+		styleFromThemeStyleBookEntry.setName(
+			LanguageUtil.get(_httpServletRequest, "styles-from-theme"));
+
+		StyleBookEntry defaultStyleBookEntry =
+			StyleBookEntryLocalServiceUtil.fetchDefaultStyleBookEntry(
+				_themeDisplay.getScopeGroupId());
+
+		if (defaultStyleBookEntry == null) {
+			styleFromThemeStyleBookEntry.setDefaultStyleBookEntry(true);
+		}
+
+		List<StyleBookEntry> styleBookEntries = ListUtil.fromArray(
+			styleFromThemeStyleBookEntry);
+
 		if (!FeatureFlagManagerUtil.isEnabled(
 				_themeDisplay.getCompanyId(), "LPD-30204")) {
 
-			return StyleBookEntryLocalServiceUtil.getStyleBookEntries(
-				StagingUtil.getLiveGroupId(_themeDisplay.getScopeGroupId()),
-				QueryUtil.ALL_POS, QueryUtil.ALL_POS,
-				StyleBookEntryNameComparator.getInstance(true));
+			styleBookEntries.addAll(
+				StyleBookEntryLocalServiceUtil.getStyleBookEntries(
+					StagingUtil.getLiveGroupId(_themeDisplay.getScopeGroupId()),
+					QueryUtil.ALL_POS, QueryUtil.ALL_POS,
+					StyleBookEntryNameComparator.getInstance(true)));
+
+			return styleBookEntries;
 		}
 
 		FrontendTokenDefinition frontendTokenDefinition =
@@ -163,9 +165,12 @@ public class StyleBookEntryItemSelectorViewDescriptor
 			return Collections.emptyList();
 		}
 
-		return _styleBookEntryLocalService.getStyleBookEntries(
-			StagingUtil.getLiveGroupId(_themeDisplay.getScopeGroupId()),
-			frontendTokenDefinition.getThemeId());
+		styleBookEntries.addAll(
+			_styleBookEntryLocalService.getStyleBookEntries(
+				StagingUtil.getLiveGroupId(_themeDisplay.getScopeGroupId()),
+				frontendTokenDefinition.getThemeId()));
+
+		return styleBookEntries;
 	}
 
 	private final FrontendTokenDefinitionRegistry

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/item/selector/StyleBookEntryItemSelectorViewDescriptor.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/item/selector/StyleBookEntryItemSelectorViewDescriptor.java
@@ -6,24 +6,29 @@
 package com.liferay.layout.admin.web.internal.item.selector;
 
 import com.liferay.exportimport.kernel.staging.StagingUtil;
+import com.liferay.frontend.token.definition.FrontendTokenDefinition;
+import com.liferay.frontend.token.definition.FrontendTokenDefinitionRegistry;
 import com.liferay.item.selector.ItemSelectorReturnType;
 import com.liferay.item.selector.ItemSelectorViewDescriptor;
 import com.liferay.item.selector.criteria.AssetEntryItemSelectorReturnType;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.JavaConstants;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.style.book.model.StyleBookEntry;
+import com.liferay.style.book.service.StyleBookEntryLocalService;
 import com.liferay.style.book.service.StyleBookEntryLocalServiceUtil;
 import com.liferay.style.book.util.comparator.StyleBookEntryNameComparator;
 
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import javax.portlet.PortletRequest;
@@ -38,14 +43,17 @@ public class StyleBookEntryItemSelectorViewDescriptor
 	implements ItemSelectorViewDescriptor<StyleBookEntry> {
 
 	public StyleBookEntryItemSelectorViewDescriptor(
+		FrontendTokenDefinitionRegistry frontendTokenDefinitionRegistry,
 		HttpServletRequest httpServletRequest, PortletURL portletURL,
-		StyleBookEntryItemSelectorCriterion
-			styleBookEntryItemSelectorCriterion) {
+		StyleBookEntryItemSelectorCriterion styleBookEntryItemSelectorCriterion,
+		StyleBookEntryLocalService styleBookEntryLocalService) {
 
+		_frontendTokenDefinitionRegistry = frontendTokenDefinitionRegistry;
 		_httpServletRequest = httpServletRequest;
 		_portletURL = portletURL;
 		_styleBookEntryItemSelectorCriterion =
 			styleBookEntryItemSelectorCriterion;
+		_styleBookEntryLocalService = styleBookEntryLocalService;
 
 		_themeDisplay = (ThemeDisplay)httpServletRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
@@ -87,8 +95,6 @@ public class StyleBookEntryItemSelectorViewDescriptor
 					JavaConstants.JAVAX_PORTLET_REQUEST),
 				_portletURL, null, "there-are-no-style-books");
 
-		List<StyleBookEntry> styleBookEntries = new ArrayList<>();
-
 		StyleBookEntry styleFromThemeStyleBookEntry =
 			StyleBookEntryLocalServiceUtil.create();
 
@@ -104,13 +110,10 @@ public class StyleBookEntryItemSelectorViewDescriptor
 			styleFromThemeStyleBookEntry.setDefaultStyleBookEntry(true);
 		}
 
-		styleBookEntries.add(styleFromThemeStyleBookEntry);
+		List<StyleBookEntry> styleBookEntries = ListUtil.fromArray(
+			styleFromThemeStyleBookEntry);
 
-		styleBookEntries.addAll(
-			StyleBookEntryLocalServiceUtil.getStyleBookEntries(
-				StagingUtil.getLiveGroupId(_themeDisplay.getScopeGroupId()),
-				QueryUtil.ALL_POS, QueryUtil.ALL_POS,
-				StyleBookEntryNameComparator.getInstance(true)));
+		styleBookEntries.addAll(_getStyleBookEntries());
 
 		styleBookEntrySearchContainer.setResultsAndTotal(styleBookEntries);
 
@@ -142,11 +145,37 @@ public class StyleBookEntryItemSelectorViewDescriptor
 		return _selLayout;
 	}
 
+	private List<StyleBookEntry> _getStyleBookEntries() {
+		if (!FeatureFlagManagerUtil.isEnabled(
+				_themeDisplay.getCompanyId(), "LPD-30204")) {
+
+			return StyleBookEntryLocalServiceUtil.getStyleBookEntries(
+				StagingUtil.getLiveGroupId(_themeDisplay.getScopeGroupId()),
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS,
+				StyleBookEntryNameComparator.getInstance(true));
+		}
+
+		FrontendTokenDefinition frontendTokenDefinition =
+			_frontendTokenDefinitionRegistry.getFrontendTokenDefinition(
+				_getSelLayout());
+
+		if (frontendTokenDefinition == null) {
+			return Collections.emptyList();
+		}
+
+		return _styleBookEntryLocalService.getStyleBookEntries(
+			StagingUtil.getLiveGroupId(_themeDisplay.getScopeGroupId()),
+			frontendTokenDefinition.getThemeId());
+	}
+
+	private final FrontendTokenDefinitionRegistry
+		_frontendTokenDefinitionRegistry;
 	private final HttpServletRequest _httpServletRequest;
 	private final PortletURL _portletURL;
 	private Layout _selLayout;
 	private final StyleBookEntryItemSelectorCriterion
 		_styleBookEntryItemSelectorCriterion;
+	private final StyleBookEntryLocalService _styleBookEntryLocalService;
 	private final ThemeDisplay _themeDisplay;
 
 }

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
@@ -66,6 +66,7 @@ import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.editor.configuration.EditorConfiguration;
 import com.liferay.portal.kernel.editor.configuration.EditorConfigurationFactoryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
@@ -1841,11 +1842,26 @@ public class ContentPageEditorDisplayContext {
 	private List<Map<String, Object>> _getStyleBooks() {
 		ArrayList<Map<String, Object>> styleBooks = new ArrayList<>();
 
-		List<StyleBookEntry> styleBookEntries =
-			_styleBookEntryLocalService.getStyleBookEntries(
+		List<StyleBookEntry> styleBookEntries = new ArrayList<>();
+
+		if (FeatureFlagManagerUtil.isEnabled("LPD-30204")) {
+			FrontendTokenDefinition frontendTokenDefinition =
+				_frontendTokenDefinitionRegistry.getFrontendTokenDefinition(
+					themeDisplay.getLayout());
+
+			if (frontendTokenDefinition != null) {
+				styleBookEntries =
+					_styleBookEntryLocalService.getStyleBookEntries(
+						_staging.getLiveGroupId(themeDisplay.getScopeGroupId()),
+						frontendTokenDefinition.getThemeId());
+			}
+		}
+		else {
+			styleBookEntries = _styleBookEntryLocalService.getStyleBookEntries(
 				_staging.getLiveGroupId(themeDisplay.getScopeGroupId()),
 				QueryUtil.ALL_POS, QueryUtil.ALL_POS,
 				StyleBookEntryNameComparator.getInstance(true));
+		}
 
 		for (StyleBookEntry styleBookEntry : styleBookEntries) {
 			styleBooks.add(

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page_design_options/components/PageDesignOptionsSidebar.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page_design_options/components/PageDesignOptionsSidebar.js
@@ -183,7 +183,11 @@ export default function PageDesignOptionsSidebar() {
 }
 
 const OptionList = ({options = [], icon, type}) => {
-	if (type === OPTIONS_TYPES.styleBook && !config.styleBookEnabled) {
+	if (
+		type === OPTIONS_TYPES.styleBook &&
+		!config.styleBookEnabled &&
+		!Liferay.FeatureFlags['LPD-30204']
+	) {
 		return (
 			<ClayAlert className="mt-3" displayType="info">
 				{config.isPrivateLayoutsEnabled

--- a/modules/apps/layout/layout-content-page-editor-web/src/test/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContextTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/test/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContextTest.java
@@ -1,0 +1,180 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.content.page.editor.web.internal.display.context;
+
+import com.liferay.exportimport.kernel.staging.Staging;
+import com.liferay.frontend.token.definition.FrontendTokenDefinition;
+import com.liferay.frontend.token.definition.FrontendTokenDefinitionRegistry;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.style.book.model.StyleBookEntry;
+import com.liferay.style.book.service.StyleBookEntryLocalService;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * @author Anderson Luiz
+ */
+public class ContentPageEditorDisplayContextTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@FeatureFlags("LPD-30204")
+	@Test
+	public void testGetStyleBooks() {
+		String themeId = RandomTestUtil.randomString();
+
+		FrontendTokenDefinition frontendTokenDefinition = Mockito.mock(
+			FrontendTokenDefinition.class);
+
+		Mockito.when(
+			frontendTokenDefinition.getThemeId()
+		).thenReturn(
+			themeId
+		);
+
+		FrontendTokenDefinitionRegistry frontendTokenDefinitionRegistry =
+			Mockito.mock(FrontendTokenDefinitionRegistry.class);
+
+		Mockito.when(
+			frontendTokenDefinitionRegistry.getFrontendTokenDefinition(
+				Mockito.any(Layout.class))
+		).thenReturn(
+			frontendTokenDefinition
+		);
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, _getThemeDisplay());
+
+		Staging staging = Mockito.mock(Staging.class);
+
+		Mockito.when(
+			staging.getLiveGroupId(Mockito.anyLong())
+		).thenReturn(
+			RandomTestUtil.randomLong()
+		);
+
+		StyleBookEntryLocalService styleBookEntryLocalService = Mockito.mock(
+			StyleBookEntryLocalService.class);
+
+		StyleBookEntry styleBookEntry1 = _newStyleBookEntry(
+			RandomTestUtil.randomString(), RandomTestUtil.randomString());
+
+		String name = RandomTestUtil.randomString();
+
+		StyleBookEntry styleBookEntry2 = _newStyleBookEntry(name, themeId);
+
+		Mockito.when(
+			styleBookEntryLocalService.getStyleBookEntries(
+				Mockito.anyLong(), Mockito.anyInt(), Mockito.anyInt(),
+				Mockito.any())
+		).thenReturn(
+			ListUtil.fromArray(styleBookEntry1, styleBookEntry2)
+		);
+
+		Mockito.when(
+			styleBookEntryLocalService.getStyleBookEntries(
+				Mockito.anyLong(), Mockito.anyString())
+		).thenReturn(
+			ListUtil.fromArray(styleBookEntry2)
+		);
+
+		ContentPageEditorDisplayContext contentPageEditorDisplayContext =
+			new ContentPageEditorDisplayContext(
+				null, null, null, null, null, null,
+				frontendTokenDefinitionRegistry, mockHttpServletRequest, null,
+				null, null, null, null, null, null, null, null, null, null,
+				null, null, null, null, null, null, null, null, null, null,
+				staging, null, styleBookEntryLocalService, null, null);
+
+		List<Map<String, Object>> result = ReflectionTestUtil.invoke(
+			contentPageEditorDisplayContext, "_getStyleBooks", new Class<?>[0]);
+
+		Mockito.verify(
+			styleBookEntryLocalService
+		).getStyleBookEntries(
+			Mockito.anyLong(), Mockito.anyString()
+		);
+
+		Assert.assertEquals(result.toString(), 1, result.size());
+
+		Map<String, Object> firstEntry = result.get(0);
+
+		Assert.assertEquals(name, firstEntry.get("name"));
+	}
+
+	private ThemeDisplay _getThemeDisplay() {
+		ThemeDisplay themeDisplay = Mockito.mock(ThemeDisplay.class);
+
+		Mockito.when(
+			themeDisplay.getCompanyId()
+		).thenReturn(
+			RandomTestUtil.randomLong()
+		);
+
+		Mockito.when(
+			themeDisplay.getScopeGroupId()
+		).thenReturn(
+			RandomTestUtil.randomLong()
+		);
+
+		Mockito.when(
+			themeDisplay.getThemeId()
+		).thenReturn(
+			RandomTestUtil.randomString()
+		);
+
+		Mockito.when(
+			themeDisplay.getLayout()
+		).thenReturn(
+			Mockito.mock(Layout.class)
+		);
+
+		return themeDisplay;
+	}
+
+	private StyleBookEntry _newStyleBookEntry(String name, String themeId) {
+		StyleBookEntry styleBookEntry = Mockito.mock(StyleBookEntry.class);
+
+		Mockito.when(
+			styleBookEntry.getThemeId()
+		).thenReturn(
+			themeId
+		);
+
+		Mockito.when(
+			styleBookEntry.getName()
+		).thenReturn(
+			name
+		);
+
+		return styleBookEntry;
+	}
+
+}

--- a/modules/apps/style-book/style-book-api/bnd.bnd
+++ b/modules/apps/style-book/style-book-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Style Book API
 Bundle-SymbolicName: com.liferay.style.book.api
-Bundle-Version: 9.1.1
+Bundle-Version: 9.2.0
 Export-Package:\
 	com.liferay.style.book.constants,\
 	com.liferay.style.book.exception,\

--- a/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryLocalService.java
+++ b/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryLocalService.java
@@ -331,6 +331,10 @@ public interface StyleBookEntryLocalService
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<StyleBookEntry> getStyleBookEntries(
+		long groupId, String themeId);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<StyleBookEntry> getStyleBookEntries(
 		long groupId, String name, int start, int end,
 		OrderByComparator<StyleBookEntry> orderByComparator);
 

--- a/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryLocalServiceUtil.java
+++ b/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryLocalServiceUtil.java
@@ -380,6 +380,12 @@ public class StyleBookEntryLocalServiceUtil {
 	}
 
 	public static List<StyleBookEntry> getStyleBookEntries(
+		long groupId, String themeId) {
+
+		return getService().getStyleBookEntries(groupId, themeId);
+	}
+
+	public static List<StyleBookEntry> getStyleBookEntries(
 		long groupId, String name, int start, int end,
 		OrderByComparator<StyleBookEntry> orderByComparator) {
 

--- a/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryLocalServiceWrapper.java
+++ b/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryLocalServiceWrapper.java
@@ -433,6 +433,14 @@ public class StyleBookEntryLocalServiceWrapper
 
 	@Override
 	public java.util.List<StyleBookEntry> getStyleBookEntries(
+		long groupId, String themeId) {
+
+		return _styleBookEntryLocalService.getStyleBookEntries(
+			groupId, themeId);
+	}
+
+	@Override
+	public java.util.List<StyleBookEntry> getStyleBookEntries(
 		long groupId, String name, int start, int end,
 		com.liferay.portal.kernel.util.OrderByComparator<StyleBookEntry>
 			orderByComparator) {

--- a/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/persistence/StyleBookEntryPersistence.java
+++ b/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/persistence/StyleBookEntryPersistence.java
@@ -2027,6 +2027,327 @@ public interface StyleBookEntryPersistence
 		long groupId, String styleBookEntryKey, boolean head);
 
 	/**
+	 * Returns all the style book entries where groupId = &#63; and themeId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @return the matching style book entries
+	 */
+	public java.util.List<StyleBookEntry> findByG_T(
+		long groupId, String themeId);
+
+	/**
+	 * Returns a range of all the style book entries where groupId = &#63; and themeId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>StyleBookEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param start the lower bound of the range of style book entries
+	 * @param end the upper bound of the range of style book entries (not inclusive)
+	 * @return the range of matching style book entries
+	 */
+	public java.util.List<StyleBookEntry> findByG_T(
+		long groupId, String themeId, int start, int end);
+
+	/**
+	 * Returns an ordered range of all the style book entries where groupId = &#63; and themeId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>StyleBookEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param start the lower bound of the range of style book entries
+	 * @param end the upper bound of the range of style book entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching style book entries
+	 */
+	public java.util.List<StyleBookEntry> findByG_T(
+		long groupId, String themeId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<StyleBookEntry>
+			orderByComparator);
+
+	/**
+	 * Returns an ordered range of all the style book entries where groupId = &#63; and themeId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>StyleBookEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param start the lower bound of the range of style book entries
+	 * @param end the upper bound of the range of style book entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching style book entries
+	 */
+	public java.util.List<StyleBookEntry> findByG_T(
+		long groupId, String themeId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<StyleBookEntry>
+			orderByComparator,
+		boolean useFinderCache);
+
+	/**
+	 * Returns the first style book entry in the ordered set where groupId = &#63; and themeId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching style book entry
+	 * @throws NoSuchEntryException if a matching style book entry could not be found
+	 */
+	public StyleBookEntry findByG_T_First(
+			long groupId, String themeId,
+			com.liferay.portal.kernel.util.OrderByComparator<StyleBookEntry>
+				orderByComparator)
+		throws NoSuchEntryException;
+
+	/**
+	 * Returns the first style book entry in the ordered set where groupId = &#63; and themeId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching style book entry, or <code>null</code> if a matching style book entry could not be found
+	 */
+	public StyleBookEntry fetchByG_T_First(
+		long groupId, String themeId,
+		com.liferay.portal.kernel.util.OrderByComparator<StyleBookEntry>
+			orderByComparator);
+
+	/**
+	 * Returns the last style book entry in the ordered set where groupId = &#63; and themeId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching style book entry
+	 * @throws NoSuchEntryException if a matching style book entry could not be found
+	 */
+	public StyleBookEntry findByG_T_Last(
+			long groupId, String themeId,
+			com.liferay.portal.kernel.util.OrderByComparator<StyleBookEntry>
+				orderByComparator)
+		throws NoSuchEntryException;
+
+	/**
+	 * Returns the last style book entry in the ordered set where groupId = &#63; and themeId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching style book entry, or <code>null</code> if a matching style book entry could not be found
+	 */
+	public StyleBookEntry fetchByG_T_Last(
+		long groupId, String themeId,
+		com.liferay.portal.kernel.util.OrderByComparator<StyleBookEntry>
+			orderByComparator);
+
+	/**
+	 * Returns the style book entries before and after the current style book entry in the ordered set where groupId = &#63; and themeId = &#63;.
+	 *
+	 * @param styleBookEntryId the primary key of the current style book entry
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next style book entry
+	 * @throws NoSuchEntryException if a style book entry with the primary key could not be found
+	 */
+	public StyleBookEntry[] findByG_T_PrevAndNext(
+			long styleBookEntryId, long groupId, String themeId,
+			com.liferay.portal.kernel.util.OrderByComparator<StyleBookEntry>
+				orderByComparator)
+		throws NoSuchEntryException;
+
+	/**
+	 * Removes all the style book entries where groupId = &#63; and themeId = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 */
+	public void removeByG_T(long groupId, String themeId);
+
+	/**
+	 * Returns the number of style book entries where groupId = &#63; and themeId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @return the number of matching style book entries
+	 */
+	public int countByG_T(long groupId, String themeId);
+
+	/**
+	 * Returns all the style book entries where groupId = &#63; and themeId = &#63; and head = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param head the head
+	 * @return the matching style book entries
+	 */
+	public java.util.List<StyleBookEntry> findByG_T_Head(
+		long groupId, String themeId, boolean head);
+
+	/**
+	 * Returns a range of all the style book entries where groupId = &#63; and themeId = &#63; and head = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>StyleBookEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param head the head
+	 * @param start the lower bound of the range of style book entries
+	 * @param end the upper bound of the range of style book entries (not inclusive)
+	 * @return the range of matching style book entries
+	 */
+	public java.util.List<StyleBookEntry> findByG_T_Head(
+		long groupId, String themeId, boolean head, int start, int end);
+
+	/**
+	 * Returns an ordered range of all the style book entries where groupId = &#63; and themeId = &#63; and head = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>StyleBookEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param head the head
+	 * @param start the lower bound of the range of style book entries
+	 * @param end the upper bound of the range of style book entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching style book entries
+	 */
+	public java.util.List<StyleBookEntry> findByG_T_Head(
+		long groupId, String themeId, boolean head, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<StyleBookEntry>
+			orderByComparator);
+
+	/**
+	 * Returns an ordered range of all the style book entries where groupId = &#63; and themeId = &#63; and head = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>StyleBookEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param head the head
+	 * @param start the lower bound of the range of style book entries
+	 * @param end the upper bound of the range of style book entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching style book entries
+	 */
+	public java.util.List<StyleBookEntry> findByG_T_Head(
+		long groupId, String themeId, boolean head, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<StyleBookEntry>
+			orderByComparator,
+		boolean useFinderCache);
+
+	/**
+	 * Returns the first style book entry in the ordered set where groupId = &#63; and themeId = &#63; and head = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param head the head
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching style book entry
+	 * @throws NoSuchEntryException if a matching style book entry could not be found
+	 */
+	public StyleBookEntry findByG_T_Head_First(
+			long groupId, String themeId, boolean head,
+			com.liferay.portal.kernel.util.OrderByComparator<StyleBookEntry>
+				orderByComparator)
+		throws NoSuchEntryException;
+
+	/**
+	 * Returns the first style book entry in the ordered set where groupId = &#63; and themeId = &#63; and head = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param head the head
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching style book entry, or <code>null</code> if a matching style book entry could not be found
+	 */
+	public StyleBookEntry fetchByG_T_Head_First(
+		long groupId, String themeId, boolean head,
+		com.liferay.portal.kernel.util.OrderByComparator<StyleBookEntry>
+			orderByComparator);
+
+	/**
+	 * Returns the last style book entry in the ordered set where groupId = &#63; and themeId = &#63; and head = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param head the head
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching style book entry
+	 * @throws NoSuchEntryException if a matching style book entry could not be found
+	 */
+	public StyleBookEntry findByG_T_Head_Last(
+			long groupId, String themeId, boolean head,
+			com.liferay.portal.kernel.util.OrderByComparator<StyleBookEntry>
+				orderByComparator)
+		throws NoSuchEntryException;
+
+	/**
+	 * Returns the last style book entry in the ordered set where groupId = &#63; and themeId = &#63; and head = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param head the head
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching style book entry, or <code>null</code> if a matching style book entry could not be found
+	 */
+	public StyleBookEntry fetchByG_T_Head_Last(
+		long groupId, String themeId, boolean head,
+		com.liferay.portal.kernel.util.OrderByComparator<StyleBookEntry>
+			orderByComparator);
+
+	/**
+	 * Returns the style book entries before and after the current style book entry in the ordered set where groupId = &#63; and themeId = &#63; and head = &#63;.
+	 *
+	 * @param styleBookEntryId the primary key of the current style book entry
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param head the head
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next style book entry
+	 * @throws NoSuchEntryException if a style book entry with the primary key could not be found
+	 */
+	public StyleBookEntry[] findByG_T_Head_PrevAndNext(
+			long styleBookEntryId, long groupId, String themeId, boolean head,
+			com.liferay.portal.kernel.util.OrderByComparator<StyleBookEntry>
+				orderByComparator)
+		throws NoSuchEntryException;
+
+	/**
+	 * Removes all the style book entries where groupId = &#63; and themeId = &#63; and head = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param head the head
+	 */
+	public void removeByG_T_Head(long groupId, String themeId, boolean head);
+
+	/**
+	 * Returns the number of style book entries where groupId = &#63; and themeId = &#63; and head = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param head the head
+	 * @return the number of matching style book entries
+	 */
+	public int countByG_T_Head(long groupId, String themeId, boolean head);
+
+	/**
 	 * Returns all the style book entries where externalReferenceCode = &#63; and groupId = &#63;.
 	 *
 	 * @param externalReferenceCode the external reference code

--- a/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/persistence/StyleBookEntryUtil.java
+++ b/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/persistence/StyleBookEntryUtil.java
@@ -2516,6 +2516,393 @@ public class StyleBookEntryUtil {
 	}
 
 	/**
+	 * Returns all the style book entries where groupId = &#63; and themeId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @return the matching style book entries
+	 */
+	public static List<StyleBookEntry> findByG_T(long groupId, String themeId) {
+		return getPersistence().findByG_T(groupId, themeId);
+	}
+
+	/**
+	 * Returns a range of all the style book entries where groupId = &#63; and themeId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>StyleBookEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param start the lower bound of the range of style book entries
+	 * @param end the upper bound of the range of style book entries (not inclusive)
+	 * @return the range of matching style book entries
+	 */
+	public static List<StyleBookEntry> findByG_T(
+		long groupId, String themeId, int start, int end) {
+
+		return getPersistence().findByG_T(groupId, themeId, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the style book entries where groupId = &#63; and themeId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>StyleBookEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param start the lower bound of the range of style book entries
+	 * @param end the upper bound of the range of style book entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching style book entries
+	 */
+	public static List<StyleBookEntry> findByG_T(
+		long groupId, String themeId, int start, int end,
+		OrderByComparator<StyleBookEntry> orderByComparator) {
+
+		return getPersistence().findByG_T(
+			groupId, themeId, start, end, orderByComparator);
+	}
+
+	/**
+	 * Returns an ordered range of all the style book entries where groupId = &#63; and themeId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>StyleBookEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param start the lower bound of the range of style book entries
+	 * @param end the upper bound of the range of style book entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching style book entries
+	 */
+	public static List<StyleBookEntry> findByG_T(
+		long groupId, String themeId, int start, int end,
+		OrderByComparator<StyleBookEntry> orderByComparator,
+		boolean useFinderCache) {
+
+		return getPersistence().findByG_T(
+			groupId, themeId, start, end, orderByComparator, useFinderCache);
+	}
+
+	/**
+	 * Returns the first style book entry in the ordered set where groupId = &#63; and themeId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching style book entry
+	 * @throws NoSuchEntryException if a matching style book entry could not be found
+	 */
+	public static StyleBookEntry findByG_T_First(
+			long groupId, String themeId,
+			OrderByComparator<StyleBookEntry> orderByComparator)
+		throws com.liferay.style.book.exception.NoSuchEntryException {
+
+		return getPersistence().findByG_T_First(
+			groupId, themeId, orderByComparator);
+	}
+
+	/**
+	 * Returns the first style book entry in the ordered set where groupId = &#63; and themeId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching style book entry, or <code>null</code> if a matching style book entry could not be found
+	 */
+	public static StyleBookEntry fetchByG_T_First(
+		long groupId, String themeId,
+		OrderByComparator<StyleBookEntry> orderByComparator) {
+
+		return getPersistence().fetchByG_T_First(
+			groupId, themeId, orderByComparator);
+	}
+
+	/**
+	 * Returns the last style book entry in the ordered set where groupId = &#63; and themeId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching style book entry
+	 * @throws NoSuchEntryException if a matching style book entry could not be found
+	 */
+	public static StyleBookEntry findByG_T_Last(
+			long groupId, String themeId,
+			OrderByComparator<StyleBookEntry> orderByComparator)
+		throws com.liferay.style.book.exception.NoSuchEntryException {
+
+		return getPersistence().findByG_T_Last(
+			groupId, themeId, orderByComparator);
+	}
+
+	/**
+	 * Returns the last style book entry in the ordered set where groupId = &#63; and themeId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching style book entry, or <code>null</code> if a matching style book entry could not be found
+	 */
+	public static StyleBookEntry fetchByG_T_Last(
+		long groupId, String themeId,
+		OrderByComparator<StyleBookEntry> orderByComparator) {
+
+		return getPersistence().fetchByG_T_Last(
+			groupId, themeId, orderByComparator);
+	}
+
+	/**
+	 * Returns the style book entries before and after the current style book entry in the ordered set where groupId = &#63; and themeId = &#63;.
+	 *
+	 * @param styleBookEntryId the primary key of the current style book entry
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next style book entry
+	 * @throws NoSuchEntryException if a style book entry with the primary key could not be found
+	 */
+	public static StyleBookEntry[] findByG_T_PrevAndNext(
+			long styleBookEntryId, long groupId, String themeId,
+			OrderByComparator<StyleBookEntry> orderByComparator)
+		throws com.liferay.style.book.exception.NoSuchEntryException {
+
+		return getPersistence().findByG_T_PrevAndNext(
+			styleBookEntryId, groupId, themeId, orderByComparator);
+	}
+
+	/**
+	 * Removes all the style book entries where groupId = &#63; and themeId = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 */
+	public static void removeByG_T(long groupId, String themeId) {
+		getPersistence().removeByG_T(groupId, themeId);
+	}
+
+	/**
+	 * Returns the number of style book entries where groupId = &#63; and themeId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @return the number of matching style book entries
+	 */
+	public static int countByG_T(long groupId, String themeId) {
+		return getPersistence().countByG_T(groupId, themeId);
+	}
+
+	/**
+	 * Returns all the style book entries where groupId = &#63; and themeId = &#63; and head = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param head the head
+	 * @return the matching style book entries
+	 */
+	public static List<StyleBookEntry> findByG_T_Head(
+		long groupId, String themeId, boolean head) {
+
+		return getPersistence().findByG_T_Head(groupId, themeId, head);
+	}
+
+	/**
+	 * Returns a range of all the style book entries where groupId = &#63; and themeId = &#63; and head = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>StyleBookEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param head the head
+	 * @param start the lower bound of the range of style book entries
+	 * @param end the upper bound of the range of style book entries (not inclusive)
+	 * @return the range of matching style book entries
+	 */
+	public static List<StyleBookEntry> findByG_T_Head(
+		long groupId, String themeId, boolean head, int start, int end) {
+
+		return getPersistence().findByG_T_Head(
+			groupId, themeId, head, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the style book entries where groupId = &#63; and themeId = &#63; and head = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>StyleBookEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param head the head
+	 * @param start the lower bound of the range of style book entries
+	 * @param end the upper bound of the range of style book entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching style book entries
+	 */
+	public static List<StyleBookEntry> findByG_T_Head(
+		long groupId, String themeId, boolean head, int start, int end,
+		OrderByComparator<StyleBookEntry> orderByComparator) {
+
+		return getPersistence().findByG_T_Head(
+			groupId, themeId, head, start, end, orderByComparator);
+	}
+
+	/**
+	 * Returns an ordered range of all the style book entries where groupId = &#63; and themeId = &#63; and head = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>StyleBookEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param head the head
+	 * @param start the lower bound of the range of style book entries
+	 * @param end the upper bound of the range of style book entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching style book entries
+	 */
+	public static List<StyleBookEntry> findByG_T_Head(
+		long groupId, String themeId, boolean head, int start, int end,
+		OrderByComparator<StyleBookEntry> orderByComparator,
+		boolean useFinderCache) {
+
+		return getPersistence().findByG_T_Head(
+			groupId, themeId, head, start, end, orderByComparator,
+			useFinderCache);
+	}
+
+	/**
+	 * Returns the first style book entry in the ordered set where groupId = &#63; and themeId = &#63; and head = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param head the head
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching style book entry
+	 * @throws NoSuchEntryException if a matching style book entry could not be found
+	 */
+	public static StyleBookEntry findByG_T_Head_First(
+			long groupId, String themeId, boolean head,
+			OrderByComparator<StyleBookEntry> orderByComparator)
+		throws com.liferay.style.book.exception.NoSuchEntryException {
+
+		return getPersistence().findByG_T_Head_First(
+			groupId, themeId, head, orderByComparator);
+	}
+
+	/**
+	 * Returns the first style book entry in the ordered set where groupId = &#63; and themeId = &#63; and head = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param head the head
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching style book entry, or <code>null</code> if a matching style book entry could not be found
+	 */
+	public static StyleBookEntry fetchByG_T_Head_First(
+		long groupId, String themeId, boolean head,
+		OrderByComparator<StyleBookEntry> orderByComparator) {
+
+		return getPersistence().fetchByG_T_Head_First(
+			groupId, themeId, head, orderByComparator);
+	}
+
+	/**
+	 * Returns the last style book entry in the ordered set where groupId = &#63; and themeId = &#63; and head = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param head the head
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching style book entry
+	 * @throws NoSuchEntryException if a matching style book entry could not be found
+	 */
+	public static StyleBookEntry findByG_T_Head_Last(
+			long groupId, String themeId, boolean head,
+			OrderByComparator<StyleBookEntry> orderByComparator)
+		throws com.liferay.style.book.exception.NoSuchEntryException {
+
+		return getPersistence().findByG_T_Head_Last(
+			groupId, themeId, head, orderByComparator);
+	}
+
+	/**
+	 * Returns the last style book entry in the ordered set where groupId = &#63; and themeId = &#63; and head = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param head the head
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching style book entry, or <code>null</code> if a matching style book entry could not be found
+	 */
+	public static StyleBookEntry fetchByG_T_Head_Last(
+		long groupId, String themeId, boolean head,
+		OrderByComparator<StyleBookEntry> orderByComparator) {
+
+		return getPersistence().fetchByG_T_Head_Last(
+			groupId, themeId, head, orderByComparator);
+	}
+
+	/**
+	 * Returns the style book entries before and after the current style book entry in the ordered set where groupId = &#63; and themeId = &#63; and head = &#63;.
+	 *
+	 * @param styleBookEntryId the primary key of the current style book entry
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param head the head
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next style book entry
+	 * @throws NoSuchEntryException if a style book entry with the primary key could not be found
+	 */
+	public static StyleBookEntry[] findByG_T_Head_PrevAndNext(
+			long styleBookEntryId, long groupId, String themeId, boolean head,
+			OrderByComparator<StyleBookEntry> orderByComparator)
+		throws com.liferay.style.book.exception.NoSuchEntryException {
+
+		return getPersistence().findByG_T_Head_PrevAndNext(
+			styleBookEntryId, groupId, themeId, head, orderByComparator);
+	}
+
+	/**
+	 * Removes all the style book entries where groupId = &#63; and themeId = &#63; and head = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param head the head
+	 */
+	public static void removeByG_T_Head(
+		long groupId, String themeId, boolean head) {
+
+		getPersistence().removeByG_T_Head(groupId, themeId, head);
+	}
+
+	/**
+	 * Returns the number of style book entries where groupId = &#63; and themeId = &#63; and head = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param head the head
+	 * @return the number of matching style book entries
+	 */
+	public static int countByG_T_Head(
+		long groupId, String themeId, boolean head) {
+
+		return getPersistence().countByG_T_Head(groupId, themeId, head);
+	}
+
+	/**
 	 * Returns all the style book entries where externalReferenceCode = &#63; and groupId = &#63;.
 	 *
 	 * @param externalReferenceCode the external reference code

--- a/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/persistence/StyleBookEntryVersionPersistence.java
+++ b/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/persistence/StyleBookEntryVersionPersistence.java
@@ -2231,6 +2231,328 @@ public interface StyleBookEntryVersionPersistence
 		long groupId, String styleBookEntryKey, int version);
 
 	/**
+	 * Returns all the style book entry versions where groupId = &#63; and themeId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @return the matching style book entry versions
+	 */
+	public java.util.List<StyleBookEntryVersion> findByG_T(
+		long groupId, String themeId);
+
+	/**
+	 * Returns a range of all the style book entry versions where groupId = &#63; and themeId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>StyleBookEntryVersionModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param start the lower bound of the range of style book entry versions
+	 * @param end the upper bound of the range of style book entry versions (not inclusive)
+	 * @return the range of matching style book entry versions
+	 */
+	public java.util.List<StyleBookEntryVersion> findByG_T(
+		long groupId, String themeId, int start, int end);
+
+	/**
+	 * Returns an ordered range of all the style book entry versions where groupId = &#63; and themeId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>StyleBookEntryVersionModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param start the lower bound of the range of style book entry versions
+	 * @param end the upper bound of the range of style book entry versions (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching style book entry versions
+	 */
+	public java.util.List<StyleBookEntryVersion> findByG_T(
+		long groupId, String themeId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<StyleBookEntryVersion>
+			orderByComparator);
+
+	/**
+	 * Returns an ordered range of all the style book entry versions where groupId = &#63; and themeId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>StyleBookEntryVersionModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param start the lower bound of the range of style book entry versions
+	 * @param end the upper bound of the range of style book entry versions (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching style book entry versions
+	 */
+	public java.util.List<StyleBookEntryVersion> findByG_T(
+		long groupId, String themeId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<StyleBookEntryVersion>
+			orderByComparator,
+		boolean useFinderCache);
+
+	/**
+	 * Returns the first style book entry version in the ordered set where groupId = &#63; and themeId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching style book entry version
+	 * @throws NoSuchEntryVersionException if a matching style book entry version could not be found
+	 */
+	public StyleBookEntryVersion findByG_T_First(
+			long groupId, String themeId,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<StyleBookEntryVersion> orderByComparator)
+		throws NoSuchEntryVersionException;
+
+	/**
+	 * Returns the first style book entry version in the ordered set where groupId = &#63; and themeId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching style book entry version, or <code>null</code> if a matching style book entry version could not be found
+	 */
+	public StyleBookEntryVersion fetchByG_T_First(
+		long groupId, String themeId,
+		com.liferay.portal.kernel.util.OrderByComparator<StyleBookEntryVersion>
+			orderByComparator);
+
+	/**
+	 * Returns the last style book entry version in the ordered set where groupId = &#63; and themeId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching style book entry version
+	 * @throws NoSuchEntryVersionException if a matching style book entry version could not be found
+	 */
+	public StyleBookEntryVersion findByG_T_Last(
+			long groupId, String themeId,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<StyleBookEntryVersion> orderByComparator)
+		throws NoSuchEntryVersionException;
+
+	/**
+	 * Returns the last style book entry version in the ordered set where groupId = &#63; and themeId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching style book entry version, or <code>null</code> if a matching style book entry version could not be found
+	 */
+	public StyleBookEntryVersion fetchByG_T_Last(
+		long groupId, String themeId,
+		com.liferay.portal.kernel.util.OrderByComparator<StyleBookEntryVersion>
+			orderByComparator);
+
+	/**
+	 * Returns the style book entry versions before and after the current style book entry version in the ordered set where groupId = &#63; and themeId = &#63;.
+	 *
+	 * @param styleBookEntryVersionId the primary key of the current style book entry version
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next style book entry version
+	 * @throws NoSuchEntryVersionException if a style book entry version with the primary key could not be found
+	 */
+	public StyleBookEntryVersion[] findByG_T_PrevAndNext(
+			long styleBookEntryVersionId, long groupId, String themeId,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<StyleBookEntryVersion> orderByComparator)
+		throws NoSuchEntryVersionException;
+
+	/**
+	 * Removes all the style book entry versions where groupId = &#63; and themeId = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 */
+	public void removeByG_T(long groupId, String themeId);
+
+	/**
+	 * Returns the number of style book entry versions where groupId = &#63; and themeId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @return the number of matching style book entry versions
+	 */
+	public int countByG_T(long groupId, String themeId);
+
+	/**
+	 * Returns all the style book entry versions where groupId = &#63; and themeId = &#63; and version = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param version the version
+	 * @return the matching style book entry versions
+	 */
+	public java.util.List<StyleBookEntryVersion> findByG_T_Version(
+		long groupId, String themeId, int version);
+
+	/**
+	 * Returns a range of all the style book entry versions where groupId = &#63; and themeId = &#63; and version = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>StyleBookEntryVersionModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param version the version
+	 * @param start the lower bound of the range of style book entry versions
+	 * @param end the upper bound of the range of style book entry versions (not inclusive)
+	 * @return the range of matching style book entry versions
+	 */
+	public java.util.List<StyleBookEntryVersion> findByG_T_Version(
+		long groupId, String themeId, int version, int start, int end);
+
+	/**
+	 * Returns an ordered range of all the style book entry versions where groupId = &#63; and themeId = &#63; and version = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>StyleBookEntryVersionModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param version the version
+	 * @param start the lower bound of the range of style book entry versions
+	 * @param end the upper bound of the range of style book entry versions (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching style book entry versions
+	 */
+	public java.util.List<StyleBookEntryVersion> findByG_T_Version(
+		long groupId, String themeId, int version, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<StyleBookEntryVersion>
+			orderByComparator);
+
+	/**
+	 * Returns an ordered range of all the style book entry versions where groupId = &#63; and themeId = &#63; and version = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>StyleBookEntryVersionModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param version the version
+	 * @param start the lower bound of the range of style book entry versions
+	 * @param end the upper bound of the range of style book entry versions (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching style book entry versions
+	 */
+	public java.util.List<StyleBookEntryVersion> findByG_T_Version(
+		long groupId, String themeId, int version, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<StyleBookEntryVersion>
+			orderByComparator,
+		boolean useFinderCache);
+
+	/**
+	 * Returns the first style book entry version in the ordered set where groupId = &#63; and themeId = &#63; and version = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param version the version
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching style book entry version
+	 * @throws NoSuchEntryVersionException if a matching style book entry version could not be found
+	 */
+	public StyleBookEntryVersion findByG_T_Version_First(
+			long groupId, String themeId, int version,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<StyleBookEntryVersion> orderByComparator)
+		throws NoSuchEntryVersionException;
+
+	/**
+	 * Returns the first style book entry version in the ordered set where groupId = &#63; and themeId = &#63; and version = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param version the version
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching style book entry version, or <code>null</code> if a matching style book entry version could not be found
+	 */
+	public StyleBookEntryVersion fetchByG_T_Version_First(
+		long groupId, String themeId, int version,
+		com.liferay.portal.kernel.util.OrderByComparator<StyleBookEntryVersion>
+			orderByComparator);
+
+	/**
+	 * Returns the last style book entry version in the ordered set where groupId = &#63; and themeId = &#63; and version = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param version the version
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching style book entry version
+	 * @throws NoSuchEntryVersionException if a matching style book entry version could not be found
+	 */
+	public StyleBookEntryVersion findByG_T_Version_Last(
+			long groupId, String themeId, int version,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<StyleBookEntryVersion> orderByComparator)
+		throws NoSuchEntryVersionException;
+
+	/**
+	 * Returns the last style book entry version in the ordered set where groupId = &#63; and themeId = &#63; and version = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param version the version
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching style book entry version, or <code>null</code> if a matching style book entry version could not be found
+	 */
+	public StyleBookEntryVersion fetchByG_T_Version_Last(
+		long groupId, String themeId, int version,
+		com.liferay.portal.kernel.util.OrderByComparator<StyleBookEntryVersion>
+			orderByComparator);
+
+	/**
+	 * Returns the style book entry versions before and after the current style book entry version in the ordered set where groupId = &#63; and themeId = &#63; and version = &#63;.
+	 *
+	 * @param styleBookEntryVersionId the primary key of the current style book entry version
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param version the version
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next style book entry version
+	 * @throws NoSuchEntryVersionException if a style book entry version with the primary key could not be found
+	 */
+	public StyleBookEntryVersion[] findByG_T_Version_PrevAndNext(
+			long styleBookEntryVersionId, long groupId, String themeId,
+			int version,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<StyleBookEntryVersion> orderByComparator)
+		throws NoSuchEntryVersionException;
+
+	/**
+	 * Removes all the style book entry versions where groupId = &#63; and themeId = &#63; and version = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param version the version
+	 */
+	public void removeByG_T_Version(long groupId, String themeId, int version);
+
+	/**
+	 * Returns the number of style book entry versions where groupId = &#63; and themeId = &#63; and version = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param version the version
+	 * @return the number of matching style book entry versions
+	 */
+	public int countByG_T_Version(long groupId, String themeId, int version);
+
+	/**
 	 * Caches the style book entry version in the entity cache if it is enabled.
 	 *
 	 * @param styleBookEntryVersion the style book entry version

--- a/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/persistence/StyleBookEntryVersionUtil.java
+++ b/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/persistence/StyleBookEntryVersionUtil.java
@@ -2789,6 +2789,397 @@ public class StyleBookEntryVersionUtil {
 	}
 
 	/**
+	 * Returns all the style book entry versions where groupId = &#63; and themeId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @return the matching style book entry versions
+	 */
+	public static List<StyleBookEntryVersion> findByG_T(
+		long groupId, String themeId) {
+
+		return getPersistence().findByG_T(groupId, themeId);
+	}
+
+	/**
+	 * Returns a range of all the style book entry versions where groupId = &#63; and themeId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>StyleBookEntryVersionModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param start the lower bound of the range of style book entry versions
+	 * @param end the upper bound of the range of style book entry versions (not inclusive)
+	 * @return the range of matching style book entry versions
+	 */
+	public static List<StyleBookEntryVersion> findByG_T(
+		long groupId, String themeId, int start, int end) {
+
+		return getPersistence().findByG_T(groupId, themeId, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the style book entry versions where groupId = &#63; and themeId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>StyleBookEntryVersionModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param start the lower bound of the range of style book entry versions
+	 * @param end the upper bound of the range of style book entry versions (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching style book entry versions
+	 */
+	public static List<StyleBookEntryVersion> findByG_T(
+		long groupId, String themeId, int start, int end,
+		OrderByComparator<StyleBookEntryVersion> orderByComparator) {
+
+		return getPersistence().findByG_T(
+			groupId, themeId, start, end, orderByComparator);
+	}
+
+	/**
+	 * Returns an ordered range of all the style book entry versions where groupId = &#63; and themeId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>StyleBookEntryVersionModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param start the lower bound of the range of style book entry versions
+	 * @param end the upper bound of the range of style book entry versions (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching style book entry versions
+	 */
+	public static List<StyleBookEntryVersion> findByG_T(
+		long groupId, String themeId, int start, int end,
+		OrderByComparator<StyleBookEntryVersion> orderByComparator,
+		boolean useFinderCache) {
+
+		return getPersistence().findByG_T(
+			groupId, themeId, start, end, orderByComparator, useFinderCache);
+	}
+
+	/**
+	 * Returns the first style book entry version in the ordered set where groupId = &#63; and themeId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching style book entry version
+	 * @throws NoSuchEntryVersionException if a matching style book entry version could not be found
+	 */
+	public static StyleBookEntryVersion findByG_T_First(
+			long groupId, String themeId,
+			OrderByComparator<StyleBookEntryVersion> orderByComparator)
+		throws com.liferay.style.book.exception.NoSuchEntryVersionException {
+
+		return getPersistence().findByG_T_First(
+			groupId, themeId, orderByComparator);
+	}
+
+	/**
+	 * Returns the first style book entry version in the ordered set where groupId = &#63; and themeId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching style book entry version, or <code>null</code> if a matching style book entry version could not be found
+	 */
+	public static StyleBookEntryVersion fetchByG_T_First(
+		long groupId, String themeId,
+		OrderByComparator<StyleBookEntryVersion> orderByComparator) {
+
+		return getPersistence().fetchByG_T_First(
+			groupId, themeId, orderByComparator);
+	}
+
+	/**
+	 * Returns the last style book entry version in the ordered set where groupId = &#63; and themeId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching style book entry version
+	 * @throws NoSuchEntryVersionException if a matching style book entry version could not be found
+	 */
+	public static StyleBookEntryVersion findByG_T_Last(
+			long groupId, String themeId,
+			OrderByComparator<StyleBookEntryVersion> orderByComparator)
+		throws com.liferay.style.book.exception.NoSuchEntryVersionException {
+
+		return getPersistence().findByG_T_Last(
+			groupId, themeId, orderByComparator);
+	}
+
+	/**
+	 * Returns the last style book entry version in the ordered set where groupId = &#63; and themeId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching style book entry version, or <code>null</code> if a matching style book entry version could not be found
+	 */
+	public static StyleBookEntryVersion fetchByG_T_Last(
+		long groupId, String themeId,
+		OrderByComparator<StyleBookEntryVersion> orderByComparator) {
+
+		return getPersistence().fetchByG_T_Last(
+			groupId, themeId, orderByComparator);
+	}
+
+	/**
+	 * Returns the style book entry versions before and after the current style book entry version in the ordered set where groupId = &#63; and themeId = &#63;.
+	 *
+	 * @param styleBookEntryVersionId the primary key of the current style book entry version
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next style book entry version
+	 * @throws NoSuchEntryVersionException if a style book entry version with the primary key could not be found
+	 */
+	public static StyleBookEntryVersion[] findByG_T_PrevAndNext(
+			long styleBookEntryVersionId, long groupId, String themeId,
+			OrderByComparator<StyleBookEntryVersion> orderByComparator)
+		throws com.liferay.style.book.exception.NoSuchEntryVersionException {
+
+		return getPersistence().findByG_T_PrevAndNext(
+			styleBookEntryVersionId, groupId, themeId, orderByComparator);
+	}
+
+	/**
+	 * Removes all the style book entry versions where groupId = &#63; and themeId = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 */
+	public static void removeByG_T(long groupId, String themeId) {
+		getPersistence().removeByG_T(groupId, themeId);
+	}
+
+	/**
+	 * Returns the number of style book entry versions where groupId = &#63; and themeId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @return the number of matching style book entry versions
+	 */
+	public static int countByG_T(long groupId, String themeId) {
+		return getPersistence().countByG_T(groupId, themeId);
+	}
+
+	/**
+	 * Returns all the style book entry versions where groupId = &#63; and themeId = &#63; and version = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param version the version
+	 * @return the matching style book entry versions
+	 */
+	public static List<StyleBookEntryVersion> findByG_T_Version(
+		long groupId, String themeId, int version) {
+
+		return getPersistence().findByG_T_Version(groupId, themeId, version);
+	}
+
+	/**
+	 * Returns a range of all the style book entry versions where groupId = &#63; and themeId = &#63; and version = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>StyleBookEntryVersionModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param version the version
+	 * @param start the lower bound of the range of style book entry versions
+	 * @param end the upper bound of the range of style book entry versions (not inclusive)
+	 * @return the range of matching style book entry versions
+	 */
+	public static List<StyleBookEntryVersion> findByG_T_Version(
+		long groupId, String themeId, int version, int start, int end) {
+
+		return getPersistence().findByG_T_Version(
+			groupId, themeId, version, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the style book entry versions where groupId = &#63; and themeId = &#63; and version = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>StyleBookEntryVersionModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param version the version
+	 * @param start the lower bound of the range of style book entry versions
+	 * @param end the upper bound of the range of style book entry versions (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching style book entry versions
+	 */
+	public static List<StyleBookEntryVersion> findByG_T_Version(
+		long groupId, String themeId, int version, int start, int end,
+		OrderByComparator<StyleBookEntryVersion> orderByComparator) {
+
+		return getPersistence().findByG_T_Version(
+			groupId, themeId, version, start, end, orderByComparator);
+	}
+
+	/**
+	 * Returns an ordered range of all the style book entry versions where groupId = &#63; and themeId = &#63; and version = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>StyleBookEntryVersionModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param version the version
+	 * @param start the lower bound of the range of style book entry versions
+	 * @param end the upper bound of the range of style book entry versions (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching style book entry versions
+	 */
+	public static List<StyleBookEntryVersion> findByG_T_Version(
+		long groupId, String themeId, int version, int start, int end,
+		OrderByComparator<StyleBookEntryVersion> orderByComparator,
+		boolean useFinderCache) {
+
+		return getPersistence().findByG_T_Version(
+			groupId, themeId, version, start, end, orderByComparator,
+			useFinderCache);
+	}
+
+	/**
+	 * Returns the first style book entry version in the ordered set where groupId = &#63; and themeId = &#63; and version = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param version the version
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching style book entry version
+	 * @throws NoSuchEntryVersionException if a matching style book entry version could not be found
+	 */
+	public static StyleBookEntryVersion findByG_T_Version_First(
+			long groupId, String themeId, int version,
+			OrderByComparator<StyleBookEntryVersion> orderByComparator)
+		throws com.liferay.style.book.exception.NoSuchEntryVersionException {
+
+		return getPersistence().findByG_T_Version_First(
+			groupId, themeId, version, orderByComparator);
+	}
+
+	/**
+	 * Returns the first style book entry version in the ordered set where groupId = &#63; and themeId = &#63; and version = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param version the version
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching style book entry version, or <code>null</code> if a matching style book entry version could not be found
+	 */
+	public static StyleBookEntryVersion fetchByG_T_Version_First(
+		long groupId, String themeId, int version,
+		OrderByComparator<StyleBookEntryVersion> orderByComparator) {
+
+		return getPersistence().fetchByG_T_Version_First(
+			groupId, themeId, version, orderByComparator);
+	}
+
+	/**
+	 * Returns the last style book entry version in the ordered set where groupId = &#63; and themeId = &#63; and version = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param version the version
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching style book entry version
+	 * @throws NoSuchEntryVersionException if a matching style book entry version could not be found
+	 */
+	public static StyleBookEntryVersion findByG_T_Version_Last(
+			long groupId, String themeId, int version,
+			OrderByComparator<StyleBookEntryVersion> orderByComparator)
+		throws com.liferay.style.book.exception.NoSuchEntryVersionException {
+
+		return getPersistence().findByG_T_Version_Last(
+			groupId, themeId, version, orderByComparator);
+	}
+
+	/**
+	 * Returns the last style book entry version in the ordered set where groupId = &#63; and themeId = &#63; and version = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param version the version
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching style book entry version, or <code>null</code> if a matching style book entry version could not be found
+	 */
+	public static StyleBookEntryVersion fetchByG_T_Version_Last(
+		long groupId, String themeId, int version,
+		OrderByComparator<StyleBookEntryVersion> orderByComparator) {
+
+		return getPersistence().fetchByG_T_Version_Last(
+			groupId, themeId, version, orderByComparator);
+	}
+
+	/**
+	 * Returns the style book entry versions before and after the current style book entry version in the ordered set where groupId = &#63; and themeId = &#63; and version = &#63;.
+	 *
+	 * @param styleBookEntryVersionId the primary key of the current style book entry version
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param version the version
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next style book entry version
+	 * @throws NoSuchEntryVersionException if a style book entry version with the primary key could not be found
+	 */
+	public static StyleBookEntryVersion[] findByG_T_Version_PrevAndNext(
+			long styleBookEntryVersionId, long groupId, String themeId,
+			int version,
+			OrderByComparator<StyleBookEntryVersion> orderByComparator)
+		throws com.liferay.style.book.exception.NoSuchEntryVersionException {
+
+		return getPersistence().findByG_T_Version_PrevAndNext(
+			styleBookEntryVersionId, groupId, themeId, version,
+			orderByComparator);
+	}
+
+	/**
+	 * Removes all the style book entry versions where groupId = &#63; and themeId = &#63; and version = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param version the version
+	 */
+	public static void removeByG_T_Version(
+		long groupId, String themeId, int version) {
+
+		getPersistence().removeByG_T_Version(groupId, themeId, version);
+	}
+
+	/**
+	 * Returns the number of style book entry versions where groupId = &#63; and themeId = &#63; and version = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param version the version
+	 * @return the number of matching style book entry versions
+	 */
+	public static int countByG_T_Version(
+		long groupId, String themeId, int version) {
+
+		return getPersistence().countByG_T_Version(groupId, themeId, version);
+	}
+
+	/**
 	 * Caches the style book entry version in the entity cache if it is enabled.
 	 *
 	 * @param styleBookEntryVersion the style book entry version

--- a/modules/apps/style-book/style-book-api/src/main/resources/com/liferay/style/book/service/packageinfo
+++ b/modules/apps/style-book/style-book-api/src/main/resources/com/liferay/style/book/service/packageinfo
@@ -1,1 +1,1 @@
-version 5.0.0
+version 5.1.0

--- a/modules/apps/style-book/style-book-api/src/main/resources/com/liferay/style/book/service/persistence/packageinfo
+++ b/modules/apps/style-book/style-book-api/src/main/resources/com/liferay/style/book/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 1.4.0
+version 1.5.0

--- a/modules/apps/style-book/style-book-service/service.xml
+++ b/modules/apps/style-book/style-book-service/service.xml
@@ -53,6 +53,10 @@
 			<finder-column name="groupId" />
 			<finder-column name="styleBookEntryKey" />
 		</finder>
+		<finder name="G_T" return-type="Collection">
+			<finder-column name="groupId" />
+			<finder-column name="themeId" />
+		</finder>
 	</entity>
 	<exceptions>
 		<exception>DuplicateStyleBookEntryKey</exception>

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/model/impl/StyleBookEntryModelImpl.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/model/impl/StyleBookEntryModelImpl.java
@@ -173,14 +173,20 @@ public class StyleBookEntryModelImpl
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long UUID_COLUMN_BITMASK = 256L;
+	public static final long THEMEID_COLUMN_BITMASK = 256L;
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
+	 */
+	@Deprecated
+	public static final long UUID_COLUMN_BITMASK = 512L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
 	 *		#getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long CREATEDATE_COLUMN_BITMASK = 512L;
+	public static final long CREATEDATE_COLUMN_BITMASK = 1024L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
@@ -878,6 +884,15 @@ public class StyleBookEntryModelImpl
 		}
 
 		_themeId = themeId;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #getColumnOriginalValue(String)}
+	 */
+	@Deprecated
+	public String getOriginalThemeId() {
+		return getColumnOriginalValue("themeId");
 	}
 
 	@Override

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/model/impl/StyleBookEntryVersionModelImpl.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/model/impl/StyleBookEntryVersionModelImpl.java
@@ -158,13 +158,19 @@ public class StyleBookEntryVersionModelImpl
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long UUID_COLUMN_BITMASK = 64L;
+	public static final long THEMEID_COLUMN_BITMASK = 64L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long VERSION_COLUMN_BITMASK = 128L;
+	public static final long UUID_COLUMN_BITMASK = 128L;
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
+	 */
+	@Deprecated
+	public static final long VERSION_COLUMN_BITMASK = 256L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
@@ -867,6 +873,15 @@ public class StyleBookEntryVersionModelImpl
 		}
 
 		_themeId = themeId;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #getColumnOriginalValue(String)}
+	 */
+	@Deprecated
+	public String getOriginalThemeId() {
+		return getColumnOriginalValue("themeId");
 	}
 
 	public long getColumnBitmask() {

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/impl/StyleBookEntryLocalServiceImpl.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/impl/StyleBookEntryLocalServiceImpl.java
@@ -230,6 +230,13 @@ public class StyleBookEntryLocalServiceImpl
 
 	@Override
 	public List<StyleBookEntry> getStyleBookEntries(
+		long groupId, String themeId) {
+
+		return styleBookEntryPersistence.findByG_T(groupId, themeId);
+	}
+
+	@Override
+	public List<StyleBookEntry> getStyleBookEntries(
 		long groupId, String name, int start, int end,
 		OrderByComparator<StyleBookEntry> orderByComparator) {
 

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/persistence/impl/StyleBookEntryPersistenceImpl.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/persistence/impl/StyleBookEntryPersistenceImpl.java
@@ -7526,6 +7526,1226 @@ public class StyleBookEntryPersistenceImpl
 	private static final String _FINDER_COLUMN_G_SBEK_HEAD_HEAD_2 =
 		"styleBookEntry.head = ?";
 
+	private FinderPath _finderPathWithPaginationFindByG_T;
+	private FinderPath _finderPathWithoutPaginationFindByG_T;
+	private FinderPath _finderPathCountByG_T;
+
+	/**
+	 * Returns all the style book entries where groupId = &#63; and themeId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @return the matching style book entries
+	 */
+	@Override
+	public List<StyleBookEntry> findByG_T(long groupId, String themeId) {
+		return findByG_T(
+			groupId, themeId, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the style book entries where groupId = &#63; and themeId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>StyleBookEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param start the lower bound of the range of style book entries
+	 * @param end the upper bound of the range of style book entries (not inclusive)
+	 * @return the range of matching style book entries
+	 */
+	@Override
+	public List<StyleBookEntry> findByG_T(
+		long groupId, String themeId, int start, int end) {
+
+		return findByG_T(groupId, themeId, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the style book entries where groupId = &#63; and themeId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>StyleBookEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param start the lower bound of the range of style book entries
+	 * @param end the upper bound of the range of style book entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching style book entries
+	 */
+	@Override
+	public List<StyleBookEntry> findByG_T(
+		long groupId, String themeId, int start, int end,
+		OrderByComparator<StyleBookEntry> orderByComparator) {
+
+		return findByG_T(groupId, themeId, start, end, orderByComparator, true);
+	}
+
+	/**
+	 * Returns an ordered range of all the style book entries where groupId = &#63; and themeId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>StyleBookEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param start the lower bound of the range of style book entries
+	 * @param end the upper bound of the range of style book entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching style book entries
+	 */
+	@Override
+	public List<StyleBookEntry> findByG_T(
+		long groupId, String themeId, int start, int end,
+		OrderByComparator<StyleBookEntry> orderByComparator,
+		boolean useFinderCache) {
+
+		try (SafeCloseable safeCloseable =
+				ctPersistenceHelper.setCTCollectionIdWithSafeCloseable(
+					StyleBookEntry.class)) {
+
+			themeId = Objects.toString(themeId, "");
+
+			FinderPath finderPath = null;
+			Object[] finderArgs = null;
+
+			if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
+				(orderByComparator == null)) {
+
+				if (useFinderCache) {
+					finderPath = _finderPathWithoutPaginationFindByG_T;
+					finderArgs = new Object[] {groupId, themeId};
+				}
+			}
+			else if (useFinderCache) {
+				finderPath = _finderPathWithPaginationFindByG_T;
+				finderArgs = new Object[] {
+					groupId, themeId, start, end, orderByComparator
+				};
+			}
+
+			List<StyleBookEntry> list = null;
+
+			if (useFinderCache) {
+				list = (List<StyleBookEntry>)finderCache.getResult(
+					finderPath, finderArgs, this);
+
+				if ((list != null) && !list.isEmpty()) {
+					for (StyleBookEntry styleBookEntry : list) {
+						if ((groupId != styleBookEntry.getGroupId()) ||
+							!themeId.equals(styleBookEntry.getThemeId())) {
+
+							list = null;
+
+							break;
+						}
+					}
+				}
+			}
+
+			if (list == null) {
+				StringBundler sb = null;
+
+				if (orderByComparator != null) {
+					sb = new StringBundler(
+						4 + (orderByComparator.getOrderByFields().length * 2));
+				}
+				else {
+					sb = new StringBundler(4);
+				}
+
+				sb.append(_SQL_SELECT_STYLEBOOKENTRY_WHERE);
+
+				sb.append(_FINDER_COLUMN_G_T_GROUPID_2);
+
+				boolean bindThemeId = false;
+
+				if (themeId.isEmpty()) {
+					sb.append(_FINDER_COLUMN_G_T_THEMEID_3);
+				}
+				else {
+					bindThemeId = true;
+
+					sb.append(_FINDER_COLUMN_G_T_THEMEID_2);
+				}
+
+				if (orderByComparator != null) {
+					appendOrderByComparator(
+						sb, _ORDER_BY_ENTITY_ALIAS, orderByComparator);
+				}
+				else {
+					sb.append(StyleBookEntryModelImpl.ORDER_BY_JPQL);
+				}
+
+				String sql = sb.toString();
+
+				Session session = null;
+
+				try {
+					session = openSession();
+
+					Query query = session.createQuery(sql);
+
+					QueryPos queryPos = QueryPos.getInstance(query);
+
+					queryPos.add(groupId);
+
+					if (bindThemeId) {
+						queryPos.add(themeId);
+					}
+
+					list = (List<StyleBookEntry>)QueryUtil.list(
+						query, getDialect(), start, end);
+
+					cacheResult(list);
+
+					if (useFinderCache) {
+						finderCache.putResult(finderPath, finderArgs, list);
+					}
+				}
+				catch (Exception exception) {
+					throw processException(exception);
+				}
+				finally {
+					closeSession(session);
+				}
+			}
+
+			return list;
+		}
+	}
+
+	/**
+	 * Returns the first style book entry in the ordered set where groupId = &#63; and themeId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching style book entry
+	 * @throws NoSuchEntryException if a matching style book entry could not be found
+	 */
+	@Override
+	public StyleBookEntry findByG_T_First(
+			long groupId, String themeId,
+			OrderByComparator<StyleBookEntry> orderByComparator)
+		throws NoSuchEntryException {
+
+		StyleBookEntry styleBookEntry = fetchByG_T_First(
+			groupId, themeId, orderByComparator);
+
+		if (styleBookEntry != null) {
+			return styleBookEntry;
+		}
+
+		StringBundler sb = new StringBundler(6);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("groupId=");
+		sb.append(groupId);
+
+		sb.append(", themeId=");
+		sb.append(themeId);
+
+		sb.append("}");
+
+		throw new NoSuchEntryException(sb.toString());
+	}
+
+	/**
+	 * Returns the first style book entry in the ordered set where groupId = &#63; and themeId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching style book entry, or <code>null</code> if a matching style book entry could not be found
+	 */
+	@Override
+	public StyleBookEntry fetchByG_T_First(
+		long groupId, String themeId,
+		OrderByComparator<StyleBookEntry> orderByComparator) {
+
+		List<StyleBookEntry> list = findByG_T(
+			groupId, themeId, 0, 1, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the last style book entry in the ordered set where groupId = &#63; and themeId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching style book entry
+	 * @throws NoSuchEntryException if a matching style book entry could not be found
+	 */
+	@Override
+	public StyleBookEntry findByG_T_Last(
+			long groupId, String themeId,
+			OrderByComparator<StyleBookEntry> orderByComparator)
+		throws NoSuchEntryException {
+
+		StyleBookEntry styleBookEntry = fetchByG_T_Last(
+			groupId, themeId, orderByComparator);
+
+		if (styleBookEntry != null) {
+			return styleBookEntry;
+		}
+
+		StringBundler sb = new StringBundler(6);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("groupId=");
+		sb.append(groupId);
+
+		sb.append(", themeId=");
+		sb.append(themeId);
+
+		sb.append("}");
+
+		throw new NoSuchEntryException(sb.toString());
+	}
+
+	/**
+	 * Returns the last style book entry in the ordered set where groupId = &#63; and themeId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching style book entry, or <code>null</code> if a matching style book entry could not be found
+	 */
+	@Override
+	public StyleBookEntry fetchByG_T_Last(
+		long groupId, String themeId,
+		OrderByComparator<StyleBookEntry> orderByComparator) {
+
+		int count = countByG_T(groupId, themeId);
+
+		if (count == 0) {
+			return null;
+		}
+
+		List<StyleBookEntry> list = findByG_T(
+			groupId, themeId, count - 1, count, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the style book entries before and after the current style book entry in the ordered set where groupId = &#63; and themeId = &#63;.
+	 *
+	 * @param styleBookEntryId the primary key of the current style book entry
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next style book entry
+	 * @throws NoSuchEntryException if a style book entry with the primary key could not be found
+	 */
+	@Override
+	public StyleBookEntry[] findByG_T_PrevAndNext(
+			long styleBookEntryId, long groupId, String themeId,
+			OrderByComparator<StyleBookEntry> orderByComparator)
+		throws NoSuchEntryException {
+
+		themeId = Objects.toString(themeId, "");
+
+		StyleBookEntry styleBookEntry = findByPrimaryKey(styleBookEntryId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			StyleBookEntry[] array = new StyleBookEntryImpl[3];
+
+			array[0] = getByG_T_PrevAndNext(
+				session, styleBookEntry, groupId, themeId, orderByComparator,
+				true);
+
+			array[1] = styleBookEntry;
+
+			array[2] = getByG_T_PrevAndNext(
+				session, styleBookEntry, groupId, themeId, orderByComparator,
+				false);
+
+			return array;
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected StyleBookEntry getByG_T_PrevAndNext(
+		Session session, StyleBookEntry styleBookEntry, long groupId,
+		String themeId, OrderByComparator<StyleBookEntry> orderByComparator,
+		boolean previous) {
+
+		StringBundler sb = null;
+
+		if (orderByComparator != null) {
+			sb = new StringBundler(
+				5 + (orderByComparator.getOrderByConditionFields().length * 3) +
+					(orderByComparator.getOrderByFields().length * 3));
+		}
+		else {
+			sb = new StringBundler(4);
+		}
+
+		sb.append(_SQL_SELECT_STYLEBOOKENTRY_WHERE);
+
+		sb.append(_FINDER_COLUMN_G_T_GROUPID_2);
+
+		boolean bindThemeId = false;
+
+		if (themeId.isEmpty()) {
+			sb.append(_FINDER_COLUMN_G_T_THEMEID_3);
+		}
+		else {
+			bindThemeId = true;
+
+			sb.append(_FINDER_COLUMN_G_T_THEMEID_2);
+		}
+
+		if (orderByComparator != null) {
+			String[] orderByConditionFields =
+				orderByComparator.getOrderByConditionFields();
+
+			if (orderByConditionFields.length > 0) {
+				sb.append(WHERE_AND);
+			}
+
+			for (int i = 0; i < orderByConditionFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByConditionFields[i]);
+
+				if ((i + 1) < orderByConditionFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN_HAS_NEXT);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN);
+					}
+				}
+			}
+
+			sb.append(ORDER_BY_CLAUSE);
+
+			String[] orderByFields = orderByComparator.getOrderByFields();
+
+			for (int i = 0; i < orderByFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByFields[i]);
+
+				if ((i + 1) < orderByFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC_HAS_NEXT);
+					}
+					else {
+						sb.append(ORDER_BY_DESC_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC);
+					}
+					else {
+						sb.append(ORDER_BY_DESC);
+					}
+				}
+			}
+		}
+		else {
+			sb.append(StyleBookEntryModelImpl.ORDER_BY_JPQL);
+		}
+
+		String sql = sb.toString();
+
+		Query query = session.createQuery(sql);
+
+		query.setFirstResult(0);
+		query.setMaxResults(2);
+
+		QueryPos queryPos = QueryPos.getInstance(query);
+
+		queryPos.add(groupId);
+
+		if (bindThemeId) {
+			queryPos.add(themeId);
+		}
+
+		if (orderByComparator != null) {
+			for (Object orderByConditionValue :
+					orderByComparator.getOrderByConditionValues(
+						styleBookEntry)) {
+
+				queryPos.add(orderByConditionValue);
+			}
+		}
+
+		List<StyleBookEntry> list = query.list();
+
+		if (list.size() == 2) {
+			return list.get(1);
+		}
+		else {
+			return null;
+		}
+	}
+
+	/**
+	 * Removes all the style book entries where groupId = &#63; and themeId = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 */
+	@Override
+	public void removeByG_T(long groupId, String themeId) {
+		for (StyleBookEntry styleBookEntry :
+				findByG_T(
+					groupId, themeId, QueryUtil.ALL_POS, QueryUtil.ALL_POS,
+					null)) {
+
+			remove(styleBookEntry);
+		}
+	}
+
+	/**
+	 * Returns the number of style book entries where groupId = &#63; and themeId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @return the number of matching style book entries
+	 */
+	@Override
+	public int countByG_T(long groupId, String themeId) {
+		try (SafeCloseable safeCloseable =
+				ctPersistenceHelper.setCTCollectionIdWithSafeCloseable(
+					StyleBookEntry.class)) {
+
+			themeId = Objects.toString(themeId, "");
+
+			FinderPath finderPath = _finderPathCountByG_T;
+
+			Object[] finderArgs = new Object[] {groupId, themeId};
+
+			Long count = (Long)finderCache.getResult(
+				finderPath, finderArgs, this);
+
+			if (count == null) {
+				StringBundler sb = new StringBundler(3);
+
+				sb.append(_SQL_COUNT_STYLEBOOKENTRY_WHERE);
+
+				sb.append(_FINDER_COLUMN_G_T_GROUPID_2);
+
+				boolean bindThemeId = false;
+
+				if (themeId.isEmpty()) {
+					sb.append(_FINDER_COLUMN_G_T_THEMEID_3);
+				}
+				else {
+					bindThemeId = true;
+
+					sb.append(_FINDER_COLUMN_G_T_THEMEID_2);
+				}
+
+				String sql = sb.toString();
+
+				Session session = null;
+
+				try {
+					session = openSession();
+
+					Query query = session.createQuery(sql);
+
+					QueryPos queryPos = QueryPos.getInstance(query);
+
+					queryPos.add(groupId);
+
+					if (bindThemeId) {
+						queryPos.add(themeId);
+					}
+
+					count = (Long)query.uniqueResult();
+
+					finderCache.putResult(finderPath, finderArgs, count);
+				}
+				catch (Exception exception) {
+					throw processException(exception);
+				}
+				finally {
+					closeSession(session);
+				}
+			}
+
+			return count.intValue();
+		}
+	}
+
+	private static final String _FINDER_COLUMN_G_T_GROUPID_2 =
+		"styleBookEntry.groupId = ? AND ";
+
+	private static final String _FINDER_COLUMN_G_T_THEMEID_2 =
+		"styleBookEntry.themeId = ?";
+
+	private static final String _FINDER_COLUMN_G_T_THEMEID_3 =
+		"(styleBookEntry.themeId IS NULL OR styleBookEntry.themeId = '')";
+
+	private FinderPath _finderPathWithPaginationFindByG_T_Head;
+	private FinderPath _finderPathWithoutPaginationFindByG_T_Head;
+	private FinderPath _finderPathCountByG_T_Head;
+
+	/**
+	 * Returns all the style book entries where groupId = &#63; and themeId = &#63; and head = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param head the head
+	 * @return the matching style book entries
+	 */
+	@Override
+	public List<StyleBookEntry> findByG_T_Head(
+		long groupId, String themeId, boolean head) {
+
+		return findByG_T_Head(
+			groupId, themeId, head, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the style book entries where groupId = &#63; and themeId = &#63; and head = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>StyleBookEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param head the head
+	 * @param start the lower bound of the range of style book entries
+	 * @param end the upper bound of the range of style book entries (not inclusive)
+	 * @return the range of matching style book entries
+	 */
+	@Override
+	public List<StyleBookEntry> findByG_T_Head(
+		long groupId, String themeId, boolean head, int start, int end) {
+
+		return findByG_T_Head(groupId, themeId, head, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the style book entries where groupId = &#63; and themeId = &#63; and head = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>StyleBookEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param head the head
+	 * @param start the lower bound of the range of style book entries
+	 * @param end the upper bound of the range of style book entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching style book entries
+	 */
+	@Override
+	public List<StyleBookEntry> findByG_T_Head(
+		long groupId, String themeId, boolean head, int start, int end,
+		OrderByComparator<StyleBookEntry> orderByComparator) {
+
+		return findByG_T_Head(
+			groupId, themeId, head, start, end, orderByComparator, true);
+	}
+
+	/**
+	 * Returns an ordered range of all the style book entries where groupId = &#63; and themeId = &#63; and head = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>StyleBookEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param head the head
+	 * @param start the lower bound of the range of style book entries
+	 * @param end the upper bound of the range of style book entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching style book entries
+	 */
+	@Override
+	public List<StyleBookEntry> findByG_T_Head(
+		long groupId, String themeId, boolean head, int start, int end,
+		OrderByComparator<StyleBookEntry> orderByComparator,
+		boolean useFinderCache) {
+
+		try (SafeCloseable safeCloseable =
+				ctPersistenceHelper.setCTCollectionIdWithSafeCloseable(
+					StyleBookEntry.class)) {
+
+			themeId = Objects.toString(themeId, "");
+
+			FinderPath finderPath = null;
+			Object[] finderArgs = null;
+
+			if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
+				(orderByComparator == null)) {
+
+				if (useFinderCache) {
+					finderPath = _finderPathWithoutPaginationFindByG_T_Head;
+					finderArgs = new Object[] {groupId, themeId, head};
+				}
+			}
+			else if (useFinderCache) {
+				finderPath = _finderPathWithPaginationFindByG_T_Head;
+				finderArgs = new Object[] {
+					groupId, themeId, head, start, end, orderByComparator
+				};
+			}
+
+			List<StyleBookEntry> list = null;
+
+			if (useFinderCache) {
+				list = (List<StyleBookEntry>)finderCache.getResult(
+					finderPath, finderArgs, this);
+
+				if ((list != null) && !list.isEmpty()) {
+					for (StyleBookEntry styleBookEntry : list) {
+						if ((groupId != styleBookEntry.getGroupId()) ||
+							!themeId.equals(styleBookEntry.getThemeId()) ||
+							(head != styleBookEntry.isHead())) {
+
+							list = null;
+
+							break;
+						}
+					}
+				}
+			}
+
+			if (list == null) {
+				StringBundler sb = null;
+
+				if (orderByComparator != null) {
+					sb = new StringBundler(
+						5 + (orderByComparator.getOrderByFields().length * 2));
+				}
+				else {
+					sb = new StringBundler(5);
+				}
+
+				sb.append(_SQL_SELECT_STYLEBOOKENTRY_WHERE);
+
+				sb.append(_FINDER_COLUMN_G_T_HEAD_GROUPID_2);
+
+				boolean bindThemeId = false;
+
+				if (themeId.isEmpty()) {
+					sb.append(_FINDER_COLUMN_G_T_HEAD_THEMEID_3);
+				}
+				else {
+					bindThemeId = true;
+
+					sb.append(_FINDER_COLUMN_G_T_HEAD_THEMEID_2);
+				}
+
+				sb.append(_FINDER_COLUMN_G_T_HEAD_HEAD_2);
+
+				if (orderByComparator != null) {
+					appendOrderByComparator(
+						sb, _ORDER_BY_ENTITY_ALIAS, orderByComparator);
+				}
+				else {
+					sb.append(StyleBookEntryModelImpl.ORDER_BY_JPQL);
+				}
+
+				String sql = sb.toString();
+
+				Session session = null;
+
+				try {
+					session = openSession();
+
+					Query query = session.createQuery(sql);
+
+					QueryPos queryPos = QueryPos.getInstance(query);
+
+					queryPos.add(groupId);
+
+					if (bindThemeId) {
+						queryPos.add(themeId);
+					}
+
+					queryPos.add(head);
+
+					list = (List<StyleBookEntry>)QueryUtil.list(
+						query, getDialect(), start, end);
+
+					cacheResult(list);
+
+					if (useFinderCache) {
+						finderCache.putResult(finderPath, finderArgs, list);
+					}
+				}
+				catch (Exception exception) {
+					throw processException(exception);
+				}
+				finally {
+					closeSession(session);
+				}
+			}
+
+			return list;
+		}
+	}
+
+	/**
+	 * Returns the first style book entry in the ordered set where groupId = &#63; and themeId = &#63; and head = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param head the head
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching style book entry
+	 * @throws NoSuchEntryException if a matching style book entry could not be found
+	 */
+	@Override
+	public StyleBookEntry findByG_T_Head_First(
+			long groupId, String themeId, boolean head,
+			OrderByComparator<StyleBookEntry> orderByComparator)
+		throws NoSuchEntryException {
+
+		StyleBookEntry styleBookEntry = fetchByG_T_Head_First(
+			groupId, themeId, head, orderByComparator);
+
+		if (styleBookEntry != null) {
+			return styleBookEntry;
+		}
+
+		StringBundler sb = new StringBundler(8);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("groupId=");
+		sb.append(groupId);
+
+		sb.append(", themeId=");
+		sb.append(themeId);
+
+		sb.append(", head=");
+		sb.append(head);
+
+		sb.append("}");
+
+		throw new NoSuchEntryException(sb.toString());
+	}
+
+	/**
+	 * Returns the first style book entry in the ordered set where groupId = &#63; and themeId = &#63; and head = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param head the head
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching style book entry, or <code>null</code> if a matching style book entry could not be found
+	 */
+	@Override
+	public StyleBookEntry fetchByG_T_Head_First(
+		long groupId, String themeId, boolean head,
+		OrderByComparator<StyleBookEntry> orderByComparator) {
+
+		List<StyleBookEntry> list = findByG_T_Head(
+			groupId, themeId, head, 0, 1, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the last style book entry in the ordered set where groupId = &#63; and themeId = &#63; and head = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param head the head
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching style book entry
+	 * @throws NoSuchEntryException if a matching style book entry could not be found
+	 */
+	@Override
+	public StyleBookEntry findByG_T_Head_Last(
+			long groupId, String themeId, boolean head,
+			OrderByComparator<StyleBookEntry> orderByComparator)
+		throws NoSuchEntryException {
+
+		StyleBookEntry styleBookEntry = fetchByG_T_Head_Last(
+			groupId, themeId, head, orderByComparator);
+
+		if (styleBookEntry != null) {
+			return styleBookEntry;
+		}
+
+		StringBundler sb = new StringBundler(8);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("groupId=");
+		sb.append(groupId);
+
+		sb.append(", themeId=");
+		sb.append(themeId);
+
+		sb.append(", head=");
+		sb.append(head);
+
+		sb.append("}");
+
+		throw new NoSuchEntryException(sb.toString());
+	}
+
+	/**
+	 * Returns the last style book entry in the ordered set where groupId = &#63; and themeId = &#63; and head = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param head the head
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching style book entry, or <code>null</code> if a matching style book entry could not be found
+	 */
+	@Override
+	public StyleBookEntry fetchByG_T_Head_Last(
+		long groupId, String themeId, boolean head,
+		OrderByComparator<StyleBookEntry> orderByComparator) {
+
+		int count = countByG_T_Head(groupId, themeId, head);
+
+		if (count == 0) {
+			return null;
+		}
+
+		List<StyleBookEntry> list = findByG_T_Head(
+			groupId, themeId, head, count - 1, count, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the style book entries before and after the current style book entry in the ordered set where groupId = &#63; and themeId = &#63; and head = &#63;.
+	 *
+	 * @param styleBookEntryId the primary key of the current style book entry
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param head the head
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next style book entry
+	 * @throws NoSuchEntryException if a style book entry with the primary key could not be found
+	 */
+	@Override
+	public StyleBookEntry[] findByG_T_Head_PrevAndNext(
+			long styleBookEntryId, long groupId, String themeId, boolean head,
+			OrderByComparator<StyleBookEntry> orderByComparator)
+		throws NoSuchEntryException {
+
+		themeId = Objects.toString(themeId, "");
+
+		StyleBookEntry styleBookEntry = findByPrimaryKey(styleBookEntryId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			StyleBookEntry[] array = new StyleBookEntryImpl[3];
+
+			array[0] = getByG_T_Head_PrevAndNext(
+				session, styleBookEntry, groupId, themeId, head,
+				orderByComparator, true);
+
+			array[1] = styleBookEntry;
+
+			array[2] = getByG_T_Head_PrevAndNext(
+				session, styleBookEntry, groupId, themeId, head,
+				orderByComparator, false);
+
+			return array;
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected StyleBookEntry getByG_T_Head_PrevAndNext(
+		Session session, StyleBookEntry styleBookEntry, long groupId,
+		String themeId, boolean head,
+		OrderByComparator<StyleBookEntry> orderByComparator, boolean previous) {
+
+		StringBundler sb = null;
+
+		if (orderByComparator != null) {
+			sb = new StringBundler(
+				6 + (orderByComparator.getOrderByConditionFields().length * 3) +
+					(orderByComparator.getOrderByFields().length * 3));
+		}
+		else {
+			sb = new StringBundler(5);
+		}
+
+		sb.append(_SQL_SELECT_STYLEBOOKENTRY_WHERE);
+
+		sb.append(_FINDER_COLUMN_G_T_HEAD_GROUPID_2);
+
+		boolean bindThemeId = false;
+
+		if (themeId.isEmpty()) {
+			sb.append(_FINDER_COLUMN_G_T_HEAD_THEMEID_3);
+		}
+		else {
+			bindThemeId = true;
+
+			sb.append(_FINDER_COLUMN_G_T_HEAD_THEMEID_2);
+		}
+
+		sb.append(_FINDER_COLUMN_G_T_HEAD_HEAD_2);
+
+		if (orderByComparator != null) {
+			String[] orderByConditionFields =
+				orderByComparator.getOrderByConditionFields();
+
+			if (orderByConditionFields.length > 0) {
+				sb.append(WHERE_AND);
+			}
+
+			for (int i = 0; i < orderByConditionFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByConditionFields[i]);
+
+				if ((i + 1) < orderByConditionFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN_HAS_NEXT);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN);
+					}
+				}
+			}
+
+			sb.append(ORDER_BY_CLAUSE);
+
+			String[] orderByFields = orderByComparator.getOrderByFields();
+
+			for (int i = 0; i < orderByFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByFields[i]);
+
+				if ((i + 1) < orderByFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC_HAS_NEXT);
+					}
+					else {
+						sb.append(ORDER_BY_DESC_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC);
+					}
+					else {
+						sb.append(ORDER_BY_DESC);
+					}
+				}
+			}
+		}
+		else {
+			sb.append(StyleBookEntryModelImpl.ORDER_BY_JPQL);
+		}
+
+		String sql = sb.toString();
+
+		Query query = session.createQuery(sql);
+
+		query.setFirstResult(0);
+		query.setMaxResults(2);
+
+		QueryPos queryPos = QueryPos.getInstance(query);
+
+		queryPos.add(groupId);
+
+		if (bindThemeId) {
+			queryPos.add(themeId);
+		}
+
+		queryPos.add(head);
+
+		if (orderByComparator != null) {
+			for (Object orderByConditionValue :
+					orderByComparator.getOrderByConditionValues(
+						styleBookEntry)) {
+
+				queryPos.add(orderByConditionValue);
+			}
+		}
+
+		List<StyleBookEntry> list = query.list();
+
+		if (list.size() == 2) {
+			return list.get(1);
+		}
+		else {
+			return null;
+		}
+	}
+
+	/**
+	 * Removes all the style book entries where groupId = &#63; and themeId = &#63; and head = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param head the head
+	 */
+	@Override
+	public void removeByG_T_Head(long groupId, String themeId, boolean head) {
+		for (StyleBookEntry styleBookEntry :
+				findByG_T_Head(
+					groupId, themeId, head, QueryUtil.ALL_POS,
+					QueryUtil.ALL_POS, null)) {
+
+			remove(styleBookEntry);
+		}
+	}
+
+	/**
+	 * Returns the number of style book entries where groupId = &#63; and themeId = &#63; and head = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param head the head
+	 * @return the number of matching style book entries
+	 */
+	@Override
+	public int countByG_T_Head(long groupId, String themeId, boolean head) {
+		try (SafeCloseable safeCloseable =
+				ctPersistenceHelper.setCTCollectionIdWithSafeCloseable(
+					StyleBookEntry.class)) {
+
+			themeId = Objects.toString(themeId, "");
+
+			FinderPath finderPath = _finderPathCountByG_T_Head;
+
+			Object[] finderArgs = new Object[] {groupId, themeId, head};
+
+			Long count = (Long)finderCache.getResult(
+				finderPath, finderArgs, this);
+
+			if (count == null) {
+				StringBundler sb = new StringBundler(4);
+
+				sb.append(_SQL_COUNT_STYLEBOOKENTRY_WHERE);
+
+				sb.append(_FINDER_COLUMN_G_T_HEAD_GROUPID_2);
+
+				boolean bindThemeId = false;
+
+				if (themeId.isEmpty()) {
+					sb.append(_FINDER_COLUMN_G_T_HEAD_THEMEID_3);
+				}
+				else {
+					bindThemeId = true;
+
+					sb.append(_FINDER_COLUMN_G_T_HEAD_THEMEID_2);
+				}
+
+				sb.append(_FINDER_COLUMN_G_T_HEAD_HEAD_2);
+
+				String sql = sb.toString();
+
+				Session session = null;
+
+				try {
+					session = openSession();
+
+					Query query = session.createQuery(sql);
+
+					QueryPos queryPos = QueryPos.getInstance(query);
+
+					queryPos.add(groupId);
+
+					if (bindThemeId) {
+						queryPos.add(themeId);
+					}
+
+					queryPos.add(head);
+
+					count = (Long)query.uniqueResult();
+
+					finderCache.putResult(finderPath, finderArgs, count);
+				}
+				catch (Exception exception) {
+					throw processException(exception);
+				}
+				finally {
+					closeSession(session);
+				}
+			}
+
+			return count.intValue();
+		}
+	}
+
+	private static final String _FINDER_COLUMN_G_T_HEAD_GROUPID_2 =
+		"styleBookEntry.groupId = ? AND ";
+
+	private static final String _FINDER_COLUMN_G_T_HEAD_THEMEID_2 =
+		"styleBookEntry.themeId = ? AND ";
+
+	private static final String _FINDER_COLUMN_G_T_HEAD_THEMEID_3 =
+		"(styleBookEntry.themeId IS NULL OR styleBookEntry.themeId = '') AND ";
+
+	private static final String _FINDER_COLUMN_G_T_HEAD_HEAD_2 =
+		"styleBookEntry.head = ?";
+
 	private FinderPath _finderPathWithPaginationFindByERC_G;
 	private FinderPath _finderPathWithoutPaginationFindByERC_G;
 	private FinderPath _finderPathCountByERC_G;
@@ -9757,6 +10977,50 @@ public class StyleBookEntryPersistenceImpl
 				Boolean.class.getName()
 			},
 			new String[] {"groupId", "styleBookEntryKey", "head"}, true);
+
+		_finderPathWithPaginationFindByG_T = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_T",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"groupId", "themeId"}, true);
+
+		_finderPathWithoutPaginationFindByG_T = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_T",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"groupId", "themeId"}, true);
+
+		_finderPathCountByG_T = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_T",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"groupId", "themeId"}, false);
+
+		_finderPathWithPaginationFindByG_T_Head = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_T_Head",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Boolean.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"groupId", "themeId", "head"}, true);
+
+		_finderPathWithoutPaginationFindByG_T_Head = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_T_Head",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Boolean.class.getName()
+			},
+			new String[] {"groupId", "themeId", "head"}, true);
+
+		_finderPathCountByG_T_Head = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_T_Head",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Boolean.class.getName()
+			},
+			new String[] {"groupId", "themeId", "head"}, false);
 
 		_finderPathWithPaginationFindByERC_G = new FinderPath(
 			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByERC_G",

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/persistence/impl/StyleBookEntryVersionPersistenceImpl.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/persistence/impl/StyleBookEntryVersionPersistenceImpl.java
@@ -8351,6 +8351,1234 @@ public class StyleBookEntryVersionPersistenceImpl
 	private static final String _FINDER_COLUMN_G_SBEK_VERSION_VERSION_2 =
 		"styleBookEntryVersion.version = ?";
 
+	private FinderPath _finderPathWithPaginationFindByG_T;
+	private FinderPath _finderPathWithoutPaginationFindByG_T;
+	private FinderPath _finderPathCountByG_T;
+
+	/**
+	 * Returns all the style book entry versions where groupId = &#63; and themeId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @return the matching style book entry versions
+	 */
+	@Override
+	public List<StyleBookEntryVersion> findByG_T(long groupId, String themeId) {
+		return findByG_T(
+			groupId, themeId, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the style book entry versions where groupId = &#63; and themeId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>StyleBookEntryVersionModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param start the lower bound of the range of style book entry versions
+	 * @param end the upper bound of the range of style book entry versions (not inclusive)
+	 * @return the range of matching style book entry versions
+	 */
+	@Override
+	public List<StyleBookEntryVersion> findByG_T(
+		long groupId, String themeId, int start, int end) {
+
+		return findByG_T(groupId, themeId, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the style book entry versions where groupId = &#63; and themeId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>StyleBookEntryVersionModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param start the lower bound of the range of style book entry versions
+	 * @param end the upper bound of the range of style book entry versions (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching style book entry versions
+	 */
+	@Override
+	public List<StyleBookEntryVersion> findByG_T(
+		long groupId, String themeId, int start, int end,
+		OrderByComparator<StyleBookEntryVersion> orderByComparator) {
+
+		return findByG_T(groupId, themeId, start, end, orderByComparator, true);
+	}
+
+	/**
+	 * Returns an ordered range of all the style book entry versions where groupId = &#63; and themeId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>StyleBookEntryVersionModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param start the lower bound of the range of style book entry versions
+	 * @param end the upper bound of the range of style book entry versions (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching style book entry versions
+	 */
+	@Override
+	public List<StyleBookEntryVersion> findByG_T(
+		long groupId, String themeId, int start, int end,
+		OrderByComparator<StyleBookEntryVersion> orderByComparator,
+		boolean useFinderCache) {
+
+		try (SafeCloseable safeCloseable =
+				ctPersistenceHelper.setCTCollectionIdWithSafeCloseable(
+					StyleBookEntryVersion.class)) {
+
+			themeId = Objects.toString(themeId, "");
+
+			FinderPath finderPath = null;
+			Object[] finderArgs = null;
+
+			if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
+				(orderByComparator == null)) {
+
+				if (useFinderCache) {
+					finderPath = _finderPathWithoutPaginationFindByG_T;
+					finderArgs = new Object[] {groupId, themeId};
+				}
+			}
+			else if (useFinderCache) {
+				finderPath = _finderPathWithPaginationFindByG_T;
+				finderArgs = new Object[] {
+					groupId, themeId, start, end, orderByComparator
+				};
+			}
+
+			List<StyleBookEntryVersion> list = null;
+
+			if (useFinderCache) {
+				list = (List<StyleBookEntryVersion>)finderCache.getResult(
+					finderPath, finderArgs, this);
+
+				if ((list != null) && !list.isEmpty()) {
+					for (StyleBookEntryVersion styleBookEntryVersion : list) {
+						if ((groupId != styleBookEntryVersion.getGroupId()) ||
+							!themeId.equals(
+								styleBookEntryVersion.getThemeId())) {
+
+							list = null;
+
+							break;
+						}
+					}
+				}
+			}
+
+			if (list == null) {
+				StringBundler sb = null;
+
+				if (orderByComparator != null) {
+					sb = new StringBundler(
+						4 + (orderByComparator.getOrderByFields().length * 2));
+				}
+				else {
+					sb = new StringBundler(4);
+				}
+
+				sb.append(_SQL_SELECT_STYLEBOOKENTRYVERSION_WHERE);
+
+				sb.append(_FINDER_COLUMN_G_T_GROUPID_2);
+
+				boolean bindThemeId = false;
+
+				if (themeId.isEmpty()) {
+					sb.append(_FINDER_COLUMN_G_T_THEMEID_3);
+				}
+				else {
+					bindThemeId = true;
+
+					sb.append(_FINDER_COLUMN_G_T_THEMEID_2);
+				}
+
+				if (orderByComparator != null) {
+					appendOrderByComparator(
+						sb, _ORDER_BY_ENTITY_ALIAS, orderByComparator);
+				}
+				else {
+					sb.append(StyleBookEntryVersionModelImpl.ORDER_BY_JPQL);
+				}
+
+				String sql = sb.toString();
+
+				Session session = null;
+
+				try {
+					session = openSession();
+
+					Query query = session.createQuery(sql);
+
+					QueryPos queryPos = QueryPos.getInstance(query);
+
+					queryPos.add(groupId);
+
+					if (bindThemeId) {
+						queryPos.add(themeId);
+					}
+
+					list = (List<StyleBookEntryVersion>)QueryUtil.list(
+						query, getDialect(), start, end);
+
+					cacheResult(list);
+
+					if (useFinderCache) {
+						finderCache.putResult(finderPath, finderArgs, list);
+					}
+				}
+				catch (Exception exception) {
+					throw processException(exception);
+				}
+				finally {
+					closeSession(session);
+				}
+			}
+
+			return list;
+		}
+	}
+
+	/**
+	 * Returns the first style book entry version in the ordered set where groupId = &#63; and themeId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching style book entry version
+	 * @throws NoSuchEntryVersionException if a matching style book entry version could not be found
+	 */
+	@Override
+	public StyleBookEntryVersion findByG_T_First(
+			long groupId, String themeId,
+			OrderByComparator<StyleBookEntryVersion> orderByComparator)
+		throws NoSuchEntryVersionException {
+
+		StyleBookEntryVersion styleBookEntryVersion = fetchByG_T_First(
+			groupId, themeId, orderByComparator);
+
+		if (styleBookEntryVersion != null) {
+			return styleBookEntryVersion;
+		}
+
+		StringBundler sb = new StringBundler(6);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("groupId=");
+		sb.append(groupId);
+
+		sb.append(", themeId=");
+		sb.append(themeId);
+
+		sb.append("}");
+
+		throw new NoSuchEntryVersionException(sb.toString());
+	}
+
+	/**
+	 * Returns the first style book entry version in the ordered set where groupId = &#63; and themeId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching style book entry version, or <code>null</code> if a matching style book entry version could not be found
+	 */
+	@Override
+	public StyleBookEntryVersion fetchByG_T_First(
+		long groupId, String themeId,
+		OrderByComparator<StyleBookEntryVersion> orderByComparator) {
+
+		List<StyleBookEntryVersion> list = findByG_T(
+			groupId, themeId, 0, 1, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the last style book entry version in the ordered set where groupId = &#63; and themeId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching style book entry version
+	 * @throws NoSuchEntryVersionException if a matching style book entry version could not be found
+	 */
+	@Override
+	public StyleBookEntryVersion findByG_T_Last(
+			long groupId, String themeId,
+			OrderByComparator<StyleBookEntryVersion> orderByComparator)
+		throws NoSuchEntryVersionException {
+
+		StyleBookEntryVersion styleBookEntryVersion = fetchByG_T_Last(
+			groupId, themeId, orderByComparator);
+
+		if (styleBookEntryVersion != null) {
+			return styleBookEntryVersion;
+		}
+
+		StringBundler sb = new StringBundler(6);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("groupId=");
+		sb.append(groupId);
+
+		sb.append(", themeId=");
+		sb.append(themeId);
+
+		sb.append("}");
+
+		throw new NoSuchEntryVersionException(sb.toString());
+	}
+
+	/**
+	 * Returns the last style book entry version in the ordered set where groupId = &#63; and themeId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching style book entry version, or <code>null</code> if a matching style book entry version could not be found
+	 */
+	@Override
+	public StyleBookEntryVersion fetchByG_T_Last(
+		long groupId, String themeId,
+		OrderByComparator<StyleBookEntryVersion> orderByComparator) {
+
+		int count = countByG_T(groupId, themeId);
+
+		if (count == 0) {
+			return null;
+		}
+
+		List<StyleBookEntryVersion> list = findByG_T(
+			groupId, themeId, count - 1, count, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the style book entry versions before and after the current style book entry version in the ordered set where groupId = &#63; and themeId = &#63;.
+	 *
+	 * @param styleBookEntryVersionId the primary key of the current style book entry version
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next style book entry version
+	 * @throws NoSuchEntryVersionException if a style book entry version with the primary key could not be found
+	 */
+	@Override
+	public StyleBookEntryVersion[] findByG_T_PrevAndNext(
+			long styleBookEntryVersionId, long groupId, String themeId,
+			OrderByComparator<StyleBookEntryVersion> orderByComparator)
+		throws NoSuchEntryVersionException {
+
+		themeId = Objects.toString(themeId, "");
+
+		StyleBookEntryVersion styleBookEntryVersion = findByPrimaryKey(
+			styleBookEntryVersionId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			StyleBookEntryVersion[] array = new StyleBookEntryVersionImpl[3];
+
+			array[0] = getByG_T_PrevAndNext(
+				session, styleBookEntryVersion, groupId, themeId,
+				orderByComparator, true);
+
+			array[1] = styleBookEntryVersion;
+
+			array[2] = getByG_T_PrevAndNext(
+				session, styleBookEntryVersion, groupId, themeId,
+				orderByComparator, false);
+
+			return array;
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected StyleBookEntryVersion getByG_T_PrevAndNext(
+		Session session, StyleBookEntryVersion styleBookEntryVersion,
+		long groupId, String themeId,
+		OrderByComparator<StyleBookEntryVersion> orderByComparator,
+		boolean previous) {
+
+		StringBundler sb = null;
+
+		if (orderByComparator != null) {
+			sb = new StringBundler(
+				5 + (orderByComparator.getOrderByConditionFields().length * 3) +
+					(orderByComparator.getOrderByFields().length * 3));
+		}
+		else {
+			sb = new StringBundler(4);
+		}
+
+		sb.append(_SQL_SELECT_STYLEBOOKENTRYVERSION_WHERE);
+
+		sb.append(_FINDER_COLUMN_G_T_GROUPID_2);
+
+		boolean bindThemeId = false;
+
+		if (themeId.isEmpty()) {
+			sb.append(_FINDER_COLUMN_G_T_THEMEID_3);
+		}
+		else {
+			bindThemeId = true;
+
+			sb.append(_FINDER_COLUMN_G_T_THEMEID_2);
+		}
+
+		if (orderByComparator != null) {
+			String[] orderByConditionFields =
+				orderByComparator.getOrderByConditionFields();
+
+			if (orderByConditionFields.length > 0) {
+				sb.append(WHERE_AND);
+			}
+
+			for (int i = 0; i < orderByConditionFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByConditionFields[i]);
+
+				if ((i + 1) < orderByConditionFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN_HAS_NEXT);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN);
+					}
+				}
+			}
+
+			sb.append(ORDER_BY_CLAUSE);
+
+			String[] orderByFields = orderByComparator.getOrderByFields();
+
+			for (int i = 0; i < orderByFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByFields[i]);
+
+				if ((i + 1) < orderByFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC_HAS_NEXT);
+					}
+					else {
+						sb.append(ORDER_BY_DESC_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC);
+					}
+					else {
+						sb.append(ORDER_BY_DESC);
+					}
+				}
+			}
+		}
+		else {
+			sb.append(StyleBookEntryVersionModelImpl.ORDER_BY_JPQL);
+		}
+
+		String sql = sb.toString();
+
+		Query query = session.createQuery(sql);
+
+		query.setFirstResult(0);
+		query.setMaxResults(2);
+
+		QueryPos queryPos = QueryPos.getInstance(query);
+
+		queryPos.add(groupId);
+
+		if (bindThemeId) {
+			queryPos.add(themeId);
+		}
+
+		if (orderByComparator != null) {
+			for (Object orderByConditionValue :
+					orderByComparator.getOrderByConditionValues(
+						styleBookEntryVersion)) {
+
+				queryPos.add(orderByConditionValue);
+			}
+		}
+
+		List<StyleBookEntryVersion> list = query.list();
+
+		if (list.size() == 2) {
+			return list.get(1);
+		}
+		else {
+			return null;
+		}
+	}
+
+	/**
+	 * Removes all the style book entry versions where groupId = &#63; and themeId = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 */
+	@Override
+	public void removeByG_T(long groupId, String themeId) {
+		for (StyleBookEntryVersion styleBookEntryVersion :
+				findByG_T(
+					groupId, themeId, QueryUtil.ALL_POS, QueryUtil.ALL_POS,
+					null)) {
+
+			remove(styleBookEntryVersion);
+		}
+	}
+
+	/**
+	 * Returns the number of style book entry versions where groupId = &#63; and themeId = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @return the number of matching style book entry versions
+	 */
+	@Override
+	public int countByG_T(long groupId, String themeId) {
+		try (SafeCloseable safeCloseable =
+				ctPersistenceHelper.setCTCollectionIdWithSafeCloseable(
+					StyleBookEntryVersion.class)) {
+
+			themeId = Objects.toString(themeId, "");
+
+			FinderPath finderPath = _finderPathCountByG_T;
+
+			Object[] finderArgs = new Object[] {groupId, themeId};
+
+			Long count = (Long)finderCache.getResult(
+				finderPath, finderArgs, this);
+
+			if (count == null) {
+				StringBundler sb = new StringBundler(3);
+
+				sb.append(_SQL_COUNT_STYLEBOOKENTRYVERSION_WHERE);
+
+				sb.append(_FINDER_COLUMN_G_T_GROUPID_2);
+
+				boolean bindThemeId = false;
+
+				if (themeId.isEmpty()) {
+					sb.append(_FINDER_COLUMN_G_T_THEMEID_3);
+				}
+				else {
+					bindThemeId = true;
+
+					sb.append(_FINDER_COLUMN_G_T_THEMEID_2);
+				}
+
+				String sql = sb.toString();
+
+				Session session = null;
+
+				try {
+					session = openSession();
+
+					Query query = session.createQuery(sql);
+
+					QueryPos queryPos = QueryPos.getInstance(query);
+
+					queryPos.add(groupId);
+
+					if (bindThemeId) {
+						queryPos.add(themeId);
+					}
+
+					count = (Long)query.uniqueResult();
+
+					finderCache.putResult(finderPath, finderArgs, count);
+				}
+				catch (Exception exception) {
+					throw processException(exception);
+				}
+				finally {
+					closeSession(session);
+				}
+			}
+
+			return count.intValue();
+		}
+	}
+
+	private static final String _FINDER_COLUMN_G_T_GROUPID_2 =
+		"styleBookEntryVersion.groupId = ? AND ";
+
+	private static final String _FINDER_COLUMN_G_T_THEMEID_2 =
+		"styleBookEntryVersion.themeId = ?";
+
+	private static final String _FINDER_COLUMN_G_T_THEMEID_3 =
+		"(styleBookEntryVersion.themeId IS NULL OR styleBookEntryVersion.themeId = '')";
+
+	private FinderPath _finderPathWithPaginationFindByG_T_Version;
+	private FinderPath _finderPathWithoutPaginationFindByG_T_Version;
+	private FinderPath _finderPathCountByG_T_Version;
+
+	/**
+	 * Returns all the style book entry versions where groupId = &#63; and themeId = &#63; and version = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param version the version
+	 * @return the matching style book entry versions
+	 */
+	@Override
+	public List<StyleBookEntryVersion> findByG_T_Version(
+		long groupId, String themeId, int version) {
+
+		return findByG_T_Version(
+			groupId, themeId, version, QueryUtil.ALL_POS, QueryUtil.ALL_POS,
+			null);
+	}
+
+	/**
+	 * Returns a range of all the style book entry versions where groupId = &#63; and themeId = &#63; and version = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>StyleBookEntryVersionModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param version the version
+	 * @param start the lower bound of the range of style book entry versions
+	 * @param end the upper bound of the range of style book entry versions (not inclusive)
+	 * @return the range of matching style book entry versions
+	 */
+	@Override
+	public List<StyleBookEntryVersion> findByG_T_Version(
+		long groupId, String themeId, int version, int start, int end) {
+
+		return findByG_T_Version(groupId, themeId, version, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the style book entry versions where groupId = &#63; and themeId = &#63; and version = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>StyleBookEntryVersionModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param version the version
+	 * @param start the lower bound of the range of style book entry versions
+	 * @param end the upper bound of the range of style book entry versions (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching style book entry versions
+	 */
+	@Override
+	public List<StyleBookEntryVersion> findByG_T_Version(
+		long groupId, String themeId, int version, int start, int end,
+		OrderByComparator<StyleBookEntryVersion> orderByComparator) {
+
+		return findByG_T_Version(
+			groupId, themeId, version, start, end, orderByComparator, true);
+	}
+
+	/**
+	 * Returns an ordered range of all the style book entry versions where groupId = &#63; and themeId = &#63; and version = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>StyleBookEntryVersionModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param version the version
+	 * @param start the lower bound of the range of style book entry versions
+	 * @param end the upper bound of the range of style book entry versions (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching style book entry versions
+	 */
+	@Override
+	public List<StyleBookEntryVersion> findByG_T_Version(
+		long groupId, String themeId, int version, int start, int end,
+		OrderByComparator<StyleBookEntryVersion> orderByComparator,
+		boolean useFinderCache) {
+
+		try (SafeCloseable safeCloseable =
+				ctPersistenceHelper.setCTCollectionIdWithSafeCloseable(
+					StyleBookEntryVersion.class)) {
+
+			themeId = Objects.toString(themeId, "");
+
+			FinderPath finderPath = null;
+			Object[] finderArgs = null;
+
+			if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
+				(orderByComparator == null)) {
+
+				if (useFinderCache) {
+					finderPath = _finderPathWithoutPaginationFindByG_T_Version;
+					finderArgs = new Object[] {groupId, themeId, version};
+				}
+			}
+			else if (useFinderCache) {
+				finderPath = _finderPathWithPaginationFindByG_T_Version;
+				finderArgs = new Object[] {
+					groupId, themeId, version, start, end, orderByComparator
+				};
+			}
+
+			List<StyleBookEntryVersion> list = null;
+
+			if (useFinderCache) {
+				list = (List<StyleBookEntryVersion>)finderCache.getResult(
+					finderPath, finderArgs, this);
+
+				if ((list != null) && !list.isEmpty()) {
+					for (StyleBookEntryVersion styleBookEntryVersion : list) {
+						if ((groupId != styleBookEntryVersion.getGroupId()) ||
+							!themeId.equals(
+								styleBookEntryVersion.getThemeId()) ||
+							(version != styleBookEntryVersion.getVersion())) {
+
+							list = null;
+
+							break;
+						}
+					}
+				}
+			}
+
+			if (list == null) {
+				StringBundler sb = null;
+
+				if (orderByComparator != null) {
+					sb = new StringBundler(
+						5 + (orderByComparator.getOrderByFields().length * 2));
+				}
+				else {
+					sb = new StringBundler(5);
+				}
+
+				sb.append(_SQL_SELECT_STYLEBOOKENTRYVERSION_WHERE);
+
+				sb.append(_FINDER_COLUMN_G_T_VERSION_GROUPID_2);
+
+				boolean bindThemeId = false;
+
+				if (themeId.isEmpty()) {
+					sb.append(_FINDER_COLUMN_G_T_VERSION_THEMEID_3);
+				}
+				else {
+					bindThemeId = true;
+
+					sb.append(_FINDER_COLUMN_G_T_VERSION_THEMEID_2);
+				}
+
+				sb.append(_FINDER_COLUMN_G_T_VERSION_VERSION_2);
+
+				if (orderByComparator != null) {
+					appendOrderByComparator(
+						sb, _ORDER_BY_ENTITY_ALIAS, orderByComparator);
+				}
+				else {
+					sb.append(StyleBookEntryVersionModelImpl.ORDER_BY_JPQL);
+				}
+
+				String sql = sb.toString();
+
+				Session session = null;
+
+				try {
+					session = openSession();
+
+					Query query = session.createQuery(sql);
+
+					QueryPos queryPos = QueryPos.getInstance(query);
+
+					queryPos.add(groupId);
+
+					if (bindThemeId) {
+						queryPos.add(themeId);
+					}
+
+					queryPos.add(version);
+
+					list = (List<StyleBookEntryVersion>)QueryUtil.list(
+						query, getDialect(), start, end);
+
+					cacheResult(list);
+
+					if (useFinderCache) {
+						finderCache.putResult(finderPath, finderArgs, list);
+					}
+				}
+				catch (Exception exception) {
+					throw processException(exception);
+				}
+				finally {
+					closeSession(session);
+				}
+			}
+
+			return list;
+		}
+	}
+
+	/**
+	 * Returns the first style book entry version in the ordered set where groupId = &#63; and themeId = &#63; and version = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param version the version
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching style book entry version
+	 * @throws NoSuchEntryVersionException if a matching style book entry version could not be found
+	 */
+	@Override
+	public StyleBookEntryVersion findByG_T_Version_First(
+			long groupId, String themeId, int version,
+			OrderByComparator<StyleBookEntryVersion> orderByComparator)
+		throws NoSuchEntryVersionException {
+
+		StyleBookEntryVersion styleBookEntryVersion = fetchByG_T_Version_First(
+			groupId, themeId, version, orderByComparator);
+
+		if (styleBookEntryVersion != null) {
+			return styleBookEntryVersion;
+		}
+
+		StringBundler sb = new StringBundler(8);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("groupId=");
+		sb.append(groupId);
+
+		sb.append(", themeId=");
+		sb.append(themeId);
+
+		sb.append(", version=");
+		sb.append(version);
+
+		sb.append("}");
+
+		throw new NoSuchEntryVersionException(sb.toString());
+	}
+
+	/**
+	 * Returns the first style book entry version in the ordered set where groupId = &#63; and themeId = &#63; and version = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param version the version
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching style book entry version, or <code>null</code> if a matching style book entry version could not be found
+	 */
+	@Override
+	public StyleBookEntryVersion fetchByG_T_Version_First(
+		long groupId, String themeId, int version,
+		OrderByComparator<StyleBookEntryVersion> orderByComparator) {
+
+		List<StyleBookEntryVersion> list = findByG_T_Version(
+			groupId, themeId, version, 0, 1, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the last style book entry version in the ordered set where groupId = &#63; and themeId = &#63; and version = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param version the version
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching style book entry version
+	 * @throws NoSuchEntryVersionException if a matching style book entry version could not be found
+	 */
+	@Override
+	public StyleBookEntryVersion findByG_T_Version_Last(
+			long groupId, String themeId, int version,
+			OrderByComparator<StyleBookEntryVersion> orderByComparator)
+		throws NoSuchEntryVersionException {
+
+		StyleBookEntryVersion styleBookEntryVersion = fetchByG_T_Version_Last(
+			groupId, themeId, version, orderByComparator);
+
+		if (styleBookEntryVersion != null) {
+			return styleBookEntryVersion;
+		}
+
+		StringBundler sb = new StringBundler(8);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("groupId=");
+		sb.append(groupId);
+
+		sb.append(", themeId=");
+		sb.append(themeId);
+
+		sb.append(", version=");
+		sb.append(version);
+
+		sb.append("}");
+
+		throw new NoSuchEntryVersionException(sb.toString());
+	}
+
+	/**
+	 * Returns the last style book entry version in the ordered set where groupId = &#63; and themeId = &#63; and version = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param version the version
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching style book entry version, or <code>null</code> if a matching style book entry version could not be found
+	 */
+	@Override
+	public StyleBookEntryVersion fetchByG_T_Version_Last(
+		long groupId, String themeId, int version,
+		OrderByComparator<StyleBookEntryVersion> orderByComparator) {
+
+		int count = countByG_T_Version(groupId, themeId, version);
+
+		if (count == 0) {
+			return null;
+		}
+
+		List<StyleBookEntryVersion> list = findByG_T_Version(
+			groupId, themeId, version, count - 1, count, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the style book entry versions before and after the current style book entry version in the ordered set where groupId = &#63; and themeId = &#63; and version = &#63;.
+	 *
+	 * @param styleBookEntryVersionId the primary key of the current style book entry version
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param version the version
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next style book entry version
+	 * @throws NoSuchEntryVersionException if a style book entry version with the primary key could not be found
+	 */
+	@Override
+	public StyleBookEntryVersion[] findByG_T_Version_PrevAndNext(
+			long styleBookEntryVersionId, long groupId, String themeId,
+			int version,
+			OrderByComparator<StyleBookEntryVersion> orderByComparator)
+		throws NoSuchEntryVersionException {
+
+		themeId = Objects.toString(themeId, "");
+
+		StyleBookEntryVersion styleBookEntryVersion = findByPrimaryKey(
+			styleBookEntryVersionId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			StyleBookEntryVersion[] array = new StyleBookEntryVersionImpl[3];
+
+			array[0] = getByG_T_Version_PrevAndNext(
+				session, styleBookEntryVersion, groupId, themeId, version,
+				orderByComparator, true);
+
+			array[1] = styleBookEntryVersion;
+
+			array[2] = getByG_T_Version_PrevAndNext(
+				session, styleBookEntryVersion, groupId, themeId, version,
+				orderByComparator, false);
+
+			return array;
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected StyleBookEntryVersion getByG_T_Version_PrevAndNext(
+		Session session, StyleBookEntryVersion styleBookEntryVersion,
+		long groupId, String themeId, int version,
+		OrderByComparator<StyleBookEntryVersion> orderByComparator,
+		boolean previous) {
+
+		StringBundler sb = null;
+
+		if (orderByComparator != null) {
+			sb = new StringBundler(
+				6 + (orderByComparator.getOrderByConditionFields().length * 3) +
+					(orderByComparator.getOrderByFields().length * 3));
+		}
+		else {
+			sb = new StringBundler(5);
+		}
+
+		sb.append(_SQL_SELECT_STYLEBOOKENTRYVERSION_WHERE);
+
+		sb.append(_FINDER_COLUMN_G_T_VERSION_GROUPID_2);
+
+		boolean bindThemeId = false;
+
+		if (themeId.isEmpty()) {
+			sb.append(_FINDER_COLUMN_G_T_VERSION_THEMEID_3);
+		}
+		else {
+			bindThemeId = true;
+
+			sb.append(_FINDER_COLUMN_G_T_VERSION_THEMEID_2);
+		}
+
+		sb.append(_FINDER_COLUMN_G_T_VERSION_VERSION_2);
+
+		if (orderByComparator != null) {
+			String[] orderByConditionFields =
+				orderByComparator.getOrderByConditionFields();
+
+			if (orderByConditionFields.length > 0) {
+				sb.append(WHERE_AND);
+			}
+
+			for (int i = 0; i < orderByConditionFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByConditionFields[i]);
+
+				if ((i + 1) < orderByConditionFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN_HAS_NEXT);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN);
+					}
+				}
+			}
+
+			sb.append(ORDER_BY_CLAUSE);
+
+			String[] orderByFields = orderByComparator.getOrderByFields();
+
+			for (int i = 0; i < orderByFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByFields[i]);
+
+				if ((i + 1) < orderByFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC_HAS_NEXT);
+					}
+					else {
+						sb.append(ORDER_BY_DESC_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC);
+					}
+					else {
+						sb.append(ORDER_BY_DESC);
+					}
+				}
+			}
+		}
+		else {
+			sb.append(StyleBookEntryVersionModelImpl.ORDER_BY_JPQL);
+		}
+
+		String sql = sb.toString();
+
+		Query query = session.createQuery(sql);
+
+		query.setFirstResult(0);
+		query.setMaxResults(2);
+
+		QueryPos queryPos = QueryPos.getInstance(query);
+
+		queryPos.add(groupId);
+
+		if (bindThemeId) {
+			queryPos.add(themeId);
+		}
+
+		queryPos.add(version);
+
+		if (orderByComparator != null) {
+			for (Object orderByConditionValue :
+					orderByComparator.getOrderByConditionValues(
+						styleBookEntryVersion)) {
+
+				queryPos.add(orderByConditionValue);
+			}
+		}
+
+		List<StyleBookEntryVersion> list = query.list();
+
+		if (list.size() == 2) {
+			return list.get(1);
+		}
+		else {
+			return null;
+		}
+	}
+
+	/**
+	 * Removes all the style book entry versions where groupId = &#63; and themeId = &#63; and version = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param version the version
+	 */
+	@Override
+	public void removeByG_T_Version(long groupId, String themeId, int version) {
+		for (StyleBookEntryVersion styleBookEntryVersion :
+				findByG_T_Version(
+					groupId, themeId, version, QueryUtil.ALL_POS,
+					QueryUtil.ALL_POS, null)) {
+
+			remove(styleBookEntryVersion);
+		}
+	}
+
+	/**
+	 * Returns the number of style book entry versions where groupId = &#63; and themeId = &#63; and version = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param themeId the theme ID
+	 * @param version the version
+	 * @return the number of matching style book entry versions
+	 */
+	@Override
+	public int countByG_T_Version(long groupId, String themeId, int version) {
+		try (SafeCloseable safeCloseable =
+				ctPersistenceHelper.setCTCollectionIdWithSafeCloseable(
+					StyleBookEntryVersion.class)) {
+
+			themeId = Objects.toString(themeId, "");
+
+			FinderPath finderPath = _finderPathCountByG_T_Version;
+
+			Object[] finderArgs = new Object[] {groupId, themeId, version};
+
+			Long count = (Long)finderCache.getResult(
+				finderPath, finderArgs, this);
+
+			if (count == null) {
+				StringBundler sb = new StringBundler(4);
+
+				sb.append(_SQL_COUNT_STYLEBOOKENTRYVERSION_WHERE);
+
+				sb.append(_FINDER_COLUMN_G_T_VERSION_GROUPID_2);
+
+				boolean bindThemeId = false;
+
+				if (themeId.isEmpty()) {
+					sb.append(_FINDER_COLUMN_G_T_VERSION_THEMEID_3);
+				}
+				else {
+					bindThemeId = true;
+
+					sb.append(_FINDER_COLUMN_G_T_VERSION_THEMEID_2);
+				}
+
+				sb.append(_FINDER_COLUMN_G_T_VERSION_VERSION_2);
+
+				String sql = sb.toString();
+
+				Session session = null;
+
+				try {
+					session = openSession();
+
+					Query query = session.createQuery(sql);
+
+					QueryPos queryPos = QueryPos.getInstance(query);
+
+					queryPos.add(groupId);
+
+					if (bindThemeId) {
+						queryPos.add(themeId);
+					}
+
+					queryPos.add(version);
+
+					count = (Long)query.uniqueResult();
+
+					finderCache.putResult(finderPath, finderArgs, count);
+				}
+				catch (Exception exception) {
+					throw processException(exception);
+				}
+				finally {
+					closeSession(session);
+				}
+			}
+
+			return count.intValue();
+		}
+	}
+
+	private static final String _FINDER_COLUMN_G_T_VERSION_GROUPID_2 =
+		"styleBookEntryVersion.groupId = ? AND ";
+
+	private static final String _FINDER_COLUMN_G_T_VERSION_THEMEID_2 =
+		"styleBookEntryVersion.themeId = ? AND ";
+
+	private static final String _FINDER_COLUMN_G_T_VERSION_THEMEID_3 =
+		"(styleBookEntryVersion.themeId IS NULL OR styleBookEntryVersion.themeId = '') AND ";
+
+	private static final String _FINDER_COLUMN_G_T_VERSION_VERSION_2 =
+		"styleBookEntryVersion.version = ?";
+
 	public StyleBookEntryVersionPersistenceImpl() {
 		Map<String, String> dbColumnNames = new HashMap<String, String>();
 
@@ -9606,6 +10834,50 @@ public class StyleBookEntryVersionPersistenceImpl
 				Integer.class.getName()
 			},
 			new String[] {"groupId", "styleBookEntryKey", "version"}, true);
+
+		_finderPathWithPaginationFindByG_T = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_T",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"groupId", "themeId"}, true);
+
+		_finderPathWithoutPaginationFindByG_T = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_T",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"groupId", "themeId"}, true);
+
+		_finderPathCountByG_T = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_T",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"groupId", "themeId"}, false);
+
+		_finderPathWithPaginationFindByG_T_Version = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_T_Version",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"groupId", "themeId", "version"}, true);
+
+		_finderPathWithoutPaginationFindByG_T_Version = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_T_Version",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Integer.class.getName()
+			},
+			new String[] {"groupId", "themeId", "version"}, true);
+
+		_finderPathCountByG_T_Version = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_T_Version",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Integer.class.getName()
+			},
+			new String[] {"groupId", "themeId", "version"}, false);
 
 		StyleBookEntryVersionUtil.setPersistence(this);
 	}

--- a/modules/apps/style-book/style-book-service/src/main/resources/META-INF/sql/indexes.sql
+++ b/modules/apps/style-book/style-book-service/src/main/resources/META-INF/sql/indexes.sql
@@ -5,18 +5,22 @@ create unique index IX_DD34F41F on StyleBookEntry (groupId, head, ctCollectionId
 create unique index IX_1FCDFAB9 on StyleBookEntry (groupId, head, ctCollectionId, styleBookEntryKey[$COLUMN_LENGTH:75$]);
 create index IX_9EFBE469 on StyleBookEntry (groupId, head, defaultStyleBookEntry);
 create index IX_9F9B48BF on StyleBookEntry (groupId, head, name[$COLUMN_LENGTH:75$]);
+create index IX_5223A5F4 on StyleBookEntry (groupId, head, themeId[$COLUMN_LENGTH:255$]);
+create unique index IX_63D3F12 on StyleBookEntry (groupId, head, uuid_[$COLUMN_LENGTH:75$], ctCollectionId);
 create index IX_F379E6EB on StyleBookEntry (groupId, name[$COLUMN_LENGTH:75$]);
 create index IX_9A76A32B on StyleBookEntry (groupId, styleBookEntryKey[$COLUMN_LENGTH:75$]);
-create unique index IX_C05F123A on StyleBookEntry (groupId, uuid_[$COLUMN_LENGTH:75$], head, ctCollectionId);
+create index IX_516C4848 on StyleBookEntry (groupId, themeId[$COLUMN_LENGTH:255$]);
 create index IX_346515B6 on StyleBookEntry (uuid_[$COLUMN_LENGTH:75$]);
 
 create index IX_E9CC1685 on StyleBookEntryVersion (groupId, defaultStyleBookEntry);
 create index IX_B5D7AB23 on StyleBookEntryVersion (groupId, name[$COLUMN_LENGTH:75$]);
 create index IX_8E1B79F3 on StyleBookEntryVersion (groupId, styleBookEntryKey[$COLUMN_LENGTH:75$]);
-create unique index IX_D274CB96 on StyleBookEntryVersion (groupId, uuid_[$COLUMN_LENGTH:75$], version, ctCollectionId);
+create index IX_EF217910 on StyleBookEntryVersion (groupId, themeId[$COLUMN_LENGTH:255$]);
 create unique index IX_24879115 on StyleBookEntryVersion (groupId, version, ctCollectionId, styleBookEntryKey[$COLUMN_LENGTH:75$]);
 create index IX_D77F24C5 on StyleBookEntryVersion (groupId, version, defaultStyleBookEntry);
 create index IX_917554E3 on StyleBookEntryVersion (groupId, version, name[$COLUMN_LENGTH:75$]);
+create index IX_DF8E7750 on StyleBookEntryVersion (groupId, version, themeId[$COLUMN_LENGTH:255$]);
+create unique index IX_3EC07F6E on StyleBookEntryVersion (groupId, version, uuid_[$COLUMN_LENGTH:75$], ctCollectionId);
 create index IX_6C02234D on StyleBookEntryVersion (styleBookEntryId);
 create index IX_930691EE on StyleBookEntryVersion (uuid_[$COLUMN_LENGTH:75$]);
 create unique index IX_A87495E7 on StyleBookEntryVersion (version, ctCollectionId, styleBookEntryId);

--- a/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/service/persistence/test/StyleBookEntryPersistenceTest.java
+++ b/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/service/persistence/test/StyleBookEntryPersistenceTest.java
@@ -499,6 +499,27 @@ public class StyleBookEntryPersistenceTest {
 	}
 
 	@Test
+	public void testCountByG_T() throws Exception {
+		_persistence.countByG_T(RandomTestUtil.nextLong(), "");
+
+		_persistence.countByG_T(0L, "null");
+
+		_persistence.countByG_T(0L, (String)null);
+	}
+
+	@Test
+	public void testCountByG_T_Head() throws Exception {
+		_persistence.countByG_T_Head(
+			RandomTestUtil.nextLong(), "", RandomTestUtil.randomBoolean());
+
+		_persistence.countByG_T_Head(
+			0L, "null", RandomTestUtil.randomBoolean());
+
+		_persistence.countByG_T_Head(
+			0L, (String)null, RandomTestUtil.randomBoolean());
+	}
+
+	@Test
 	public void testCountByERC_G() throws Exception {
 		_persistence.countByERC_G("", RandomTestUtil.nextLong());
 

--- a/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/service/persistence/test/StyleBookEntryVersionPersistenceTest.java
+++ b/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/service/persistence/test/StyleBookEntryVersionPersistenceTest.java
@@ -367,6 +367,25 @@ public class StyleBookEntryVersionPersistenceTest {
 	}
 
 	@Test
+	public void testCountByG_T() throws Exception {
+		_persistence.countByG_T(RandomTestUtil.nextLong(), "");
+
+		_persistence.countByG_T(0L, "null");
+
+		_persistence.countByG_T(0L, (String)null);
+	}
+
+	@Test
+	public void testCountByG_T_Version() throws Exception {
+		_persistence.countByG_T_Version(
+			RandomTestUtil.nextLong(), "", RandomTestUtil.nextInt());
+
+		_persistence.countByG_T_Version(0L, "null", 0);
+
+		_persistence.countByG_T_Version(0L, (String)null, 0);
+	}
+
+	@Test
 	public void testFindByPrimaryKeyExisting() throws Exception {
 		StyleBookEntryVersion newStyleBookEntryVersion =
 			addStyleBookEntryVersion();


### PR DESCRIPTION
### _Resent from:_ https://github.com/liferay-page-management/liferay-portal/pull/16975

-------------------------------------
_Original_

Ticket: https://liferay.atlassian.net/browse/LPD-47819

## Motivation
* Currently, when user goes to Edit Page → Page Design Options → Style Books tab, it shows all available style books on list.
* Currently, when user goes to Configure Page → Design tab → Select Style Book (Basic Settings section), it shows all available style books on list.

## Proposed Solution
Only style books based on page theme css client extension or theme should be listed.


## Steps to Verify
1. Edit a page
2. Go to Page Design Options
3. Go to Style Books tab
=============================

1. Configure a page
2. Go to Design tab
3. Select Style Book ( on Basic Settings section)

## Testing

* I'm just using Dialect as sample here

### Scenario 1

1. Create a page 
2. Change theme for Dialect
3. Create two style books: One for Dialect and other randomly
5. Edit Page -> Page Design Options -> Style Book tab

Expected result: Only Dialect style books should appear on the list

### Scenario 2

1. Create page
2. Change theme for Dialect
3. Apply a Theme CSS client extension to the page
4. Create two style books: One for the themeCSS CX applied and other randomly
6. Go to Page Design Options -> Style Book tab

Expected result: Only style books based on theme css client extension applied should appear on the list.

### Scenario 3

1. Create a new master template and change theme for Dialect
2. Create a page based on this template
5. Create two style books: One for Dialect and other randomly
7. Go to Page Design Options -> Style Book tab

Expected result: Only style books based on Dialect should appear on the list.

**Test same scenarios on Configure Page -> Design -> Select Style Book ( item selector component - Basic Settings section)**
