### PR TITLE
LPD-49787 Role deletion takes long time

### DIFF
--- a/modules/apps/site/site-api/bnd.bnd
+++ b/modules/apps/site/site-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Site API
 Bundle-SymbolicName: com.liferay.site.api
-Bundle-Version: 23.0.2
+Bundle-Version: 24.0.0
 Export-Package:\
 	com.liferay.site.configuration,\
 	com.liferay.site.configuration.manager,\

--- a/modules/apps/site/site-api/src/main/java/com/liferay/site/configuration/manager/MenuAccessConfigurationManager.java
+++ b/modules/apps/site/site-api/src/main/java/com/liferay/site/configuration/manager/MenuAccessConfigurationManager.java
@@ -12,8 +12,6 @@ import com.liferay.portal.kernel.model.Role;
  */
 public interface MenuAccessConfigurationManager {
 
-	public void addAccessRoleToControlMenu(Role role) throws Exception;
-
 	public void deleteRoleAccessToControlMenu(Role role) throws Exception;
 
 	public String[] getAccessToControlMenuRoleIds(long groupId)

--- a/modules/apps/site/site-api/src/main/resources/com/liferay/site/configuration/manager/packageinfo
+++ b/modules/apps/site/site-api/src/main/resources/com/liferay/site/configuration/manager/packageinfo
@@ -1,1 +1,1 @@
-version 4.0.0
+version 5.0.0

--- a/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/configuration/manager/MenuAccessConfigurationManagerImpl.java
+++ b/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/configuration/manager/MenuAccessConfigurationManagerImpl.java
@@ -63,8 +63,8 @@ public class MenuAccessConfigurationManagerImpl
 	@Override
 	public void deleteRoleAccessToControlMenu(Role role) throws Exception {
 		String filterString = StringBundler.concat(
-			"(&(service.factoryPid=", MenuAccessConfiguration.class.getName(),
-			".scoped))");
+			"(service.factoryPid=", MenuAccessConfiguration.class.getName(),
+			".scoped)");
 
 		Configuration[] configurations = _configurationAdmin.listConfigurations(
 			filterString);

--- a/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/configuration/manager/MenuAccessConfigurationManagerImpl.java
+++ b/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/configuration/manager/MenuAccessConfigurationManagerImpl.java
@@ -5,6 +5,7 @@
 
 package com.liferay.site.internal.configuration.manager;
 
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.configuration.module.configuration.ConfigurationProvider;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
@@ -15,6 +16,10 @@ import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.site.configuration.MenuAccessConfiguration;
 import com.liferay.site.configuration.manager.MenuAccessConfigurationManager;
 
+import java.util.Dictionary;
+
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
@@ -57,26 +62,33 @@ public class MenuAccessConfigurationManagerImpl
 
 	@Override
 	public void deleteRoleAccessToControlMenu(Role role) throws Exception {
-		for (Group group :
-				_groupLocalService.getGroups(
-					role.getCompanyId(), GroupConstants.ANY_PARENT_GROUP_ID,
-					true)) {
+		String filterString = StringBundler.concat(
+			"(&(service.factoryPid=", MenuAccessConfiguration.class.getName(),
+			".scoped))");
 
-			MenuAccessConfiguration menuAccessConfiguration =
-				_configurationProvider.getGroupConfiguration(
-					MenuAccessConfiguration.class, group.getGroupId());
+		Configuration[] configurations = _configurationAdmin.listConfigurations(
+			filterString);
 
-			String roleId = String.valueOf(role.getRoleId());
-			String[] accessToControlMenuRoleIds =
-				menuAccessConfiguration.accessToControlMenuRoleIds();
+		if (configurations == null) {
+			return;
+		}
+
+		String roleId = String.valueOf(role.getRoleId());
+
+		for (Configuration configuration : configurations) {
+			Dictionary<String, Object> properties =
+				configuration.getProperties();
+
+			String[] accessToControlMenuRoleIds = (String[])properties.get(
+				"accessToControlMenuRoleIds");
 
 			if (ArrayUtil.contains(accessToControlMenuRoleIds, roleId)) {
 				accessToControlMenuRoleIds = ArrayUtil.remove(
 					accessToControlMenuRoleIds, roleId);
 
 				updateMenuAccessConfiguration(
-					group.getGroupId(), accessToControlMenuRoleIds,
-					menuAccessConfiguration.showControlMenuByRole());
+					(long)properties.get("groupId"), accessToControlMenuRoleIds,
+					(boolean)properties.get("showControlMenuByRole"));
 			}
 		}
 	}
@@ -115,6 +127,9 @@ public class MenuAccessConfigurationManagerImpl
 				"showControlMenuByRole", showControlMenuByRole
 			).build());
 	}
+
+	@Reference
+	private ConfigurationAdmin _configurationAdmin;
 
 	@Reference
 	private ConfigurationProvider _configurationProvider;

