### PR TITLE
LPD-33300 Add upgrade process to account for the themeId in 'old' StyleBookEntry

### DIFF
--- a/modules/apps/style-book/style-book-service/bnd.bnd
+++ b/modules/apps/style-book/style-book-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Style Book Service
 Bundle-SymbolicName: com.liferay.style.book.service
 Bundle-Version: 2.0.55
-Liferay-Require-SchemaVersion: 1.6.0
+Liferay-Require-SchemaVersion: 1.7.0
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/internal/upgrade/registry/StyleBookServiceUpgradeStepRegistrator.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/internal/upgrade/registry/StyleBookServiceUpgradeStepRegistrator.java
@@ -5,6 +5,7 @@
 
 package com.liferay.style.book.internal.upgrade.registry;
 
+import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.upgrade.BaseExternalReferenceCodeUpgradeProcess;
 import com.liferay.portal.kernel.upgrade.CTModelUpgradeProcess;
 import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
@@ -13,8 +14,10 @@ import com.liferay.portal.kernel.upgrade.UpgradeProcessFactory;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 import com.liferay.style.book.internal.upgrade.v1_1_0.StyleBookEntryUpgradeProcess;
 import com.liferay.style.book.internal.upgrade.v1_2_0.StyleBookEntryVersionUpgradeProcess;
+import com.liferay.style.book.internal.upgrade.v1_7_0.StyleBookEntryThemeIdUpgradeProcess;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Jürgen Kappler
@@ -81,6 +84,13 @@ public class StyleBookServiceUpgradeStepRegistrator
 				"StyleBookEntry", "themeId VARCHAR(255) null"),
 			UpgradeProcessFactory.addColumns(
 				"StyleBookEntryVersion", "themeId VARCHAR(255) null"));
+
+		registry.register(
+			"1.6.0", "1.7.0",
+			new StyleBookEntryThemeIdUpgradeProcess(_groupLocalService));
 	}
+
+	@Reference
+	private GroupLocalService _groupLocalService;
 
 }

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/internal/upgrade/v1_7_0/StyleBookEntryThemeIdUpgradeProcess.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/internal/upgrade/v1_7_0/StyleBookEntryThemeIdUpgradeProcess.java
@@ -1,0 +1,63 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.style.book.internal.upgrade.v1_7_0;
+
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.LayoutSet;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+/**
+ * @author Thiago Buarque
+ */
+public class StyleBookEntryThemeIdUpgradeProcess extends UpgradeProcess {
+
+	public StyleBookEntryThemeIdUpgradeProcess(
+		GroupLocalService groupLocalService) {
+
+		_groupLocalService = groupLocalService;
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		try (PreparedStatement preparedStatement1 = connection.prepareStatement(
+				"select ctCollectionId, groupId, styleBookEntryId from " +
+					"StyleBookEntry");
+			PreparedStatement preparedStatement2 =
+				AutoBatchPreparedStatementUtil.autoBatch(
+					connection,
+					"update StyleBookEntry set themeId = ? where " +
+						"ctCollectionId = ? and styleBookEntryId = ?");
+			ResultSet resultSet = preparedStatement1.executeQuery()) {
+
+			while (resultSet.next()) {
+				Group group = _groupLocalService.getGroup(
+					resultSet.getLong("groupId"));
+
+				LayoutSet privateLayoutSet = group.getPrivateLayoutSet();
+
+				preparedStatement2.setString(1, privateLayoutSet.getThemeId());
+
+				preparedStatement2.setLong(
+					2, resultSet.getLong("ctCollectionId"));
+
+				preparedStatement2.setLong(
+					3, resultSet.getLong("styleBookEntryId"));
+
+				preparedStatement2.addBatch();
+			}
+
+			preparedStatement2.executeBatch();
+		}
+	}
+
+	private final GroupLocalService _groupLocalService;
+
+}

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/internal/upgrade/v1_7_0/StyleBookEntryThemeIdUpgradeProcess.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/internal/upgrade/v1_7_0/StyleBookEntryThemeIdUpgradeProcess.java
@@ -41,9 +41,9 @@ public class StyleBookEntryThemeIdUpgradeProcess extends UpgradeProcess {
 				Group group = _groupLocalService.getGroup(
 					resultSet.getLong("groupId"));
 
-				LayoutSet privateLayoutSet = group.getPrivateLayoutSet();
+				LayoutSet publicLayoutSet = group.getPublicLayoutSet();
 
-				preparedStatement2.setString(1, privateLayoutSet.getThemeId());
+				preparedStatement2.setString(1, publicLayoutSet.getThemeId());
 
 				preparedStatement2.setLong(
 					2, resultSet.getLong("ctCollectionId"));

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/impl/StyleBookEntryLocalServiceImpl.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/impl/StyleBookEntryLocalServiceImpl.java
@@ -14,11 +14,13 @@ import com.liferay.portal.kernel.dao.orm.WildcardMode;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.ModelHintsUtil;
 import com.liferay.portal.kernel.model.Repository;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.portletfilerepository.PortletFileRepositoryUtil;
 import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.service.LayoutSetLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -96,7 +98,16 @@ public class StyleBookEntryLocalServiceImpl
 		styleBookEntry.setFrontendTokensValues(frontendTokensValues);
 		styleBookEntry.setName(name);
 		styleBookEntry.setStyleBookEntryKey(styleBookEntryKey);
-		styleBookEntry.setThemeId(themeId);
+
+		if (FeatureFlagManagerUtil.isEnabled("LPD-30204")) {
+			styleBookEntry.setThemeId(themeId);
+		}
+		else {
+			LayoutSet publicLayoutSet = _layoutSetLocalService.getLayoutSet(
+				groupId, false);
+
+			styleBookEntry.setThemeId(publicLayoutSet.getThemeId());
+		}
 
 		return publishDraft(styleBookEntry);
 	}
