### PR TITLE
LPD-52557  fix - check themeDisplay is not null before get its data for fetching segments experience

### DIFF
--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/manager/SegmentsExperienceManager.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/manager/SegmentsExperienceManager.java
@@ -30,16 +30,22 @@ public class SegmentsExperienceManager {
 	}
 
 	public long getSegmentsExperienceId(HttpServletRequest httpServletRequest) {
-		long segmentsExperienceId = ParamUtil.getLong(
-			PortalUtil.getOriginalServletRequest(httpServletRequest),
-			"segmentsExperienceId", -1);
-
 		PermissionChecker permissionChecker =
 			PermissionThreadLocal.getPermissionChecker();
 
 		ThemeDisplay themeDisplay =
 			(ThemeDisplay)httpServletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY);
+
+		if ((themeDisplay == null) || (permissionChecker == null)) {
+			return _segmentsExperienceLocalService.
+				fetchDefaultSegmentsExperienceId(
+					ParamUtil.getLong(httpServletRequest, "plid"));
+		}
+
+		long segmentsExperienceId = ParamUtil.getLong(
+			PortalUtil.getOriginalServletRequest(httpServletRequest),
+			"segmentsExperienceId", -1);
 
 		if ((segmentsExperienceId != -1) &&
 			permissionChecker.isGroupAdmin(themeDisplay.getScopeGroupId())) {
@@ -55,13 +61,8 @@ public class SegmentsExperienceManager {
 			return segmentsExperienceIds[0];
 		}
 
-		if (themeDisplay != null) {
-			return _segmentsExperienceLocalService.
-				fetchDefaultSegmentsExperienceId(themeDisplay.getPlid());
-		}
-
 		return _segmentsExperienceLocalService.fetchDefaultSegmentsExperienceId(
-			ParamUtil.getLong(httpServletRequest, "plid"));
+			themeDisplay.getPlid());
 	}
 
 	private final SegmentsExperienceLocalService

--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/manager/SegmentsExperienceManager.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/manager/SegmentsExperienceManager.java
@@ -30,18 +30,18 @@ public class SegmentsExperienceManager {
 	}
 
 	public long getSegmentsExperienceId(HttpServletRequest httpServletRequest) {
-		PermissionChecker permissionChecker =
-			PermissionThreadLocal.getPermissionChecker();
-
 		ThemeDisplay themeDisplay =
 			(ThemeDisplay)httpServletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY);
 
-		if ((themeDisplay == null) || (permissionChecker == null)) {
+		if (themeDisplay == null) {
 			return _segmentsExperienceLocalService.
 				fetchDefaultSegmentsExperienceId(
 					ParamUtil.getLong(httpServletRequest, "plid"));
 		}
+
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
 
 		long segmentsExperienceId = ParamUtil.getLong(
 			PortalUtil.getOriginalServletRequest(httpServletRequest),

--- a/modules/apps/segments/segments-api/src/test/java/com/liferay/segments/manager/SegmentsExperienceManagerTest.java
+++ b/modules/apps/segments/segments-api/src/test/java/com/liferay/segments/manager/SegmentsExperienceManagerTest.java
@@ -1,0 +1,62 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.segments.manager;
+
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.segments.service.SegmentsExperienceLocalService;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * @author Anderson Luiz
+ */
+public class SegmentsExperienceManagerTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		MockitoAnnotations.initMocks(this);
+	}
+
+	@Test
+	public void testGetSegmentsExperienceId() {
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setAttribute(WebKeys.THEME_DISPLAY, null);
+
+		_segmentsExperienceManager.getSegmentsExperienceId(
+			mockHttpServletRequest);
+
+		Mockito.verify(
+			_segmentsExperienceLocalService
+		).fetchDefaultSegmentsExperienceId(
+			Mockito.anyLong()
+		);
+	}
+
+	@Mock
+	private SegmentsExperienceLocalService _segmentsExperienceLocalService;
+
+	@InjectMocks
+	private SegmentsExperienceManager _segmentsExperienceManager;
+
+}


### PR DESCRIPTION
During https://liferay.atlassian.net/browse/LPP-58245 scenario reproduction, it seems a nullpoint when trying to get segments experience id is causing the bug, since themeDisplay was null in this moment. So I rearranged the flow to check if themeDisplay is not null before continues.