### PR TITLE
LPD-49366 Apply the inherited StyleBookEntry when the applied StyleBookEntry is incompatible with the Layout's theme

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutLookAndFeelDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutLookAndFeelDisplayContext.java
@@ -22,6 +22,7 @@ import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeCon
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalServiceUtil;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
@@ -252,7 +253,13 @@ public class LayoutLookAndFeelDisplayContext {
 
 		Layout selLayout = _layoutsAdminDisplayContext.getSelLayout();
 
-		if (selLayout.getStyleBookEntryId() > 0) {
+		if (FeatureFlagManagerUtil.isEnabled(
+				selLayout.getCompanyId(), "LPD-30204")) {
+
+			styleBookEntry = DefaultStyleBookEntryUtil.getDefaultStyleBookEntry(
+				selLayout);
+		}
+		else if (selLayout.getStyleBookEntryId() > 0) {
 			styleBookEntry = StyleBookEntryLocalServiceUtil.fetchStyleBookEntry(
 				selLayout.getStyleBookEntryId());
 		}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
@@ -683,7 +683,23 @@ public class ContentPageEditorDisplayContext {
 				() -> {
 					Layout layout = themeDisplay.getLayout();
 
-					return layout.getStyleBookEntryId();
+					if (!FeatureFlagManagerUtil.isEnabled(
+							layout.getCompanyId(), "LPD-30204")) {
+
+						return layout.getStyleBookEntryId();
+					}
+
+					if (layout.getStyleBookEntryId() > 0) {
+						StyleBookEntry defaultStyleBookEntry =
+							DefaultStyleBookEntryUtil.getDefaultStyleBookEntry(
+								layout);
+
+						if (defaultStyleBookEntry != null) {
+							return defaultStyleBookEntry.getStyleBookEntryId();
+						}
+					}
+
+					return "0";
 				}
 			).put(
 				"styleBooks", _getStyleBooks()

--- a/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/util/DefaultStyleBookEntryUtil.java
+++ b/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/util/DefaultStyleBookEntryUtil.java
@@ -17,6 +17,7 @@ import com.liferay.style.book.model.StyleBookEntry;
 import com.liferay.style.book.service.StyleBookEntryLocalServiceUtil;
 
 import java.util.Locale;
+import java.util.Objects;
 
 /**
  * @author Víctor Galán
@@ -53,11 +54,29 @@ public class DefaultStyleBookEntryUtil {
 				layout.getStyleBookEntryId());
 		}
 
-		if (styleBookEntry != null) {
-			return styleBookEntry;
+		if (styleBookEntry == null) {
+			return getDefaultMasterStyleBookEntry(layout);
 		}
 
-		return getDefaultMasterStyleBookEntry(layout);
+		if (FeatureFlagManagerUtil.isEnabled(
+				layout.getCompanyId(), "LPD-30204")) {
+
+			FrontendTokenDefinitionRegistry frontendTokenDefinitionRegistry =
+				_frontendTokenDefinitionRegistrySnapshot.get();
+
+			FrontendTokenDefinition frontendTokenDefinition =
+				frontendTokenDefinitionRegistry.getFrontendTokenDefinition(
+					layout);
+
+			if (!Objects.equals(
+					frontendTokenDefinition.getThemeId(),
+					styleBookEntry.getThemeId())) {
+
+				return getDefaultMasterStyleBookEntry(layout);
+			}
+		}
+
+		return styleBookEntry;
 	}
 
 	public static String getStyleBookEntryName(

--- a/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/util/test/DefaultStyleBookEntryUtilTest.java
+++ b/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/util/test/DefaultStyleBookEntryUtilTest.java
@@ -10,6 +10,7 @@ import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeCon
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalService;
 import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutSet;
@@ -52,7 +53,7 @@ public class DefaultStyleBookEntryUtilTest {
 
 		LayoutSet layoutSet = _group.getPublicLayoutSet();
 
-		layoutSet.setThemeId(_THEME_ID);
+		layoutSet.setThemeId(_CLASSIC_THEME_ID);
 
 		_layout = LayoutTestUtil.addTypeContentLayout(_group);
 	}
@@ -90,7 +91,7 @@ public class DefaultStyleBookEntryUtilTest {
 	}
 
 	@Test
-	public void testGetDefaultStyleBookEntry() throws Exception {
+	public void testGetDefaultStyleBookEntry1() throws Exception {
 		Layout masterLayoutBasedLayout = _getMasterLayoutBasedLayout();
 
 		Layout masterLayout = _layoutLocalService.getLayout(
@@ -121,6 +122,36 @@ public class DefaultStyleBookEntryUtilTest {
 		defaultStyleBookEntry =
 			DefaultStyleBookEntryUtil.getDefaultStyleBookEntry(
 				masterLayoutBasedLayout);
+
+		Assert.assertEquals(
+			styleBookEntry2.getStyleBookEntryId(),
+			defaultStyleBookEntry.getStyleBookEntryId());
+	}
+
+	@FeatureFlags("LPD-30204")
+	@Test
+	public void testGetDefaultStyleBookEntry2() throws Exception {
+		StyleBookEntry styleBookEntry1 = _addStyleBookEntry(false);
+
+		_layout.setStyleBookEntryId(styleBookEntry1.getStyleBookEntryId());
+
+		_layout = _layoutLocalService.updateLayout(_layout);
+
+		_layout = _layoutLocalService.updateLookAndFeel(
+			_group.getGroupId(), _layout.isPrivateLayout(),
+			_layout.getLayoutId(), _DIALECT_THEME_ID, "01", StringPool.BLANK);
+
+		Assert.assertNull(
+			DefaultStyleBookEntryUtil.getDefaultStyleBookEntry(_layout));
+
+		StyleBookEntry styleBookEntry2 =
+			_styleBookEntryLocalService.addStyleBookEntry(
+				RandomTestUtil.randomString(), TestPropsValues.getUserId(),
+				_group.getGroupId(), true, null, RandomTestUtil.randomString(),
+				null, _DIALECT_THEME_ID, null);
+
+		StyleBookEntry defaultStyleBookEntry =
+			DefaultStyleBookEntryUtil.getDefaultStyleBookEntry(_layout);
 
 		Assert.assertEquals(
 			styleBookEntry2.getStyleBookEntryId(),
@@ -244,7 +275,8 @@ public class DefaultStyleBookEntryUtilTest {
 		StyleBookEntry styleBookEntry =
 			_styleBookEntryLocalService.addStyleBookEntry(
 				RandomTestUtil.randomString(), TestPropsValues.getUserId(),
-				_group.getGroupId(), false, null, name, null, _THEME_ID, null);
+				_group.getGroupId(), false, null, name, null, _CLASSIC_THEME_ID,
+				null);
 
 		Assert.assertEquals(
 			name,
@@ -258,7 +290,7 @@ public class DefaultStyleBookEntryUtilTest {
 		return _styleBookEntryLocalService.addStyleBookEntry(
 			RandomTestUtil.randomString(), TestPropsValues.getUserId(),
 			_group.getGroupId(), defaultStyleBookEntry, null,
-			RandomTestUtil.randomString(), null, _THEME_ID, null);
+			RandomTestUtil.randomString(), null, _CLASSIC_THEME_ID, null);
 	}
 
 	private Layout _getMasterLayoutBasedLayout() throws Exception {
@@ -294,7 +326,9 @@ public class DefaultStyleBookEntryUtilTest {
 				masterLayoutBasedLayout, null, null));
 	}
 
-	private static final String _THEME_ID = RandomTestUtil.randomString();
+	private static final String _CLASSIC_THEME_ID = "classic_WAR_classictheme";
+
+	private static final String _DIALECT_THEME_ID = "dialect_WAR_dialecttheme";
 
 	private Group _group;
 	private Layout _layout;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-49366

# Goal

To return the inherited `StyleBookEntry` when the current Layout's `StyleBookEntry` is not based on the current theme.

# Approach

Update `DefaultStyleBookEntryUtil.getDefaultStyleBookEntry` to handle that case.

# How to test it

### Content page
1. Create a style book for the dialect theme (change the button color or something if you want);
2. Create a page and apply the dialect theme to it;
3. Select the new style book for that page;
4. Change the page theme to classic.
5. While in page editor, go to the design section > style books

**_Expected: the selected style book is "Styles from Classic"_**

### Content page based on a master page
1. Create a style book for the dialect theme (change the button color or something if you want);
2. Create a master page and apply the dialect theme to it;
3. Create a content page based on the master page;
4. Change the content page style book to the one you created;
5. Publish it;
6. Change the master page theme to classic and publish it;
8. Open the page editor for the content page;
9. While in page editor, go to the design section > style books

**_Expected: the selected style book is "Styles from Classic"_**

For additional scenarios see https://liferay.atlassian.net/wiki/spaces/PEDS/pages/3670442049/Style+Books+-+Draft#Definitions
