### PR TITLE
LPD-52295 - Style books created in a site that has a themeCSS client extension which includes a frontendTokenDefinition assigned to the public pages should have the themeId of the themeCSS client extension.

### DIFF
--- a/modules/apps/style-book/style-book-service/build.gradle
+++ b/modules/apps/style-book/style-book-service/build.gradle
@@ -15,6 +15,7 @@ dependencies {
 	compileOnly project(":apps:document-library:document-library-api")
 	compileOnly project(":apps:export-import:export-import-api")
 	compileOnly project(":apps:frontend-css:frontend-css-variables-api")
+	compileOnly project(":apps:frontend-token:frontend-token-definition-api")
 	compileOnly project(":apps:portal:portal-aop-api")
 	compileOnly project(":apps:portal:portal-dao-orm-custom-sql-api")
 	compileOnly project(":apps:static:portal:portal-upgrade-api")

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/internal/upgrade/registry/StyleBookServiceUpgradeStepRegistrator.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/internal/upgrade/registry/StyleBookServiceUpgradeStepRegistrator.java
@@ -5,6 +5,7 @@
 
 package com.liferay.style.book.internal.upgrade.registry;
 
+import com.liferay.frontend.token.definition.FrontendTokenDefinitionRegistry;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.upgrade.BaseExternalReferenceCodeUpgradeProcess;
 import com.liferay.portal.kernel.upgrade.CTModelUpgradeProcess;
@@ -87,8 +88,12 @@ public class StyleBookServiceUpgradeStepRegistrator
 
 		registry.register(
 			"1.6.0", "1.7.0",
-			new StyleBookEntryThemeIdUpgradeProcess(_groupLocalService));
+			new StyleBookEntryThemeIdUpgradeProcess(
+				_frontendTokenDefinitionRegistry, _groupLocalService));
 	}
+
+	@Reference
+	private FrontendTokenDefinitionRegistry _frontendTokenDefinitionRegistry;
 
 	@Reference
 	private GroupLocalService _groupLocalService;

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/internal/upgrade/v1_7_0/StyleBookEntryThemeIdUpgradeProcess.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/internal/upgrade/v1_7_0/StyleBookEntryThemeIdUpgradeProcess.java
@@ -5,6 +5,8 @@
 
 package com.liferay.style.book.internal.upgrade.v1_7_0;
 
+import com.liferay.frontend.token.definition.FrontendTokenDefinition;
+import com.liferay.frontend.token.definition.FrontendTokenDefinitionRegistry;
 import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.LayoutSet;
@@ -20,8 +22,10 @@ import java.sql.ResultSet;
 public class StyleBookEntryThemeIdUpgradeProcess extends UpgradeProcess {
 
 	public StyleBookEntryThemeIdUpgradeProcess(
+		FrontendTokenDefinitionRegistry frontendTokenDefinitionRegistry,
 		GroupLocalService groupLocalService) {
 
+		_frontendTokenDefinitionRegistry = frontendTokenDefinitionRegistry;
 		_groupLocalService = groupLocalService;
 	}
 
@@ -43,7 +47,17 @@ public class StyleBookEntryThemeIdUpgradeProcess extends UpgradeProcess {
 
 				LayoutSet publicLayoutSet = group.getPublicLayoutSet();
 
-				preparedStatement2.setString(1, publicLayoutSet.getThemeId());
+				String themeId = publicLayoutSet.getThemeId();
+
+				FrontendTokenDefinition frontendTokenDefinition =
+					_frontendTokenDefinitionRegistry.getFrontendTokenDefinition(
+						publicLayoutSet);
+
+				if (frontendTokenDefinition != null) {
+					themeId = frontendTokenDefinition.getThemeId();
+				}
+
+				preparedStatement2.setString(1, themeId);
 
 				preparedStatement2.setLong(
 					2, resultSet.getLong("ctCollectionId"));
@@ -57,6 +71,8 @@ public class StyleBookEntryThemeIdUpgradeProcess extends UpgradeProcess {
 		}
 	}
 
+	private final FrontendTokenDefinitionRegistry
+		_frontendTokenDefinitionRegistry;
 	private final GroupLocalService _groupLocalService;
 
 }

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/impl/StyleBookEntryLocalServiceImpl.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/impl/StyleBookEntryLocalServiceImpl.java
@@ -6,6 +6,8 @@
 package com.liferay.style.book.service.impl;
 
 import com.liferay.document.library.kernel.service.DLAppLocalService;
+import com.liferay.frontend.token.definition.FrontendTokenDefinition;
+import com.liferay.frontend.token.definition.FrontendTokenDefinitionRegistry;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.aop.AopService;
@@ -106,7 +108,16 @@ public class StyleBookEntryLocalServiceImpl
 			LayoutSet publicLayoutSet = _layoutSetLocalService.getLayoutSet(
 				groupId, false);
 
-			styleBookEntry.setThemeId(publicLayoutSet.getThemeId());
+			FrontendTokenDefinition frontendTokenDefinition =
+				_frontendTokenDefinitionRegistry.getFrontendTokenDefinition(
+					publicLayoutSet);
+
+			if (frontendTokenDefinition != null) {
+				styleBookEntry.setThemeId(frontendTokenDefinition.getThemeId());
+			}
+			else {
+				styleBookEntry.setThemeId(publicLayoutSet.getThemeId());
+			}
 		}
 
 		return publishDraft(styleBookEntry);