@@ -591,6 +602,9 @@ public class StyleBookEntryLocalServiceImpl
 
 	@Reference
 	private Language _language;
+
+	@Reference
+	private LayoutSetLocalService _layoutSetLocalService;
 
 	@Reference
 	private UserLocalService _userLocalService;

--- a/modules/apps/style-book/style-book-test/build.gradle
+++ b/modules/apps/style-book/style-book-test/build.gradle
@@ -3,6 +3,8 @@ dependencies {
 	testIntegrationImplementation project(":apps:frontend-token:frontend-token-definition-api")
 	testIntegrationImplementation project(":apps:layout:layout-page-template-api")
 	testIntegrationImplementation project(":apps:layout:layout-test-util")
+	testIntegrationImplementation project(":apps:portal:portal-upgrade-test-util")
+	testIntegrationImplementation project(":apps:static:portal:portal-upgrade-api")
 	testIntegrationImplementation project(":apps:style-book:style-book-api")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/internal/upgrade/v1_7_0/test/StyleBookEntryThemeIdUpgradeProcessTest.java
+++ b/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/internal/upgrade/v1_7_0/test/StyleBookEntryThemeIdUpgradeProcessTest.java
@@ -17,6 +17,7 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
@@ -50,13 +51,14 @@ public class StyleBookEntryThemeIdUpgradeProcessTest {
 			_group, TestPropsValues.getUserId());
 	}
 
+	@FeatureFlags("LPD-30204")
 	@Test
 	public void testDoUpgrade() throws Exception {
 		StyleBookEntry styleBookEntry =
 			_styleBookEntryLocalService.addStyleBookEntry(
 				RandomTestUtil.randomString(), TestPropsValues.getUserId(),
 				_group.getGroupId(), false, null, RandomTestUtil.randomString(),
-				null, "", _serviceContext);
+				null, null, _serviceContext);
 
 		Assert.assertTrue(Validator.isNull(styleBookEntry.getThemeId()));
 

