### PR TITLE
LPD-52966 Failed upgrade process v1_7_0.StyleBookEntryThemeIdUpgradeProcess

### DIFF
--- a/modules/apps/style-book/style-book-service/bnd.bnd
+++ b/modules/apps/style-book/style-book-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Style Book Service
 Bundle-SymbolicName: com.liferay.style.book.service
 Bundle-Version: 2.0.56
-Liferay-Require-SchemaVersion: 1.7.0
+Liferay-Require-SchemaVersion: 1.8.0
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/internal/upgrade/registry/StyleBookServiceUpgradeStepRegistrator.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/internal/upgrade/registry/StyleBookServiceUpgradeStepRegistrator.java
@@ -16,6 +16,8 @@ import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 import com.liferay.style.book.internal.upgrade.v1_1_0.StyleBookEntryUpgradeProcess;
 import com.liferay.style.book.internal.upgrade.v1_2_0.StyleBookEntryVersionUpgradeProcess;
 import com.liferay.style.book.internal.upgrade.v1_7_0.StyleBookEntryThemeIdUpgradeProcess;
+import com.liferay.style.book.internal.upgrade.v1_8_0.StyleBookEntryVersionThemeIdUpgradeProcess;
+import com.liferay.style.book.service.StyleBookEntryLocalService;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -90,6 +92,11 @@ public class StyleBookServiceUpgradeStepRegistrator
 			"1.6.0", "1.7.0",
 			new StyleBookEntryThemeIdUpgradeProcess(
 				_frontendTokenDefinitionRegistry, _groupLocalService));
+
+		registry.register(
+			"1.7.0", "1.8.0",
+			new StyleBookEntryVersionThemeIdUpgradeProcess(
+				_groupLocalService, _styleBookEntryLocalService));
 	}
 
 	@Reference
@@ -97,5 +104,8 @@ public class StyleBookServiceUpgradeStepRegistrator
 
 	@Reference
 	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private StyleBookEntryLocalService _styleBookEntryLocalService;
 
 }

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/internal/upgrade/v1_7_0/StyleBookEntryThemeIdUpgradeProcess.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/internal/upgrade/v1_7_0/StyleBookEntryThemeIdUpgradeProcess.java
@@ -7,7 +7,10 @@ package com.liferay.style.book.internal.upgrade.v1_7_0;
 
 import com.liferay.frontend.token.definition.FrontendTokenDefinition;
 import com.liferay.frontend.token.definition.FrontendTokenDefinitionRegistry;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.service.GroupLocalService;
@@ -39,11 +42,42 @@ public class StyleBookEntryThemeIdUpgradeProcess extends UpgradeProcess {
 					connection,
 					"update StyleBookEntry set themeId = ? where " +
 						"ctCollectionId = ? and styleBookEntryId = ?");