@@ -599,6 +610,9 @@ public class StyleBookEntryLocalServiceImpl
 
 	@Reference
 	private DLAppLocalService _dlAppLocalService;
+
+	@Reference
+	private FrontendTokenDefinitionRegistry _frontendTokenDefinitionRegistry;
 
 	@Reference
 	private Language _language;

--- a/modules/apps/style-book/style-book-test/build.gradle
+++ b/modules/apps/style-book/style-book-test/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	testIntegrationImplementation project(":apps:change-tracking:change-tracking-test-util")
+	testIntegrationImplementation project(":apps:client-extension:client-extension-api")
 	testIntegrationImplementation project(":apps:frontend-token:frontend-token-definition-api")
 	testIntegrationImplementation project(":apps:layout:layout-page-template-api")
 	testIntegrationImplementation project(":apps:layout:layout-test-util")

--- a/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/service/test/StyleBookEntryLocalServiceTest.java
+++ b/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/service/test/StyleBookEntryLocalServiceTest.java
@@ -6,7 +6,13 @@
 package com.liferay.style.book.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.client.extension.constants.ClientExtensionEntryConstants;
+import com.liferay.client.extension.model.ClientExtensionEntry;
+import com.liferay.client.extension.service.ClientExtensionEntryLocalService;
+import com.liferay.client.extension.service.ClientExtensionEntryRelLocalService;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -15,13 +21,19 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.style.book.exception.DuplicateStyleBookEntryExternalReferenceCodeException;
 import com.liferay.style.book.model.StyleBookEntry;
 import com.liferay.style.book.service.StyleBookEntryLocalService;
+
+import java.util.Collections;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -81,6 +93,54 @@ public class StyleBookEntryLocalServiceTest {
 			null, RandomTestUtil.randomString(), _serviceContext);
 	}
 
+	@FeatureFlags(enable = false, value = "LPD-13311")
+	@Test
+	public void testAddStyleBookEntryWithFrontendTokensFromClientExtension()
+		throws Exception {
+
+		_clientExtensionEntry =
+			_clientExtensionEntryLocalService.addClientExtensionEntry(
+				RandomTestUtil.randomString(), TestPropsValues.getUserId(),
+				StringPool.BLANK,
+				Collections.singletonMap(
+					LocaleUtil.getDefault(), RandomTestUtil.randomString()),
+				StringPool.BLANK, StringPool.BLANK,
+				ClientExtensionEntryConstants.TYPE_THEME_CSS,
+				UnicodePropertiesBuilder.create(
+					true
+				).put(
+					"clayRTLURL", _URL_CLAY_RTL_CSS
+				).put(
+					"clayURL", _URL_CLAY_CSS
+				).put(
+					"frontendTokenDefinitionJSON", "{}"
+				).put(
+					"mainRTLURL", _URL_MAIN_RTL_CSS
+				).put(
+					"mainURL", _URL_MAIN_CSS
+				).buildString());
+
+		LayoutSet publicLayoutSet = _group.getPublicLayoutSet();
+
+		_clientExtensionEntryRelLocalService.addClientExtensionEntryRel(
+			TestPropsValues.getUserId(), _group.getGroupId(),
+			_portal.getClassNameId(LayoutSet.class),
+			publicLayoutSet.getLayoutSetId(),
+			_clientExtensionEntry.getExternalReferenceCode(),
+			ClientExtensionEntryConstants.TYPE_THEME_CSS, StringPool.BLANK,
+			_serviceContext);
+
+		StyleBookEntry styleBookEntry =
+			_styleBookEntryLocalService.addStyleBookEntry(
+				RandomTestUtil.randomString(), TestPropsValues.getUserId(),
+				_group.getGroupId(), false, null, RandomTestUtil.randomString(),
+				null, null, _serviceContext);
+
+		Assert.assertEquals(
+			_clientExtensionEntry.getExternalReferenceCode(),
+			styleBookEntry.getThemeId());
+	}
+
 	@Test
 	public void testDeleteGroup() throws Exception {
 		StyleBookEntry styleBookEntry =
@@ -121,11 +181,35 @@ public class StyleBookEntryLocalServiceTest {
 				styleBookEntry.getStyleBookEntryId()));
 	}
 
+	private static final String _URL_CLAY_CSS =
+		"http://" + RandomTestUtil.randomString() + ".com/styles.css";
+
+	private static final String _URL_CLAY_RTL_CSS =
+		"http://" + RandomTestUtil.randomString() + ".com/styles_rtl.css";
+
+	private static final String _URL_MAIN_CSS =
+		"http://" + RandomTestUtil.randomString() + ".com/main.css";
+
+	private static final String _URL_MAIN_RTL_CSS =
+		"http://" + RandomTestUtil.randomString() + ".com/main_rtl.css";
+
+	private ClientExtensionEntry _clientExtensionEntry;
+
+	@Inject
+	private ClientExtensionEntryLocalService _clientExtensionEntryLocalService;
+
+	@Inject
+	private ClientExtensionEntryRelLocalService
+		_clientExtensionEntryRelLocalService;
+
 	@DeleteAfterTestRun
 	private Group _group;
 
 	@Inject
 	private GroupLocalService _groupLocalService;
+
+	@Inject
+	private Portal _portal;
 
 	private ServiceContext _serviceContext;
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-52295

When upgrading style books we need to set the themeId based on the theme or themeCSS applied to public pages. If no frontend token definition is available, then we should default to the theme assigned to public pages.

This should be applied to setting a themeId when creating a style book when the feature flag is disabled too.