### PR TITLE
LPD-52725 Check and Adjust the Places that don't Use Taglibs Applying the Maxium Size Automatically (Fluid Layout Improvements)

### DIFF
--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/object_definitions/object_definition/details.jsp
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/object_definitions/object_definition/details.jsp
@@ -12,6 +12,7 @@ ObjectDefinition objectDefinition = (ObjectDefinition)request.getAttribute(Objec
 
 ObjectDefinitionsDetailsDisplayContext objectDefinitionsDetailsDisplayContext = (ObjectDefinitionsDetailsDisplayContext)request.getAttribute(WebKeys.PORTLET_DISPLAY_CONTEXT);
 
+portletDisplay.setCustomCSSClassName("container-fluid-max-xxxl");
 portletDisplay.setShowBackIcon(true);
 portletDisplay.setURLBack(
 	ParamUtil.getString(

--- a/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/control_menu/page.jsp
+++ b/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/control_menu/page.jsp
@@ -11,6 +11,8 @@
 boolean applicationsMenuApp = GetterUtil.getBoolean(request.getAttribute("liferay-product-navigation:control-menu:applicationsMenuApp"));
 
 ProductNavigationControlMenuTagDisplayContext productNavigationControlMenuTagDisplayContext = new ProductNavigationControlMenuTagDisplayContext(request, pageContext);
+
+String customCssClass = portletDisplay.getCustomCSSClassName();
 %>
 
 <c:if test="<%= productNavigationControlMenuTagDisplayContext.hasControlMenuEntries() %>">
@@ -19,6 +21,7 @@ ProductNavigationControlMenuTagDisplayContext productNavigationControlMenuTagDis
 
 		<div class="control-menu control-menu-level-1 control-menu-level-1-<%= applicationsMenuApp ? "light" : "dark" %> d-print-none" data-qa-id="controlMenu" id="<portlet:namespace />ControlMenu">
 			<clay:container-fluid
+				cssClass="<%= customCssClass%>"
 				fullWidth="<%= true %>"
 			>
 				<div class="control-menu-level-1-nav control-menu-nav" data-namespace="<portlet:namespace />" data-qa-id="header" id="<portlet:namespace />controlMenu">


### PR DESCRIPTION
I know the control menu should remain full width, but we have a ticket in the BPM team to align all the items on the Edit Object Definitions page (including the control menu) based on this [Figma design](https://www.figma.com/design/9XH4pN3nGMl6QhTfCxOiok/LPD-48994?node-id=1-84837&t=L5M5pMatTy9CJ2YN-0).
The problem is that the control menu is not being aligned with the other items in the header, as you can see in the screenshot:
![Screenshot from 2025-04-14 15-13-17](https://github.com/user-attachments/assets/24879623-e232-4d5d-b8a7-a016ba4f2bde)

To address this, we came up with a workaround—though I’m not sure if it's the best approach. We're setting the container-fluid-max-xxxl class in the JSP for the details page in our side, and then retrieving it in the control-menu/page.jsp file.

I’d really appreciate your input on whether this is a good solution or if there’s a better way to handle it.
Thanks!