### PR TITLE
LPD-51580 Change pagination delta values to be 5, 10, 20, 40, 60

### DIFF
--- a/modules/test/playwright/tests/account-admin-web/accountAddresses.spec.ts
+++ b/modules/test/playwright/tests/account-admin-web/accountAddresses.spec.ts
@@ -132,6 +132,9 @@ test('LPD-46415 Can paginate the addresses of an account', async ({
 		{
 			name: `5_${getRandomString()}`,
 		},
+		{
+			name: `6_${getRandomString()}`,
+		},
 	];
 
 	await accountsPage.goto();
@@ -145,10 +148,10 @@ test('LPD-46415 Can paginate the addresses of an account', async ({
 		await editAccountAddressPage.addAddress(address);
 	}
 
-	await setItemsPerPage(page, 4);
+	await setItemsPerPage(page, 5);
 
 	for (const [index, address] of addresses.entries()) {
-		if (index < 4) {
+		if (index < 5) {
 			await expect(
 				accountAddressesPage.addressesTable.valueLink(address.name)
 			).toBeVisible();
@@ -163,7 +166,7 @@ test('LPD-46415 Can paginate the addresses of an account', async ({
 	await nextPage(page);
 
 	for (const [index, address] of addresses.entries()) {
-		if (index < 4) {
+		if (index < 5) {
 			await expect(
 				accountAddressesPage.addressesTable.valueLink(address.name)
 			).toHaveCount(0);

--- a/modules/test/playwright/tests/account-admin-web/accountOrganizations.spec.ts
+++ b/modules/test/playwright/tests/account-admin-web/accountOrganizations.spec.ts
@@ -325,7 +325,7 @@ test('LPD-47225 Can paginate organizations during assignment', async ({
 
 	const organizations = [];
 
-	for (let i = 1; i <= 5; i++) {
+	for (let i = 1; i <= 6; i++) {
 		organizations.push(
 			await apiHelpers.headlessAdminUser.postOrganization({
 				name: `A Organization ${i}`,
@@ -340,10 +340,10 @@ test('LPD-47225 Can paginate organizations during assignment', async ({
 	await accountsPage.organizationsTab.click();
 	await accountOrganizationsPage.organizationsTable.newButton.click();
 
-	await setItemsPerPage(accountOrganizationSelectorPage.frame, 4);
+	await setItemsPerPage(accountOrganizationSelectorPage.frame, 5);
 
 	for (const [index, organization] of organizations.entries()) {
-		if (index < 4) {
+		if (index < 5) {
 			await expect(
 				accountOrganizationSelectorPage.organizationsTable.cell(
 					organization.name
@@ -362,7 +362,7 @@ test('LPD-47225 Can paginate organizations during assignment', async ({
 	await nextPage(accountOrganizationSelectorPage.frame);
 
 	for (const [index, organization] of organizations.entries()) {
-		if (index < 4) {
+		if (index < 5) {
 			await expect(
 				accountOrganizationSelectorPage.organizationsTable.cell(
 					organization.name

--- a/modules/test/playwright/tests/account-admin-web/accountPermissions.spec.ts
+++ b/modules/test/playwright/tests/account-admin-web/accountPermissions.spec.ts
@@ -703,7 +703,7 @@ test(
 		).toBeVisible();
 
 		for (let i = 1; i < 7; i++) {
-			if (i <= 5 ) {
+			if (i <= 5) {
 				await expect(
 					accountManagementWidgetPage.accountCell(`Account ${i}`)
 				).toBeVisible();

--- a/modules/test/playwright/tests/account-admin-web/accountPermissions.spec.ts
+++ b/modules/test/playwright/tests/account-admin-web/accountPermissions.spec.ts
@@ -696,14 +696,14 @@ test(
 
 		await page.waitForLoadState('domcontentloaded');
 
-		await setItemsPerPage(page, '4');
+		await setItemsPerPage(page, '5');
 
 		await expect(
-			page.getByText('Showing 1 to 4 of 6 entries.', {exact: true})
+			page.getByText('Showing 1 to 5 of 6 entries.', {exact: true})
 		).toBeVisible();
 
 		for (let i = 1; i < 7; i++) {
-			if (i < 5) {
+			if (i <= 5 ) {
 				await expect(
 					accountManagementWidgetPage.accountCell(`Account ${i}`)
 				).toBeVisible();
@@ -718,11 +718,11 @@ test(
 		await nextPage(page);
 
 		await expect(
-			page.getByText('Showing 5 to 6 of 6 entries.')
+			page.getByText('Showing 6 to 6 of 6 entries.')
 		).toBeVisible();
 
 		for (let i = 1; i < 7; i++) {
-			if (i < 5) {
+			if (i <= 5) {
 				await expect(
 					accountManagementWidgetPage.accountCell(`Account ${i}`)
 				).not.toBeVisible();
@@ -734,7 +734,7 @@ test(
 			}
 		}
 
-		await setItemsPerPage(page, '8');
+		await setItemsPerPage(page, '10');
 
 		await expect(
 			page.getByText('Showing 1 to 6 of 6 entries.')

--- a/modules/test/playwright/tests/account-admin-web/accountUsers.spec.ts
+++ b/modules/test/playwright/tests/account-admin-web/accountUsers.spec.ts
@@ -351,7 +351,7 @@ test(
 
 		const users = [];
 
-		for (let i = 1; i <= 5; i++) {
+		for (let i = 1; i <= 6; i++) {
 			users.push(
 				await apiHelpers.headlessAdminUser.postUserAccount({
 					familyName: `A User ${i}`,
@@ -367,10 +367,10 @@ test(
 		await accountUsersPage.usersTable.newButton.click();
 		await accountUsersPage.assignUserMenuItem.click();
 
-		await setItemsPerPage(accountUserSelectorPage.frame, 4);
+		await setItemsPerPage(accountUserSelectorPage.frame, 5);
 
 		for (const [index, user] of users.entries()) {
-			if (index < 4) {
+			if (index < 5) {
 				await expect(
 					accountUserSelectorPage.usersTable.cell(user.name)
 				).toBeVisible();
@@ -385,7 +385,7 @@ test(
 		await nextPage(accountUserSelectorPage.frame);
 
 		for (const [index, user] of users.entries()) {
-			if (index < 4) {
+			if (index < 5) {
 				await expect(
 					accountUserSelectorPage.usersTable.cell(user.name)
 				).toHaveCount(0);
@@ -1778,7 +1778,7 @@ test(
 
 		const users: Array<TUserAccount> = [];
 
-		for (let i = 1; i < 6; i++) {
+		for (let i = 1; i <= 6; i++) {
 			const user = await apiHelpers.headlessAdminUser.postUserAccount({
 				familyName: `${i} ${getRandomString()}`,
 			});
@@ -1793,10 +1793,10 @@ test(
 
 		await accountUsersPage.goto();
 
-		await setItemsPerPage(page, 4);
+		await setItemsPerPage(page, 5);
 
 		for (const [index, user] of users.entries()) {
-			if (index < 4) {
+			if (index < 5) {
 				await expect(
 					accountUsersPage.usersTable.cell(user.emailAddress)
 				).toBeVisible();
@@ -1811,7 +1811,7 @@ test(
 		await nextPage(page);
 
 		for (const [index, user] of users.entries()) {
-			if (index < 4) {
+			if (index < 5) {
 				await expect(
 					accountUsersPage.usersTable.cell(user.emailAddress)
 				).toHaveCount(0);

--- a/modules/test/playwright/tests/account-admin-web/accounts.spec.ts
+++ b/modules/test/playwright/tests/account-admin-web/accounts.spec.ts
@@ -926,7 +926,7 @@ test('LPS-101893 Account list should be paginated', async ({
 	apiHelpers,
 	page,
 }) => {
-	for (let i = 1; i < 6; i++) {
+	for (let i = 1; i < 7; i++) {
 		const account = await apiHelpers.headlessAdminUser.postAccount({
 			name: `Account ${i}`,
 			type: 'business',
@@ -937,10 +937,10 @@ test('LPS-101893 Account list should be paginated', async ({
 
 	await accountsPage.goto();
 
-	await setItemsPerPage(page, 4);
+	await setItemsPerPage(page, 5);
 
-	for (let i = 1; i < 6; i++) {
-		if (i < 5) {
+	for (let i = 1; i < 7; i++) {
+		if (i < 6) {
 			await expect(
 				accountsPage.accountsTable.cell(`Account ${i}`)
 			).toBeVisible();
@@ -954,8 +954,8 @@ test('LPS-101893 Account list should be paginated', async ({
 
 	await nextPage(page);
 
-	for (let i = 1; i < 6; i++) {
-		if (i < 5) {
+	for (let i = 1; i < 7; i++) {
+		if (i < 6) {
 			await expect(
 				accountsPage.accountsTable.cell(`Account ${i}`)
 			).toHaveCount(0);

--- a/modules/test/playwright/tests/address-web/countriesManagement.spec.ts
+++ b/modules/test/playwright/tests/address-web/countriesManagement.spec.ts
@@ -65,7 +65,7 @@ test('LPD-41857 Can delete regions in bulk', async ({
 }) => {
 	await countriesManagementPage.goto();
 
-	const regions: string[] = ['AAAA', 'BBBB', 'CCCC', 'DDDD', 'EEEE'];
+	const regions: string[] = ['AAAA', 'BBBB', 'CCCC', 'DDDD', 'EEEE', 'FFFF'];
 
 	const country =
 		await apiHelpers.headlessAdminAddress.getCountryByName('antarctica');
@@ -85,7 +85,7 @@ test('LPD-41857 Can delete regions in bulk', async ({
 	await (await countriesManagementPage.regionsLink).click();
 
 	await countriesManagementPage.selectPaginationItemsPerPage({
-		itemsPerPage: '4  Entries per Page',
+		itemsPerPage: '5  Entries per Page',
 		page,
 	});
 
@@ -94,7 +94,7 @@ test('LPD-41857 Can delete regions in bulk', async ({
 
 		await (await countriesManagementPage.regionsCheckbox(region)).check();
 
-		if (i === 3) {
+		if (i === 4) {
 			await countriesManagementPage.paginationLink('Page  2').click();
 			await waitForLoading(page);
 		}

--- a/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
@@ -507,7 +507,7 @@ baseTest(
 		const contentStructureId =
 			await getBasicWebContentStructureId(apiHelpers);
 
-		for (let i = 0; i < 10; i++) {
+		for (let i = 0; i < 12; i++) {
 			await apiHelpers.jsonWebServicesJournal.addWebContent({
 				ddmStructureId: contentStructureId,
 				groupId: site.id,
@@ -516,7 +516,11 @@ baseTest(
 
 		await journalPage.goto(site.friendlyUrlPath);
 
-		await setItemsPerPage(page, 4);
+		await expect(
+			page.getByText(/Showing \d+ to \d+ of \d+ entries\./)
+		).toBeVisible();
+
+		await setItemsPerPage(page, 5);
 
 		await page.getByTestId('row').nth(0).getByRole('checkbox').check();
 		await page.getByTestId('row').nth(1).getByRole('checkbox').check();
@@ -524,7 +528,7 @@ baseTest(
 		await nextPage(page);
 
 		await expect(
-			page.getByText('Showing 5 to 8 of 10 entries.')
+			page.getByText('Showing 6 to 10 of 12 entries.')
 		).toBeVisible();
 
 		await page.getByTestId('row').nth(0).getByRole('checkbox').check();
@@ -533,7 +537,7 @@ baseTest(
 		await nextPage(page);
 
 		await expect(
-			page.getByText('Showing 9 to 10 of 10 entries.')
+			page.getByText('Showing 11 to 12 of 12 entries.')
 		).toBeVisible();
 
 		await page.getByTestId('row').nth(0).getByRole('checkbox').check();

--- a/modules/test/playwright/tests/message-boards-web/message-boards-web.spec.ts
+++ b/modules/test/playwright/tests/message-boards-web/message-boards-web.spec.ts
@@ -191,7 +191,7 @@ test(
 		const threadsLinks = page.getByRole('link', {
 			name: /Thread with headline #\d+/,
 		});
-		for (let i = 0; i < 5; i++) {
+		for (let i = 0; i < 6; i++) {
 			await apiHelpers.headlessDelivery.postMessageBoardThread({
 				articleBody: getRandomString(),
 				headline: 'Thread with headline #' + i,
@@ -201,14 +201,14 @@ test(
 
 		await messageBoardsPage.goto(site.friendlyUrlPath);
 
-		await setItemsPerPage(page, 4);
-		await expect(threadsLinks).toHaveCount(4);
+		await setItemsPerPage(page, 5);
+		await expect(threadsLinks).toHaveCount(5);
 
 		await gotoPage(page, 2);
 		await expect(threadsLinks).toHaveCount(1);
 
-		await setItemsPerPage(page, 8);
-		await expect(threadsLinks).toHaveCount(5);
+		await setItemsPerPage(page, 10);
+		await expect(threadsLinks).toHaveCount(6);
 	}
 );
 
@@ -219,7 +219,7 @@ test(
 		const threadsLinks = page.getByRole('link', {
 			name: /Thread with headline #\d+/,
 		});
-		for (let i = 0; i < 5; i++) {
+		for (let i = 0; i < 6; i++) {
 			await apiHelpers.headlessDelivery.postMessageBoardThread({
 				articleBody: getRandomString(),
 				headline: 'Thread with headline #' + i,
@@ -228,13 +228,13 @@ test(
 		}
 		await messageBoardsWidgetPage.addMessageBoardsPortlet(site);
 
-		await setItemsPerPage(page, 4);
-		await expect(threadsLinks).toHaveCount(4);
+		await setItemsPerPage(page, 5);
+		await expect(threadsLinks).toHaveCount(5);
 
 		await gotoPage(page, 2);
 		await expect(threadsLinks).toHaveCount(1);
 
-		await setItemsPerPage(page, 8);
-		await expect(threadsLinks).toHaveCount(5);
+		await setItemsPerPage(page, 10);
+		await expect(threadsLinks).toHaveCount(6);
 	}
 );

--- a/modules/test/playwright/tests/portal-search-web/searchFacets.spec.ts
+++ b/modules/test/playwright/tests/portal-search-web/searchFacets.spec.ts
@@ -185,7 +185,7 @@ test.describe('Clear and retain facet selections', () => {
 		searchPage,
 	}) => {
 		await test.step('Change pagination items per page and page number', async () => {
-			await searchPage.selectPaginationItemsPerPage(4);
+			await searchPage.selectPaginationItemsPerPage(5);
 
 			await searchPage.selectPaginationPageNumber(2);
 		});
@@ -201,7 +201,7 @@ test.describe('Clear and retain facet selections', () => {
 		await test.step('Verify that page number is reset but items per page is not', async () => {
 			await expect(
 				searchPage.searchResultsPaginationItemsPerPageToggle
-			).toHaveText(/4 Entries/);
+			).toHaveText(/5 Entries/);
 
 			await expect(
 				searchPage.searchResultsPaginationBar.getByText('1').first()
@@ -209,7 +209,7 @@ test.describe('Clear and retain facet selections', () => {
 
 			await expect(
 				searchPage.searchResultsPaginationDescription
-			).toHaveText(/Showing 1 to 4 of \d+ entries./);
+			).toHaveText(/Showing 1 to 5 of \d+ entries./);
 		});
 	});
 

--- a/modules/test/playwright/tests/portal-search-web/searchResults.spec.ts
+++ b/modules/test/playwright/tests/portal-search-web/searchResults.spec.ts
@@ -109,17 +109,17 @@ test.describe('Use two Search Results widgets in the same page', () => {
 		await test.step('Check if the pagination delta of a Search Results widget persists when changing that of another widget', async () => {
 			await page.reload();
 
-			await searchPage.selectPaginationItemsPerPage(4);
+			await searchPage.selectPaginationItemsPerPage(5);
 
 			await expect(
 				searchPage.searchResultsPaginationItemsPerPageToggle.nth(1)
 			).toHaveText('20 Entries');
 
-			await searchPage.selectPaginationItemsPerPage(8, 1);
+			await searchPage.selectPaginationItemsPerPage(10, 1);
 
 			await expect(
 				searchPage.searchResultsPaginationItemsPerPageToggle.nth(0)
-			).toHaveText('4 Entries');
+			).toHaveText('5 Entries');
 		});
 
 		await test.step('Remove the federatedSearchKey of one Search Results and Search Options widget', async () => {
@@ -155,7 +155,7 @@ test.describe('Use two Search Results widgets in the same page', () => {
 				searchPage.searchResultsPaginationItemsPerPageToggle.nth(1)
 			).toHaveText('20 Entries');
 
-			await searchPage.selectPaginationItemsPerPage(4, 1);
+			await searchPage.selectPaginationItemsPerPage(5, 1);
 
 			await expect(
 				searchPage.searchResultsPaginationItemsPerPageToggle.nth(0)

--- a/modules/test/playwright/tests/portal-web/html/taglib/ui/pageIterator.spec.ts
+++ b/modules/test/playwright/tests/portal-web/html/taglib/ui/pageIterator.spec.ts
@@ -44,9 +44,11 @@ test(
 		await test.step('Check pagination button is selected and contains option role', async () => {
 			await page.getByLabel('Items per Page').click();
 
-			await page.getByRole('option', {
-				name: '5  Entries per Page',
-			}).click();
+			await page
+				.getByRole('option', {
+					name: '5  Entries per Page',
+				})
+				.click();
 
 			const pagination = page.getByLabel('Items per Page');
 

--- a/modules/test/playwright/tests/portal-web/html/taglib/ui/pageIterator.spec.ts
+++ b/modules/test/playwright/tests/portal-web/html/taglib/ui/pageIterator.spec.ts
@@ -44,18 +44,16 @@ test(
 		await test.step('Check pagination button is selected and contains option role', async () => {
 			await page.getByLabel('Items per Page').click();
 
-			const paginationFourSelection = page.getByRole('option', {
-				name: '4  Entries per Page',
-			});
-
-			await paginationFourSelection.click();
+			await page.getByRole('option', {
+				name: '5  Entries per Page',
+			}).click();
 
 			const pagination = page.getByLabel('Items per Page');
 
 			await pagination.waitFor({state: 'visible'});
 
 			const paginationLinkSelected = page.locator(
-				'a[aria-selected="true"][role="option"][id="4"]'
+				'a[aria-selected="true"][role="option"][id="5"]'
 			);
 
 			await expect(paginationLinkSelected).toBeHidden();

--- a/modules/test/playwright/tests/portal-workflow-task-web/workload.spec.ts
+++ b/modules/test/playwright/tests/portal-workflow-task-web/workload.spec.ts
@@ -64,8 +64,8 @@ test('view workload distribution for all assignees', async ({
 	metricsPage,
 	page,
 }) => {
-	const NEW_PAGE_SIZE = 4;
-	const NUMBER_OF_USERS_AND_TASKS = 5;
+	const NEW_PAGE_SIZE = 5;
+	const NUMBER_OF_USERS_AND_TASKS = 6;
 	const WORKFLOW_DEFINITION_NAME = 'Single Approver';
 
 	const blogPosts = [];

--- a/modules/test/playwright/tests/portlet-configuration-web/rolePermissions.spec.ts
+++ b/modules/test/playwright/tests/portlet-configuration-web/rolePermissions.spec.ts
@@ -33,7 +33,7 @@ test('LPD-25265 search results should stay when form submitted', async ({
 		portletConfigurationPermissionsPage.siteMemberRoleCell
 	).toBeVisible();
 
-	await portletConfigurationPermissionsPage.changePagination(20, 4);
+	await portletConfigurationPermissionsPage.changePagination(20, 5);
 
 	await expect(
 		portletConfigurationPermissionsPage.ownerRoleCell

--- a/modules/test/playwright/tests/roles-admin-web/roles.spec.ts
+++ b/modules/test/playwright/tests/roles-admin-web/roles.spec.ts
@@ -306,9 +306,9 @@ test(
 		await expect(rolesPage.rolesTable.searchInput).toBeEditable();
 
 		await expect(async () => {
-			await setItemsPerPage(page, 4);
+			await setItemsPerPage(page, 5);
 
-			await expect(page.getByText('Showing 1 to 4')).toBeVisible();
+			await expect(page.getByText('Showing 1 to 5')).toBeVisible();
 		}).toPass();
 
 		await expect(async () => {

--- a/modules/test/playwright/tests/site-admin-web/siteInitializerSelection.spec.ts
+++ b/modules/test/playwright/tests/site-admin-web/siteInitializerSelection.spec.ts
@@ -53,7 +53,7 @@ test(
 	async ({apiHelpers, page, selectSiteInitializerPage, sitesPage}) => {
 		const layoutSetPrototypes = [];
 
-		for (let i = 0; i < 5; i++) {
+		for (let i = 0; i < 6; i++) {
 			const layoutSetPrototype: LayoutSetPrototype =
 				await apiHelpers.jsonWebServicesLayoutSetPrototype.addLayoutSetPrototypes(
 					{
@@ -70,10 +70,10 @@ test(
 
 		await page.getByLabel('Items per Page').click();
 
-		await page.getByRole('option', {name: '4  Entries per Page'}).click();
+		await page.getByRole('option', {name: '5  Entries per Page'}).click();
 
 		await expect(
-			page.getByText('Showing 1 to 4 of 5 entries.')
+			page.getByText('Showing 1 to 5 of 6 entries.')
 		).toBeVisible();
 
 		await expect(

--- a/modules/test/playwright/tests/users-admin-web/gdpr.spec.ts
+++ b/modules/test/playwright/tests/users-admin-web/gdpr.spec.ts
@@ -1737,6 +1737,7 @@ testAdmin(
 
 		const checkVisibility = async (visibilityFlags: boolean[]) => {
 			const statuses = [
+				exportUserDataPage.announcementsStatus,
 				exportUserDataPage.blogsStatus,
 				exportUserDataPage.documentsAndMediaStatus,
 				exportUserDataPage.messageBoardsStatus,
@@ -1785,6 +1786,11 @@ testAdmin(
 		});
 
 		apiHelpers.data.push({id: site.id, type: 'site'});
+
+		const announcement =
+			await apiHelpers.jsonWebServicesAnnouncementsEntryApiHelper.addEntry();
+
+		apiHelpers.data.push({id: announcement.entryId, type: 'announcement'});
 
 		await apiHelpers.headlessDelivery.postBlog(site.id);
 
@@ -1836,6 +1842,7 @@ testAdmin(
 		await usersAndOrganizationsPage.exportPersonalDataItem.click();
 		await exportUserDataPage.addExportProcessesButton.click();
 
+		await exportUserDataPage.announcementsCheckbox.check();
 		await exportUserDataPage.blogsCheckbox.check();
 		await exportUserDataPage.documentsAndMediaCheckbox.check();
 		await exportUserDataPage.messageBoardsCheckbox.check();
@@ -1846,26 +1853,26 @@ testAdmin(
 
 		await waitForAlert(page);
 
-		await checkVisibility([true, true, true, true, true]);
+		await checkVisibility([true, true, true, true, true, true]);
 
 		await exportUserDataPage.orderByButton.click();
 		await exportUserDataPage.nameMenuItem.click();
 
-		for (const itemsPerPage of [4, 8, 20, 40, 60]) {
+		for (const itemsPerPage of [5, 10, 20, 40, 60]) {
 			await setItemsPerPage(page, itemsPerPage);
 
-			if (itemsPerPage === 4) {
-				await checkVisibility([true, true, true, true, false]);
-				await exportUserDataPage.verifyPaginationResult(1, 4, 5);
+			if (itemsPerPage === 5) {
+				await checkVisibility([true, true, true, true, true, false]);
+				await exportUserDataPage.verifyPaginationResult(1, 5, 6);
 				await gotoPage(page, 2);
 
-				await checkVisibility([false, false, false, false, true]);
-				await exportUserDataPage.verifyPaginationResult(5, 5, 5);
+				await checkVisibility([false, false, false, false, false, true]);
+				await exportUserDataPage.verifyPaginationResult(6, 6, 6);
 				await gotoPage(page, 1);
 			}
 			else {
-				await checkVisibility([true, true, true, true, true]);
-				await exportUserDataPage.verifyPaginationResult(1, 5, 5);
+				await checkVisibility([true, true, true, true, true, true]);
+				await exportUserDataPage.verifyPaginationResult(1, 6, 6);
 			}
 		}
 	}

--- a/modules/test/playwright/tests/users-admin-web/gdpr.spec.ts
+++ b/modules/test/playwright/tests/users-admin-web/gdpr.spec.ts
@@ -1866,7 +1866,14 @@ testAdmin(
 				await exportUserDataPage.verifyPaginationResult(1, 5, 6);
 				await gotoPage(page, 2);
 
-				await checkVisibility([false, false, false, false, false, true]);
+				await checkVisibility([
+					false,
+					false,
+					false,
+					false,
+					false,
+					true,
+				]);
 				await exportUserDataPage.verifyPaginationResult(6, 6, 6);
 				await gotoPage(page, 1);
 			}

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -9206,8 +9206,8 @@
     # Env: LIFERAY_SEARCH_PERIOD_CONTAINER_PERIOD_PAGE_PERIOD_DELTA_PERIOD_VALUES
     #
     search.container.page.delta.values=\
-        4,\
-        8,\
+        5,\
+        10,\
         20,\
         40,\
         60
@@ -10511,8 +10511,8 @@
     # Env: LIFERAY_ANNOUNCEMENTS_PERIOD_ENTRY_PERIOD_PAGE_PERIOD_DELTA_PERIOD_VALUES
     #
     announcements.entry.page.delta.values=\
-        4,\
-        8,\
+        5,\
+        10,\
         20,\
         40,\
         60
@@ -10647,8 +10647,8 @@
     # Env: LIFERAY_BLOGS_PERIOD_ENTRY_PERIOD_PAGE_PERIOD_DELTA_PERIOD_VALUES
     #
     blogs.entry.page.delta.values=\
-        4,\
-        8,\
+        5,\
+        10,\
         20,\
         40,\
         60


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-51580

This pr is meant to work with https://github.com/liferay/clay/pull/5974. Search Iterator lumps directory card and asset cards together. It will output up to 20 directory cards before outputting asset cards. This causes unintended layout issues. The image below shows what it would look like when there is 1 directory card. I think we need to discuss how to handle this.

![20items](https://github.com/user-attachments/assets/605e2148-74f0-49e4-a457-a6d4cfb21118)


/cc @marcoscv-work @dsanz