### PR TITLE
LPD-53379 The frontend token definition used on the style book editor page is the one in the public pages configuration rather than the one which the style book was based on

### DIFF
--- a/modules/apps/frontend-token/frontend-token-definition-impl/src/main/java/com/liferay/frontend/token/definition/internal/frontend/css/variables/DefaultThemeScopedCSSVariablesProvider.java
+++ b/modules/apps/frontend-token/frontend-token-definition-impl/src/main/java/com/liferay/frontend/token/definition/internal/frontend/css/variables/DefaultThemeScopedCSSVariablesProvider.java
@@ -15,6 +15,7 @@ import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.service.LayoutSetLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 
@@ -51,9 +52,21 @@ public class DefaultThemeScopedCSSVariablesProvider
 		if (FeatureFlagManagerUtil.isEnabled(
 				themeDisplay.getCompanyId(), "LPD-30204")) {
 
-			frontendTokenDefinition =
-				_frontendTokenDefinitionRegistry.getFrontendTokenDefinition(
-					themeDisplay.getLayout());
+			if (GetterUtil.getBoolean(
+					httpServletRequest.getParameter(
+						"styleBookEntryFragmentCollectionPreview"))) {
+
+				frontendTokenDefinition =
+					_frontendTokenDefinitionRegistry.getFrontendTokenDefinition(
+						themeDisplay.getCompanyId(),
+						GetterUtil.getString(
+							httpServletRequest.getParameter("themeId")));
+			}
+			else {
+				frontendTokenDefinition =
+					_frontendTokenDefinitionRegistry.getFrontendTokenDefinition(
+						themeDisplay.getLayout());
+			}
 		}
 		else {
 			Group group = themeDisplay.getScopeGroup();

--- a/modules/apps/frontend-token/frontend-token-definition-impl/src/main/java/com/liferay/frontend/token/definition/internal/frontend/css/variables/DefaultThemeScopedCSSVariablesProvider.java
+++ b/modules/apps/frontend-token/frontend-token-definition-impl/src/main/java/com/liferay/frontend/token/definition/internal/frontend/css/variables/DefaultThemeScopedCSSVariablesProvider.java
@@ -52,15 +52,13 @@ public class DefaultThemeScopedCSSVariablesProvider
 		if (FeatureFlagManagerUtil.isEnabled(
 				themeDisplay.getCompanyId(), "LPD-30204")) {
 
-			if (GetterUtil.getBoolean(
-					httpServletRequest.getParameter(
-						"styleBookEntryFragmentCollectionPreview"))) {
+			String styleBookEntryThemeId = GetterUtil.getString(
+				httpServletRequest.getParameter("styleBookEntryThemeId"));
 
+			if (Validator.isNotNull(styleBookEntryThemeId)) {
 				frontendTokenDefinition =
 					_frontendTokenDefinitionRegistry.getFrontendTokenDefinition(
-						themeDisplay.getCompanyId(),
-						GetterUtil.getString(
-							httpServletRequest.getParameter("themeId")));
+						themeDisplay.getCompanyId(), styleBookEntryThemeId);
 			}
 			else {
 				frontendTokenDefinition =

--- a/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/display/context/EditStyleBookEntryDisplayContext.java
+++ b/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/display/context/EditStyleBookEntryDisplayContext.java
@@ -283,13 +283,11 @@ public class EditStyleBookEntryDisplayContext {
 	private String _getFragmentCollectionPreviewURL(
 		String fragmentCollectionKey, long groupId) {
 
-		String url = _getFragmentCollectionPreviewURL();
-
 		String portletNamespace = PortalUtil.getPortletNamespace(
 			StyleBookPortletKeys.STYLE_BOOK);
 
-		url = HttpComponentsUtil.addParameter(
-			url, portletNamespace + "groupId", groupId);
+		String url = HttpComponentsUtil.addParameter(
+			_getFragmentCollectionPreviewURL(), portletNamespace + "groupId", groupId);
 
 		return HttpComponentsUtil.addParameter(
 			url, portletNamespace + "fragmentCollectionKey",

--- a/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/display/context/EditStyleBookEntryDisplayContext.java
+++ b/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/display/context/EditStyleBookEntryDisplayContext.java
@@ -104,12 +104,7 @@ public class EditStyleBookEntryDisplayContext {
 
 	public Map<String, Object> getStyleBookEditorData() throws Exception {
 		return HashMapBuilder.<String, Object>put(
-			"fragmentCollectionPreviewURL",
-			ResourceURLBuilder.createResourceURL(
-				_renderResponse
-			).setResourceID(
-				"/style_book/preview_fragment_collection"
-			).buildString()
+			"fragmentCollectionPreviewURL", _getFragmentCollectionPreviewURL()
 		).put(
 			"frontendTokenDefinition", _getFrontendTokenDefinitionJSONObject()
 		).put(
@@ -246,7 +241,7 @@ public class EditStyleBookEntryDisplayContext {
 								"name", fragmentCollectionContributor.getName()
 							).put(
 								"url",
-								_getPreviewFragmentCollectionURL(
+								_getFragmentCollectionPreviewURL(
 									fragmentCollectionContributor.
 										getFragmentCollectionKey(),
 									CompanyConstants.SYSTEM)
@@ -262,7 +257,7 @@ public class EditStyleBookEntryDisplayContext {
 								"name", fragmentCollection.getName()
 							).put(
 								"url",
-								_getPreviewFragmentCollectionURL(
+								_getFragmentCollectionPreviewURL(
 									fragmentCollection.
 										getFragmentCollectionKey(),
 									fragmentCollection.getGroupId())
@@ -273,6 +268,34 @@ public class EditStyleBookEntryDisplayContext {
 		).put(
 			"totalLayouts", fragmentCollectionsCount
 		);
+	}
+
+	private String _getFragmentCollectionPreviewURL() {
+		return ResourceURLBuilder.createResourceURL(
+			_renderResponse
+		).setParameter(
+			"styleBookEntryFragmentCollectionPreview", true
+		).setParameter(
+			"themeId", _styleBookEntry.getThemeId()
+		).setResourceID(
+			"/style_book/preview_fragment_collection"
+		).buildString();
+	}
+
+	private String _getFragmentCollectionPreviewURL(
+		String fragmentCollectionKey, long groupId) {
+
+		String url = _getFragmentCollectionPreviewURL();
+
+		String portletNamespace = PortalUtil.getPortletNamespace(
+			StyleBookPortletKeys.STYLE_BOOK);
+
+		url = HttpComponentsUtil.addParameter(
+			url, portletNamespace + "groupId", groupId);
+
+		return HttpComponentsUtil.addParameter(
+			url, portletNamespace + "fragmentCollectionKey",
+			fragmentCollectionKey);
 	}
 
 	private int _getFragmentCollectionsCount() {
@@ -439,26 +462,6 @@ public class EditStyleBookEntryDisplayContext {
 		).put(
 			"totalLayouts", total
 		);
-	}
-
-	private String _getPreviewFragmentCollectionURL(
-		String fragmentCollectionKey, long groupId) {
-
-		String url = ResourceURLBuilder.createResourceURL(
-			_renderResponse
-		).setResourceID(
-			"/style_book/preview_fragment_collection"
-		).buildString();
-
-		String portletNamespace = PortalUtil.getPortletNamespace(
-			StyleBookPortletKeys.STYLE_BOOK);
-
-		url = HttpComponentsUtil.addParameter(
-			url, portletNamespace + "groupId", groupId);
-
-		return HttpComponentsUtil.addParameter(
-			url, portletNamespace + "fragmentCollectionKey",
-			fragmentCollectionKey);
 	}
 
 	private long _getPreviewItemsGroupId() {

--- a/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/display/context/EditStyleBookEntryDisplayContext.java
+++ b/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/display/context/EditStyleBookEntryDisplayContext.java
@@ -287,7 +287,8 @@ public class EditStyleBookEntryDisplayContext {
 			StyleBookPortletKeys.STYLE_BOOK);
 
 		String url = HttpComponentsUtil.addParameter(
-			_getFragmentCollectionPreviewURL(), portletNamespace + "groupId", groupId);
+			_getFragmentCollectionPreviewURL(), portletNamespace + "groupId",
+			groupId);
 
 		return HttpComponentsUtil.addParameter(
 			url, portletNamespace + "fragmentCollectionKey",

--- a/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/display/context/EditStyleBookEntryDisplayContext.java
+++ b/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/display/context/EditStyleBookEntryDisplayContext.java
@@ -274,9 +274,7 @@ public class EditStyleBookEntryDisplayContext {
 		return ResourceURLBuilder.createResourceURL(
 			_renderResponse
 		).setParameter(
-			"styleBookEntryFragmentCollectionPreview", true
-		).setParameter(
-			"themeId", _styleBookEntry.getThemeId()
+			"styleBookEntryThemeId", _styleBookEntry.getThemeId()
 		).setResourceID(
 			"/style_book/preview_fragment_collection"
 		).buildString();

--- a/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/portlet/action/PreviewFragmentCollectionMVCResourceCommand.java
+++ b/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/portlet/action/PreviewFragmentCollectionMVCResourceCommand.java
@@ -5,22 +5,33 @@
 
 package com.liferay.style.book.web.internal.portlet.action;
 
+import com.liferay.client.extension.type.ThemeCSSCET;
+import com.liferay.client.extension.type.manager.CETManager;
 import com.liferay.fragment.contributor.FragmentCollectionContributorRegistry;
+import com.liferay.frontend.token.definition.FrontendTokenDefinition;
+import com.liferay.frontend.token.definition.FrontendTokenDefinitionRegistry;
+import com.liferay.frontend.token.definition.constants.FrontendTokenDefinitionConstants;
 import com.liferay.petra.io.unsync.UnsyncStringWriter;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.model.LayoutSet;
+import com.liferay.portal.kernel.model.Theme;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCResourceCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
 import com.liferay.portal.kernel.service.LayoutSetLocalService;
+import com.liferay.portal.kernel.service.ThemeLocalService;
 import com.liferay.portal.kernel.servlet.PipingServletResponse;
 import com.liferay.portal.kernel.servlet.ServletContextPool;
 import com.liferay.portal.kernel.servlet.ServletResponseUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.theme.ThemeUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.style.book.constants.StyleBookPortletKeys;
 import com.liferay.style.book.web.internal.constants.StyleBookWebKeys;
+
+import java.util.Objects;
 
 import javax.portlet.ResourceRequest;
 import javax.portlet.ResourceResponse;
@@ -90,17 +101,64 @@ public class PreviewFragmentCollectionMVCResourceCommand
 			(ThemeDisplay)httpServletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY);
 
-		LayoutSet layoutSet = _layoutSetLocalService.getLayoutSet(
-			themeDisplay.getScopeGroupId(), false);
+		Theme theme = null;
 
-		themeDisplay.setLayoutSet(layoutSet);
-		themeDisplay.setLookAndFeel(
-			layoutSet.getTheme(), layoutSet.getColorScheme());
+		if (!FeatureFlagManagerUtil.isEnabled(
+				themeDisplay.getCompanyId(), "LPD-30204")) {
+
+			LayoutSet layoutSet = _layoutSetLocalService.getLayoutSet(
+				themeDisplay.getScopeGroupId(), false);
+
+			theme = layoutSet.getTheme();
+
+			themeDisplay.setLayoutSet(layoutSet);
+
+			themeDisplay.setLookAndFeel(theme, layoutSet.getColorScheme());
+		}
+		else {
+			String themeId = GetterUtil.getString(
+				httpServletRequest.getParameter("themeId"));
+
+			FrontendTokenDefinition frontendTokenDefinition =
+				_frontendTokenDefinitionRegistry.getFrontendTokenDefinition(
+					themeDisplay.getCompanyId(), themeId);
+
+			if ((frontendTokenDefinition != null) &&
+				Objects.equals(
+					frontendTokenDefinition.getThemeType(),
+					FrontendTokenDefinitionConstants.
+						THEME_TYPE_THEME_CSS_CET)) {
+
+				themeId = "classic_WAR_classictheme";
+
+				ThemeCSSCET themeCSSCET = (ThemeCSSCET)_cetManager.getCET(
+					themeDisplay.getCompanyId(), themeId);
+
+				if (themeCSSCET != null) {
+					if (_portal.isRightToLeft(httpServletRequest)) {
+						themeDisplay.setClayCSSURL(themeCSSCET.getClayRTLURL());
+						themeDisplay.setMainCSSURL(themeCSSCET.getMainRTLURL());
+					}
+					else {
+						themeDisplay.setClayCSSURL(themeCSSCET.getClayURL());
+						themeDisplay.setMainCSSURL(themeCSSCET.getMainURL());
+					}
+				}
+			}
+
+			theme = _themeLocalService.fetchTheme(
+				themeDisplay.getCompanyId(), themeId);
+
+			themeDisplay.setLookAndFeel(
+				theme,
+				_themeLocalService.getColorScheme(
+					themeDisplay.getCompanyId(), theme.getThemeId(),
+					StringPool.BLANK));
+		}
 
 		return ThemeUtil.include(
 			ServletContextPool.get(StringPool.BLANK), httpServletRequest,
-			httpServletResponse, "portal_normal.ftl", layoutSet.getTheme(),
-			false);
+			httpServletResponse, "portal_normal.ftl", theme, false);
 	}
 
 	private String _renderPreviewFragmentCollection(
@@ -123,8 +181,14 @@ public class PreviewFragmentCollectionMVCResourceCommand
 	}
 
 	@Reference
+	private CETManager _cetManager;
+
+	@Reference
 	private FragmentCollectionContributorRegistry
 		_fragmentCollectionContributorRegistry;
+
+	@Reference
+	private FrontendTokenDefinitionRegistry _frontendTokenDefinitionRegistry;
 
 	@Reference
 	private LayoutSetLocalService _layoutSetLocalService;
@@ -134,5 +198,8 @@ public class PreviewFragmentCollectionMVCResourceCommand
 
 	@Reference(target = "(osgi.web.symbolicname=com.liferay.style.book.web)")
 	private ServletContext _servletContext;
+
+	@Reference
+	private ThemeLocalService _themeLocalService;
 
 }

--- a/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/portlet/action/PreviewFragmentCollectionMVCResourceCommand.java
+++ b/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/portlet/action/PreviewFragmentCollectionMVCResourceCommand.java
@@ -101,15 +101,13 @@ public class PreviewFragmentCollectionMVCResourceCommand
 			(ThemeDisplay)httpServletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY);
 
-		Theme theme = null;
+		LayoutSet layoutSet = _layoutSetLocalService.getLayoutSet(
+			themeDisplay.getScopeGroupId(), false);
+
+		Theme theme = layoutSet.getTheme();
 
 		if (!FeatureFlagManagerUtil.isEnabled(
 				themeDisplay.getCompanyId(), "LPD-30204")) {
-
-			LayoutSet layoutSet = _layoutSetLocalService.getLayoutSet(
-				themeDisplay.getScopeGroupId(), false);
-
-			theme = layoutSet.getTheme();
 
 			themeDisplay.setLayoutSet(layoutSet);
 
@@ -129,7 +127,7 @@ public class PreviewFragmentCollectionMVCResourceCommand
 					FrontendTokenDefinitionConstants.
 						THEME_TYPE_THEME_CSS_CET)) {
 
-				themeId = "classic_WAR_classictheme";
+				themeId = theme.getThemeId();
 
 				ThemeCSSCET themeCSSCET = (ThemeCSSCET)_cetManager.getCET(
 					themeDisplay.getCompanyId(), themeId);

--- a/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/portlet/action/PreviewFragmentCollectionMVCResourceCommand.java
+++ b/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/portlet/action/PreviewFragmentCollectionMVCResourceCommand.java
@@ -117,7 +117,7 @@ public class PreviewFragmentCollectionMVCResourceCommand
 		}
 		else {
 			String themeId = GetterUtil.getString(
-				httpServletRequest.getParameter("themeId"));
+				httpServletRequest.getParameter("styleBookEntryThemeId"));
 
 			FrontendTokenDefinition frontendTokenDefinition =
 				_frontendTokenDefinitionRegistry.getFrontendTokenDefinition(

--- a/modules/test/playwright/pages/style-book-web/StyleBooksPage.ts
+++ b/modules/test/playwright/pages/style-book-web/StyleBooksPage.ts
@@ -32,16 +32,35 @@ export class StyleBooksPage {
 		await this.page.getByRole('menuitem', {name: nextPage}).click();
 	}
 
-	async create(styleBookName: string) {
+	async create(styleBookName: string, baseThemeName?: string) {
 		await this.page.getByRole('button', {exact: true, name: 'Add'}).click();
 
 		await this.page
 			.getByRole('textbox', {name: 'Name'})
 			.fill(styleBookName);
 
+		if (baseThemeName) {
+			await this.page.getByLabel('Create Style Book For').click();
+
+			await this.page.getByRole('option', {name: baseThemeName}).click();
+		}
+
 		await this.page.getByRole('button', {name: 'Save'}).click();
 
 		await waitForAlert(this.page);
+	}
+
+	async previewFragmentCollection(collectionName: string) {
+		await this.page
+			.getByRole('button', {name: 'Fragments'})
+			.or(this.page.getByRole('button', {name: 'Pages'}))
+			.click();
+
+		await this.page.getByRole('menuitem', {name: 'Fragments'}).click();
+
+		await this.page.getByRole('button', {name: 'Account'}).click();
+
+		await this.page.getByRole('menuitem', {name: collectionName}).click();
 	}
 
 	async delete(styleBookName: string) {

--- a/modules/test/playwright/tests/style-book-web/stylebookEditor.spec.ts
+++ b/modules/test/playwright/tests/style-book-web/stylebookEditor.spec.ts
@@ -480,3 +480,33 @@ test(
 		});
 	}
 );
+
+test('Fragment collection preview applies the theme in which the style book is based on', async ({
+	page,
+	site,
+	styleBooksPage,
+}) => {
+	await test.step('Create a style book based on the Dialect theme', async () => {
+		await styleBooksPage.goto(site.friendlyUrlPath);
+
+		await styleBooksPage.create('New style book', 'Dialect Theme');
+	});
+
+	await test.step("Assert that the tokens applied to the preview page of the 'Basic Components' fragment collection are from the dialect theme", async () => {
+		await styleBooksPage.previewFragmentCollection('Basic Components');
+
+		const previewIframe = page.frameLocator(
+			'iframe.style-book-editor__page-preview-frame'
+		);
+
+		const firstButton = previewIframe
+			.getByRole('link', {
+				name: 'Go Somewhere',
+			})
+			.first();
+
+		await firstButton.waitFor();
+
+		expect(firstButton).toHaveCSS('background-color', 'rgb(89, 36, 235)');
+	});
+});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-53379

# Issue

Since now style books are theme based, the theme applied to the fragments collection preview page is incorrect. It's using the theme from the layout set instead of the one the style book is based on

# Approach

When importing the frontend token definition to create the variables, check if it's the fragments collection preview page that is being loaded by using a request parameter `styleBookEntryFragmentCollectionPreview`.

## Important

The preview iframe (see image below) is a control panel layout. 
![image](https://github.com/user-attachments/assets/1ee31603-a5b1-4615-b0d4-b4d35a9f9cd0)

The HTML and CSS used to build the preview page is injected from within different classes 
1. `PreviewFragmentCollectionMVCResourceCommand`
2. `ScopedCSSVariablesTopHeadDynamicInclude` (especifically `DefaultThemeScopedCSSVariablesProvider`)
3. `LayoutStructureCommonStylesCSSServlet`

### Discarded approaches

1. We could create a site with a single layout that would be a wrapper just to show that content. The problem with that is having to change the layout theme and themeCSSCET every time the page renders (which can occur more than once at the same time for multiple users).
2. We could update the control panel layout to use the theme of the current style book, but that would mean having to rollback the changes made somehow. 

**I have stick to the approach of using a request parameter `styleBookEntryFragmentCollectionPreview` because it doesn't seem there is any other valid option. Also, we have a similar case which is the `styleBookEntryPreview` request parameter. It's used in `LayoutStructureCommonStylesCSSServlet` to know what to import based whether is a style book preview or not.**

## Steps to reproduce:

Enable the feature flag LPD-30204

1. With classic applied to public pages configuration, create a style book based on the dialect theme;
5. The style book editor page will show open

**Expected:** the applied styles are from the dialect theme;

**Actual:** the applied styles are from the classic theme.

6. Apply the dialect theme to public pages configuration;
7. Open the new style book

**Expected:** the applied styles are from the dialect theme and is the same as the preview in a previous Liferay version (prior this epic has even started).

**Actual:** the tokens applied seem to be from dialect, but it's not correctly applied