### PR TITLE
LPD-50051 - The CX is cleared from the configuration after deploy

### DIFF
--- a/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/type/internal/configuration/test/CETConfigurationFactoryTest.java
+++ b/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/type/internal/configuration/test/CETConfigurationFactoryTest.java
@@ -18,7 +18,6 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.test.util.ConfigurationTestUtil;
 import com.liferay.portal.kernel.exception.NoSuchLayoutException;
-import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
@@ -137,12 +136,12 @@ public class CETConfigurationFactoryTest {
 
 		String pid2 = null;
 
+		Layout layout = _getControlPanelLayout(_virtualInstanceCompanyId);
+
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
 				"com.liferay.client.extension.type.internal.configuration." +
 					"CETConfigurationFactory",
 				LoggerTestUtil.ERROR)) {
-
-			Layout layout = _getControlPanelLayout(_virtualInstanceCompanyId);
 
 			List<ClientExtensionEntryRel> clientExtensionEntryRels =
 				_clientExtensionEntryRelLocalService.
@@ -182,13 +181,23 @@ public class CETConfigurationFactoryTest {
 		}
 		finally {
 			ConfigurationTestUtil.deleteConfiguration(pid1);
-			ConfigurationTestUtil.deleteConfiguration(pid2);
+
+			if (pid2 != null) {
+				ConfigurationTestUtil.deleteConfiguration(pid2);
+			}
 		}
+
+		List<ClientExtensionEntryRel> clientExtensionEntryRels =
+			_clientExtensionEntryRelLocalService.getClientExtensionEntryRels(
+				_portal.getClassNameId(Layout.class), layout.getPlid(),
+				ClientExtensionEntryConstants.TYPE_THEME_CSS);
+
+		Assert.assertEquals(
+			clientExtensionEntryRels.toString(), 0,
+			clientExtensionEntryRels.size());
 	}
 
-	private Layout _getControlPanelLayout(long companyId)
-		throws PortalException {
-
+	private Layout _getControlPanelLayout(long companyId) throws Exception {
 		Group group = _groupLocalService.fetchGroup(
 			companyId, GroupConstants.CONTROL_PANEL);
 

--- a/modules/apps/client-extension/client-extension-type-impl/src/main/java/com/liferay/client/extension/type/internal/configuration/CETConfigurationFactory.java
+++ b/modules/apps/client-extension/client-extension-type-impl/src/main/java/com/liferay/client/extension/type/internal/configuration/CETConfigurationFactory.java
@@ -138,6 +138,21 @@ public class CETConfigurationFactory {
 
 					_cetManager.deleteCET(_cet);
 
+					if (!Objects.equals(
+							_cet.getType(),
+							ClientExtensionEntryConstants.TYPE_THEME_CSS)) {
+
+						return;
+					}
+
+					ThemeCSSCET themeCSSCET = (ThemeCSSCET)_cet;
+
+					if (!Objects.equals(
+							themeCSSCET.getScope(), "controlPanel")) {
+
+						return;
+					}
+
 					if (_log.isInfoEnabled()) {
 						_log.info(
 							StringBundler.concat(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-50051

# Issue
After undeploy a CX from Liferay, its relationship with a layout were removed.

# Steps to reproduce

1. Deploy a theme CSS CX
2. Apply it to a page
3. Change something in that CX (e.g. the color in CSS) and rebuild the CX.
4. Deploy the CX again

Issue
The CX is no longer applied to that page

# Proposed solution

@thiago-buarqque added the removal of the relationship between the CX and the page by mistake. The idea was just to remove relationships for control panel ThemeCSS CX. This is what's being done now