+			PreparedStatement preparedStatement3 =
+				AutoBatchPreparedStatementUtil.autoBatch(
+					connection,
+					"delete from StyleBookEntry where styleBookEntryId = ?");
+			PreparedStatement preparedStatement4 =
+				AutoBatchPreparedStatementUtil.autoBatch(
+					connection,
+					"delete from StyleBookEntryVersion where " +
+						"styleBookEntryId = ?");
 			ResultSet resultSet = preparedStatement1.executeQuery()) {
 
 			while (resultSet.next()) {
-				Group group = _groupLocalService.getGroup(
-					resultSet.getLong("groupId"));
+				long groupId = resultSet.getLong("groupId");
+				long styleBookEntryId = resultSet.getLong("styleBookEntryId");
+
+				Group group = _groupLocalService.fetchGroup(groupId);
+
+				if (group == null) {
+					if (_log.isWarnEnabled()) {
+						_log.warn(
+							StringBundler.concat(
+								"Unable to find group with id ", groupId,
+								". Removing orphaned style book entry with id ",
+								styleBookEntryId, "."));
+					}
+
+					preparedStatement3.setLong(1, styleBookEntryId);
+
+					preparedStatement3.addBatch();
+
+					preparedStatement4.setLong(1, styleBookEntryId);
+
+					preparedStatement4.addBatch();
+
+					continue;
+				}
 
 				LayoutSet publicLayoutSet = group.getPublicLayoutSet();
 
@@ -61,15 +95,19 @@ public class StyleBookEntryThemeIdUpgradeProcess extends UpgradeProcess {
 
 				preparedStatement2.setLong(
 					2, resultSet.getLong("ctCollectionId"));
-				preparedStatement2.setLong(
-					3, resultSet.getLong("styleBookEntryId"));
+				preparedStatement2.setLong(3, styleBookEntryId);
 
 				preparedStatement2.addBatch();
 			}
 
 			preparedStatement2.executeBatch();
+			preparedStatement3.executeBatch();
+			preparedStatement4.executeBatch();
 		}
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		StyleBookEntryThemeIdUpgradeProcess.class);
 
 	private final FrontendTokenDefinitionRegistry
 		_frontendTokenDefinitionRegistry;

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/internal/upgrade/v1_8_0/StyleBookEntryVersionThemeIdUpgradeProcess.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/internal/upgrade/v1_8_0/StyleBookEntryVersionThemeIdUpgradeProcess.java
@@ -1,0 +1,106 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.style.book.internal.upgrade.v1_8_0;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.style.book.model.StyleBookEntry;
+import com.liferay.style.book.service.StyleBookEntryLocalService;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+/**
+ * @author Thiago Buarque
+ */
+public class StyleBookEntryVersionThemeIdUpgradeProcess extends UpgradeProcess {
+
+	public StyleBookEntryVersionThemeIdUpgradeProcess(
+		GroupLocalService groupLocalService,
+		StyleBookEntryLocalService styleBookEntryLocalService) {
+
+		_groupLocalService = groupLocalService;
+		_styleBookEntryLocalService = styleBookEntryLocalService;
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		try (PreparedStatement preparedStatement1 = connection.prepareStatement(
+				"select groupId, ctCollectionId, styleBookEntryId, themeId " +
+					"from StyleBookEntryVersion");
+			PreparedStatement preparedStatement2 =
+				AutoBatchPreparedStatementUtil.autoBatch(
+					connection,
+					"update StyleBookEntryVersion set themeId = ? where " +
+						"ctCollectionId = ? and styleBookEntryId = ?");
+			PreparedStatement preparedStatement3 =
+				AutoBatchPreparedStatementUtil.autoBatch(
+					connection,
+					"delete from StyleBookEntryVersion where " +
+						"styleBookEntryId = ?");
+			PreparedStatement preparedStatement4 =
+				AutoBatchPreparedStatementUtil.autoBatch(
+					connection,
+					"delete from StyleBookEntry where styleBookEntryId = ?");
+			ResultSet resultSet = preparedStatement1.executeQuery()) {
+
+			while (resultSet.next()) {
+				long groupId = resultSet.getLong("groupId");
+				long styleBookEntryId = resultSet.getLong("styleBookEntryId");
+
+				Group group = _groupLocalService.fetchGroup(groupId);
+
+				if (group == null) {
+					if (_log.isWarnEnabled()) {
+						_log.warn(
+							StringBundler.concat(
+								"Unable to find group with id ", groupId,
+								". Removing orphaned style book entry version ",
+								"with id ", styleBookEntryId, "."));
+					}
+
+					preparedStatement3.setLong(1, styleBookEntryId);
+
+					preparedStatement3.addBatch();
+
+					preparedStatement4.setLong(1, styleBookEntryId);
+
+					preparedStatement4.addBatch();
+
+					continue;
+				}
+
+				StyleBookEntry styleBookEntry =
+					_styleBookEntryLocalService.fetchStyleBookEntry(
+						styleBookEntryId);
+
+				preparedStatement2.setString(1, styleBookEntry.getThemeId());
+
+				preparedStatement2.setLong(
+					2, resultSet.getLong("ctCollectionId"));
+				preparedStatement2.setLong(3, styleBookEntryId);
+
+				preparedStatement2.addBatch();
+			}
+
+			preparedStatement2.executeBatch();
+			preparedStatement3.executeBatch();
+			preparedStatement4.executeBatch();
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		StyleBookEntryVersionThemeIdUpgradeProcess.class);
+
+	private final GroupLocalService _groupLocalService;
+	private final StyleBookEntryLocalService _styleBookEntryLocalService;
+
+}

--- a/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/internal/upgrade/v1_7_0/test/StyleBookEntryThemeIdUpgradeProcessTest.java
+++ b/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/internal/upgrade/v1_7_0/test/StyleBookEntryThemeIdUpgradeProcessTest.java
@@ -6,6 +6,7 @@
 package com.liferay.style.book.internal.upgrade.v1_7_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.dao.orm.EntityCacheUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.LayoutSet;
@@ -17,6 +18,9 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LogEntry;
+import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -24,6 +28,8 @@ import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
 import com.liferay.style.book.model.StyleBookEntry;
 import com.liferay.style.book.service.StyleBookEntryLocalService;
+
+import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -60,9 +66,38 @@ public class StyleBookEntryThemeIdUpgradeProcessTest {
 				_group.getGroupId(), false, null, RandomTestUtil.randomString(),
 				null, null, _serviceContext);
 
-		Assert.assertTrue(Validator.isNull(styleBookEntry.getThemeId()));
+		long groupId = RandomTestUtil.randomLong();
 
-		_runUpgrade();
+		StyleBookEntry orphanedStyleBookEntry =
+			_styleBookEntryLocalService.addStyleBookEntry(
+				RandomTestUtil.randomString(), TestPropsValues.getUserId(),
+				groupId, false, null, RandomTestUtil.randomString(), null, null,
+				_serviceContext);
+
+		Assert.assertTrue(Validator.isNull(styleBookEntry.getThemeId()));
+		Assert.assertTrue(
+			Validator.isNull(orphanedStyleBookEntry.getThemeId()));
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.style.book.internal.upgrade.v1_7_0." +
+					"StyleBookEntryThemeIdUpgradeProcess",
+				LoggerTestUtil.WARN)) {
+
+			_runUpgrade();
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertEquals(logEntries.toString(), 1, logEntries.size());
+
+			LogEntry logEntry = logEntries.get(0);
+
+			Assert.assertEquals(
+				StringBundler.concat(
+					"Unable to find group with id ", groupId,
+					". Removing orphaned style book entry with id ",
+					orphanedStyleBookEntry.getStyleBookEntryId(), "."),
+				logEntry.getMessage());
+		}
 
 		EntityCacheUtil.clearCache();
 