--- a/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/configuration/manager/MenuAccessConfigurationManagerImpl.java
+++ b/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/configuration/manager/MenuAccessConfigurationManagerImpl.java
@@ -7,10 +7,7 @@ package com.liferay.site.internal.configuration.manager;
 
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.configuration.module.configuration.ConfigurationProvider;
-import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Role;
-import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.site.configuration.MenuAccessConfiguration;
@@ -29,36 +26,6 @@ import org.osgi.service.component.annotations.Reference;
 @Component(service = MenuAccessConfigurationManager.class)
 public class MenuAccessConfigurationManagerImpl
 	implements MenuAccessConfigurationManager {
-
-	@Override
-	public void addAccessRoleToControlMenu(Role role) throws Exception {
-		for (Group group :
-				_groupLocalService.getGroups(
-					role.getCompanyId(), GroupConstants.ANY_PARENT_GROUP_ID,
-					true)) {
-
-			MenuAccessConfiguration menuAccessConfiguration =
-				_configurationProvider.getGroupConfiguration(
-					MenuAccessConfiguration.class, group.getGroupId());
-
-			if (!menuAccessConfiguration.showControlMenuByRole()) {
-				continue;
-			}
-
-			String roleId = String.valueOf(role.getRoleId());
-			String[] accessToControlMenuRoleIds =
-				menuAccessConfiguration.accessToControlMenuRoleIds();
-
-			if (!ArrayUtil.contains(accessToControlMenuRoleIds, roleId)) {
-				accessToControlMenuRoleIds = ArrayUtil.append(
-					accessToControlMenuRoleIds, roleId);
-
-				updateMenuAccessConfiguration(
-					group.getGroupId(), accessToControlMenuRoleIds,
-					menuAccessConfiguration.showControlMenuByRole());
-			}
-		}
-	}
 
 	@Override
 	public void deleteRoleAccessToControlMenu(Role role) throws Exception {
@@ -134,8 +101,5 @@ public class MenuAccessConfigurationManagerImpl
 
 	@Reference
 	private ConfigurationProvider _configurationProvider;
-
-	@Reference
-	private GroupLocalService _groupLocalService;
 
 }

--- a/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/configuration/manager/MenuAccessConfigurationManagerImpl.java
+++ b/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/configuration/manager/MenuAccessConfigurationManagerImpl.java
@@ -86,9 +86,10 @@ public class MenuAccessConfigurationManagerImpl
 				accessToControlMenuRoleIds = ArrayUtil.remove(
 					accessToControlMenuRoleIds, roleId);
 
-				updateMenuAccessConfiguration(
-					(long)properties.get("groupId"), accessToControlMenuRoleIds,
-					(boolean)properties.get("showControlMenuByRole"));
+				properties.put(
+					"accessToControlMenuRoleIds", accessToControlMenuRoleIds);
+
+				configuration.update(properties);
 			}
 		}
 	}

--- a/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/configuration/manager/test/MenuAccessConfigurationManagerPerformanceTest.java
+++ b/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/configuration/manager/test/MenuAccessConfigurationManagerPerformanceTest.java
@@ -1,0 +1,87 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.configuration.manager.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.test.performance.PerformanceTimer;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RoleTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.site.configuration.manager.MenuAccessConfigurationManager;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Evan Thibodeau
+ */
+@RunWith(Arquillian.class)
+public class MenuAccessConfigurationManagerPerformanceTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		for (int i = 0; i < _NUMBER_GROUPS; i++) {
+			_groups.add(GroupTestUtil.addGroup());
+		}
+	}
+
+	@Test
+	public void testDeleteRoleAccessToControlMenu() throws Exception {
+		Role role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
+
+		try (PerformanceTimer performanceTimer = new PerformanceTimer(200)) {
+			_menuAccessConfigurationManager.deleteRoleAccessToControlMenu(role);
+		}
+	}
+
+	@Test
+	public void testDeleteRoleAccessToControlMenuWithMenuAccessEnabled()
+		throws Exception {
+
+		Role role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
+
+		for (int i = 0; i < (_NUMBER_GROUPS / 5); i++) {
+			Group group = _groups.get(i);
+
+			_menuAccessConfigurationManager.updateMenuAccessConfiguration(
+				group.getGroupId(),
+				new String[] {String.valueOf(role.getRoleId())}, true);
+		}
+
+		try (PerformanceTimer performanceTimer = new PerformanceTimer(400)) {
+			_menuAccessConfigurationManager.deleteRoleAccessToControlMenu(role);
+		}
+	}
+
+	private static final int _NUMBER_GROUPS = 100;
+
+	@DeleteAfterTestRun
+	private final List<Group> _groups = new ArrayList<>();
+
+	@Inject
+	private MenuAccessConfigurationManager _menuAccessConfigurationManager;
+
+}

--- a/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/configuration/manager/test/MenuAccessConfigurationManagerTest.java
+++ b/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/configuration/manager/test/MenuAccessConfigurationManagerTest.java
@@ -73,7 +73,9 @@ public class MenuAccessConfigurationManagerTest {
 	public void testAddAccessRoleToControlMenu() throws Exception {
 		Role role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
 
-		_menuAccessConfigurationManager.addAccessRoleToControlMenu(role);
+		_menuAccessConfigurationManager.updateMenuAccessConfiguration(
+			_group.getGroupId(),
+			new String[] {String.valueOf(role.getRoleId())}, true);
 
 		_assertMenuAccessConfiguration(
 			new String[] {String.valueOf(role.getRoleId())});

--- a/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/internal/model/listener/test/RoleModelListenerTest.java
+++ b/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/internal/model/listener/test/RoleModelListenerTest.java
@@ -114,7 +114,9 @@ public class RoleModelListenerTest {
 			StringUtil.randomString(), null, null, RoleConstants.TYPE_REGULAR,
 			null, _serviceContext);
 
-		_menuAccessConfigurationManager.addAccessRoleToControlMenu(role);
+		_menuAccessConfigurationManager.updateMenuAccessConfiguration(
+			_group.getGroupId(),
+			new String[] {String.valueOf(role.getRoleId())}, true);
 
 		_assertConfiguration(new String[] {String.valueOf(role.getRoleId())});
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-49787

## Problem

Role deletion was taking too long when an instance of Liferay had many sites. This was because we were requesting all sites and then for each site checking if the configuration is set.

## Solution

This PR improves performance by only getting the configurations that are set and updating the ones that need to be updated.


## Questions

I'm unsure what parameters should be used for the performance test? The test requires creating many sites, but I'm unsure how many sites I should create in order to make the test a real example, but also not unnecessarily take too long to run.