### PR TITLE
LPD-51885

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/administration/portalconfiguration/systemmanagement/SystemSettings.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/administration/portalconfiguration/systemmanagement/SystemSettings.testcase
@@ -221,7 +221,7 @@ definition {
 		}
 
 		task ("When change groupKey to new instance site and copy it to the configs folder") {
-			var exportConfigFileName = TestCase.getDownloadedTempFileName(fileNamePattern = "com.liferay.account.internal.configuration.AccountEntryGroupConfiguration.scoped_*.config");
+			var exportConfigFileName = TestCase.getDownloadedTempFileName(fileNamePattern = "com.liferay.account.internal.configuration.AccountEntryGroupConfiguration.scoped*.config");
 			var exportFileDirectory = selenium.getOutputDirName();
 
 			OSGiConfig.editOSGiConfigFileFromTempFolder(
@@ -313,7 +313,7 @@ definition {
 		}
 
 		task ("When change groupKey to new instance site and copy it to the configs folder") {
-			var exportConfigFileName = TestCase.getDownloadedTempFileName(fileNamePattern = "com.liferay.account.internal.configuration.AccountEntryGroupConfiguration.scoped_*.config");
+			var exportConfigFileName = TestCase.getDownloadedTempFileName(fileNamePattern = "com.liferay.account.internal.configuration.AccountEntryGroupConfiguration.scoped*.config");
 			var exportFileDirectory = selenium.getOutputDirName();
 
 			OSGiConfig.editOSGiConfigFileFromTempFolder(


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPD-51885

## Motivation
SystemSettings#CanUseSiteConfigurationAcrossDifferentSystems and SystemSettings#CanUseSiteConfigurationAcrossDifferentSitesInSameCompany tests are failing with the following error:

LIFERAY_ERROR: Unable to install artifact: /opt/dev/projects/github/liferay-portal/bundles/osgi/configs/com.liferay.account.internal.configuration.AccountEntryGroupConfiguration.scoped_25b6dab6-6a8f-403c-b853-e4672a867dbd.config

## Proposed Solution
I believe the cause is in SystemSettings.testcase it is searching for the fileNamePattern com.liferay.account.internal.configuration.AccountEntryGroupConfiguration.scoped_*.config
but when I export the file is called com.liferay.account.internal.configuration.AccountEntryGroupConfiguration.scoped~0acbc9c4-7f4f-41c1-af5d-8732ea5445ec.config with ~ instead of _.

## Steps to Verify
Run the following tests:
ant -f build-test.xml run-selenium-test         
-Dtest.class=SystemSettings#CanUseSiteConfigurationAcrossDifferentSystems
-Dtest.analytics.cloud.url=http://localhost:8080         
-Ddefault.portal.url=http://localhost:8080         
-Dinstance.url=http://localhost:8080

ant -f build-test.xml run-selenium-test         
-Dtest.class=SystemSettings#CanUseSiteConfigurationAcrossDifferentSitesInSameCompany         
-Dtest.analytics.cloud.url=http://localhost:8080         
-Ddefault.portal.url=http://localhost:8080         
-Dinstance.url=http://localhost:8080

## Screenshots