@@ -76,6 +111,10 @@ public class StyleBookEntryThemeIdUpgradeProcessTest {
 
 		Assert.assertEquals(
 			publicLayoutSet.getThemeId(), styleBookEntry.getThemeId());
+
+		Assert.assertNull(
+			_styleBookEntryLocalService.fetchStyleBookEntry(
+				orphanedStyleBookEntry.getStyleBookEntryId()));
 	}
 
 	private void _runUpgrade() throws Exception {

--- a/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/internal/upgrade/v1_8_0/test/StyleBookEntryVersionThemeIdUpgradeProcessTest.java
+++ b/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/internal/upgrade/v1_8_0/test/StyleBookEntryVersionThemeIdUpgradeProcessTest.java
@@ -1,0 +1,148 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.style.book.internal.upgrade.v1_8_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LogEntry;
+import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
+import com.liferay.style.book.model.StyleBookEntry;
+import com.liferay.style.book.service.StyleBookEntryLocalService;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Thiago Buarque
+ */
+@RunWith(Arquillian.class)
+public class StyleBookEntryVersionThemeIdUpgradeProcessTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_serviceContext = ServiceContextTestUtil.getServiceContext(
+			_group, TestPropsValues.getUserId());
+	}
+
+	@FeatureFlags("LPD-30204")
+	@Test
+	public void testUpgrade() throws Exception {
+		String themeId = "classic_WAR_classictheme";
+
+		StyleBookEntry styleBookEntry =
+			_styleBookEntryLocalService.addStyleBookEntry(
+				RandomTestUtil.randomString(), TestPropsValues.getUserId(),
+				_group.getGroupId(), false, null, RandomTestUtil.randomString(),
+				null, themeId, _serviceContext);
+
+		long groupId = RandomTestUtil.randomLong();
+
+		StyleBookEntry orphanedStyleBookEntry =
+			_styleBookEntryLocalService.addStyleBookEntry(
+				RandomTestUtil.randomString(), TestPropsValues.getUserId(),
+				groupId, false, null, RandomTestUtil.randomString(), null,
+				themeId, _serviceContext);
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.style.book.internal.upgrade.v1_8_0." +
+					"StyleBookEntryVersionThemeIdUpgradeProcess",
+				LoggerTestUtil.WARN)) {
+
+			_runUpgrade();
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertEquals(logEntries.toString(), 1, logEntries.size());
+
+			LogEntry logEntry = logEntries.get(0);
+
+			Assert.assertEquals(
+				StringBundler.concat(
+					"Unable to find group with id ", groupId,
+					". Removing orphaned style book entry version with id ",
+					orphanedStyleBookEntry.getStyleBookEntryId(), "."),
+				logEntry.getMessage());
+		}
+
+		try (Connection connection = DataAccess.getConnection();
+			 PreparedStatement preparedStatement = connection.prepareStatement(
+				 StringBundler.concat(
+					 "select * from StyleBookEntryVersion where ",
+					 "styleBookEntryId = ",
+					 styleBookEntry.getStyleBookEntryId(), " or ",
+					 "styleBookEntryId = ",
+					 orphanedStyleBookEntry.getStyleBookEntryId()));
+
+			 ResultSet resultSet = preparedStatement.executeQuery()) {
+
+			Assert.assertTrue(resultSet.next());
+
+			Assert.assertEquals(
+				"classic_WAR_classictheme", resultSet.getString("themeId"));
+			Assert.assertEquals(
+				styleBookEntry.getUuid(), resultSet.getString("uuid_"));
+
+			Assert.assertFalse(resultSet.next());
+		}
+	}
+
+	private void _runUpgrade() throws Exception {
+		UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
+			_upgradeStepRegistrator, _CLASS_NAME);
+
+		upgradeProcess.upgrade();
+	}
+
+	private static final String _CLASS_NAME =
+		"com.liferay.style.book.internal.upgrade.v1_8_0." +
+			"StyleBookEntryVersionThemeIdUpgradeProcess";
+
+	@Inject(
+		filter = "(&(component.name=com.liferay.style.book.internal.upgrade.registry.StyleBookServiceUpgradeStepRegistrator))"
+	)
+	private static UpgradeStepRegistrator _upgradeStepRegistrator;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	private ServiceContext _serviceContext;
+
+	@Inject
+	private StyleBookEntryLocalService _styleBookEntryLocalService;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-52966?

# Issues

## Not handling missing groups when upgrading `StyleBookEntry`
We recently received a PR that highlighted an issue with the style book entry. After deleting a group, the related style book entries were not removed. That was fixed in https://github.com/liferay-platform-experience/liferay-portal/pull/1087.

Unfortunately, I forgot to consider that on the `StyleBookEntryThemeIdUpgradeProcess`, which causes an error when there is an orphaned style book entry.

## Not upgrading `StyleBookEntryVersion`

We missed adding an upgrade for the `StyleBookEntryVersion` along with `StyleBookEntryThemeIdUpgradeProcess`

# Solution

1. Remove orphaned style book entries during the upgrade.
2. Add a similar upgrade to style book entry version.