### PR TITLE
LPD-51725 Orphaned data in Configuration_ table when deleting a group

### DIFF
--- a/modules/apps/configuration-admin/configuration-admin-test/build.gradle
+++ b/modules/apps/configuration-admin/configuration-admin-test/build.gradle
@@ -3,6 +3,7 @@ dependencies {
 	testIntegrationImplementation group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	testIntegrationImplementation group: "org.osgi", name: "org.osgi.service.metatype", version: "1.3.0"
 	testIntegrationImplementation project(":apps:configuration-admin:configuration-admin-api")
+	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-module-configuration-api")
 	testIntegrationImplementation project(":apps:portal-search:portal-search-test-util")
 	testIntegrationImplementation project(":apps:static:osgi:osgi-util")
 	testIntegrationImplementation project(":apps:static:portal-configuration:portal-configuration-metatype-api")

--- a/modules/apps/configuration-admin/configuration-admin-test/src/testIntegration/java/com/liferay/configuration/admin/web/internal/model/listener/test/GroupModelListenerTest.java
+++ b/modules/apps/configuration-admin/configuration-admin-test/src/testIntegration/java/com/liferay/configuration/admin/web/internal/model/listener/test/GroupModelListenerTest.java
@@ -1,0 +1,79 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.configuration.admin.web.internal.model.listener.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.configuration.module.configuration.ConfigurationProvider;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.framework.Constants;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+
+/**
+ * @author Jonathan McCann
+ */
+@RunWith(Arquillian.class)
+public class GroupModelListenerTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testDeleteGroup() throws Exception {
+		Group group = GroupTestUtil.addGroup();
+
+		_configurationProvider.saveGroupConfiguration(
+			group.getGroupId(), _PID,
+			HashMapDictionaryBuilder.<String, Object>put(
+				RandomTestUtil.randomString(), RandomTestUtil.randomString()
+			).build());
+
+		Assert.assertNotNull(_getConfiguration());
+
+		_groupLocalService.deleteGroup(group);
+
+		Assert.assertNull(_getConfiguration());
+	}
+
+	private Configuration _getConfiguration() throws Exception {
+		Configuration[] configurations = _configurationAdmin.listConfigurations(
+			String.format("(%s=%s*)", Constants.SERVICE_PID, _PID));
+
+		if (configurations != null) {
+			return configurations[0];
+		}
+
+		return null;
+	}
+
+	private static final String _PID = "test.pid";
+
+	@Inject
+	private ConfigurationAdmin _configurationAdmin;
+
+	@Inject
+	private ConfigurationProvider _configurationProvider;
+
+	@Inject
+	private GroupLocalService _groupLocalService;
+
+}

--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/model/listener/GroupModelListener.java
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/model/listener/GroupModelListener.java
@@ -1,0 +1,72 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.configuration.admin.web.internal.model.listener;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
+import com.liferay.portal.kernel.exception.ModelListenerException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.BaseModelListener;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.ModelListener;
+
+import java.io.IOException;
+
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Jonathan McCann
+ */
+@Component(service = ModelListener.class)
+public class GroupModelListener extends BaseModelListener<Group> {
+
+	@Override
+	public void onAfterRemove(Group group) throws ModelListenerException {
+		try {
+			_clean(group);
+		}
+		catch (Exception exception) {
+			throw new ModelListenerException(exception);
+		}
+	}
+
+	private void _clean(Group group) throws Exception {
+		String filterString = StringBundler.concat(
+			StringPool.OPEN_PARENTHESIS,
+			ExtendedObjectClassDefinition.Scope.GROUP.getPropertyKey(),
+			StringPool.EQUAL, group.getGroupId(), StringPool.CLOSE_PARENTHESIS);
+
+		Configuration[] configurations = _configurationAdmin.listConfigurations(
+			filterString);
+
+		if (configurations == null) {
+			return;
+		}
+
+		for (Configuration configuration : configurations) {
+			try {
+				configuration.delete();
+			}
+			catch (IOException ioException) {
+				if (_log.isWarnEnabled()) {
+					_log.warn(ioException);
+				}
+			}
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		GroupModelListener.class);
+
+	@Reference
+	private ConfigurationAdmin _configurationAdmin;
+
+}


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-51725

# How am I fixing it?

There is already a [CompanyModelListener](https://github.com/liferay/liferay-portal/blob/master/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/model/listener/CompanyModelListener.java) that removes the associated configurations when a company is deleted so I made a similar listener for groups.

Two questions for your team:

1. Is there a reason we want to keep these group specific configurations?
2. Is the [filter string](https://github.com/liferay-platform-experience/liferay-portal/compare/master...jonathanmccann:LPD-51725?expand=1#diff-55b9175c71b11e17f245139408910f5cc6e572ca8efaf246526c88f7a8af32f9R42) too broad and will unexpectedly capture configurations that should not be deleted?

If this is not the correct approach or there are any other concerns please let me know.

# How can you verify that it works?

In `configuration-admin-test` run `gw testIntegration --tests *.GroupModelListenerTest`

Alternatively there are steps to reproduce on LPD-51725.