--- a/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/internal/upgrade/v1_7_0/test/StyleBookEntryThemeIdUpgradeProcessTest.java
+++ b/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/internal/upgrade/v1_7_0/test/StyleBookEntryThemeIdUpgradeProcessTest.java
@@ -1,0 +1,103 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.style.book.internal.upgrade.v1_7_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.dao.orm.EntityCacheUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.LayoutSet;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
+import com.liferay.style.book.model.StyleBookEntry;
+import com.liferay.style.book.service.StyleBookEntryLocalService;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Thiago Buarque
+ */
+@RunWith(Arquillian.class)
+public class StyleBookEntryThemeIdUpgradeProcessTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_serviceContext = ServiceContextTestUtil.getServiceContext(
+			_group, TestPropsValues.getUserId());
+	}
+
+	@Test
+	public void testDoUpgrade() throws Exception {
+		StyleBookEntry styleBookEntry =
+			_styleBookEntryLocalService.addStyleBookEntry(
+				RandomTestUtil.randomString(), TestPropsValues.getUserId(),
+				_group.getGroupId(), false, null, RandomTestUtil.randomString(),
+				null, "", _serviceContext);
+
+		Assert.assertTrue(Validator.isNull(styleBookEntry.getThemeId()));
+
+		_runUpgrade();
+
+		EntityCacheUtil.clearCache();
+
+		styleBookEntry = _styleBookEntryLocalService.fetchStyleBookEntry(
+			styleBookEntry.getStyleBookEntryId());
+
+		LayoutSet privateLayoutSet = _group.getPrivateLayoutSet();
+
+		Assert.assertEquals(
+			"classic_WAR_classictheme", privateLayoutSet.getThemeId());
+
+		Assert.assertEquals(
+			privateLayoutSet.getThemeId(), styleBookEntry.getThemeId());
+	}
+
+	private void _runUpgrade() throws Exception {
+		UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
+			_upgradeStepRegistrator, _CLASS_NAME);
+
+		upgradeProcess.upgrade();
+	}
+
+	private static final String _CLASS_NAME =
+		"com.liferay.style.book.internal.upgrade.v1_7_0." +
+			"StyleBookEntryThemeIdUpgradeProcess";
+
+	@Inject(
+		filter = "(&(component.name=com.liferay.style.book.internal.upgrade.registry.StyleBookServiceUpgradeStepRegistrator))"
+	)
+	private static UpgradeStepRegistrator _upgradeStepRegistrator;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	private ServiceContext _serviceContext;
+
+	@Inject
+	private StyleBookEntryLocalService _styleBookEntryLocalService;
+
+}

--- a/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/internal/upgrade/v1_7_0/test/StyleBookEntryThemeIdUpgradeProcessTest.java
+++ b/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/internal/upgrade/v1_7_0/test/StyleBookEntryThemeIdUpgradeProcessTest.java
@@ -67,13 +67,13 @@ public class StyleBookEntryThemeIdUpgradeProcessTest {
 		styleBookEntry = _styleBookEntryLocalService.fetchStyleBookEntry(
 			styleBookEntry.getStyleBookEntryId());
 
-		LayoutSet privateLayoutSet = _group.getPrivateLayoutSet();
+		LayoutSet publicLayoutSet = _group.getPublicLayoutSet();
 
 		Assert.assertEquals(
-			"classic_WAR_classictheme", privateLayoutSet.getThemeId());
+			"classic_WAR_classictheme", publicLayoutSet.getThemeId());
 
 		Assert.assertEquals(
-			privateLayoutSet.getThemeId(), styleBookEntry.getThemeId());
+			publicLayoutSet.getThemeId(), styleBookEntry.getThemeId());
 	}
 
 	private void _runUpgrade() throws Exception {

--- a/modules/apps/style-book/style-book-web-test/src/testIntegration/java/com/liferay/style/book/web/internal/portlet/action/test/ExportImportStyleBookEntriesMVCResourceCommandTest.java
+++ b/modules/apps/style-book/style-book-web-test/src/testIntegration/java/com/liferay/style/book/web/internal/portlet/action/test/ExportImportStyleBookEntriesMVCResourceCommandTest.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -116,6 +117,7 @@ public class ExportImportStyleBookEntriesMVCResourceCommandTest {
 				_targetGroup.getGroupId(), styleBookEntryKey2));
 	}
 
+	@FeatureFlags("LPD-30204")
 	@Test
 	public void testExportImportSingleStyleBookEntry() throws Exception {
 		String name = RandomTestUtil.randomString();


### PR DESCRIPTION
_Origina Message_

Ticket: https://liferay.atlassian.net/browse/LPD-33300
Related story: https://liferay.atlassian.net/browse/LPD-30355

# Problem
The changes introduced by https://liferay.atlassian.net/browse/LPD-30360 raised the need handle the upgrades from the old Style Books to the new ones.

# Approach

Add a new upgrade to the `StyleBookEntry` to update the `themeId` (which will currently be null) to the public page's `themeId` (the one in Site builder > Pages > Configuration)

# Test
Requirements: these changes are not deployed and the epic's feature flag is disabled

1. Create a style book;
2. Assert in the database that the `themeId` is `null` (the table name is `StyleBookEntry`);
3. Deploy these changes and wait for the upgrade to complete;
4. Assert in the database that the `themeId` is the same as the id of the theme for the public pages.

