### PR TITLE
LPD-54702 Handle panel categories with same order and same key

### DIFF
--- a/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/application/list/ControlPanelCategoryWrapper.java
+++ b/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/application/list/ControlPanelCategoryWrapper.java
@@ -26,7 +26,7 @@ import org.osgi.service.component.annotations.Reference;
 @Component(
 	property = {
 		"panel.category.key=" + PanelCategoryKeys.APPLICATIONS_MENU,
-		"panel.category.order:Integer=100"
+		"panel.category.order:Integer=150"
 	},
 	service = PanelCategory.class
 )

--- a/modules/apps/application-list/application-list-api/src/main/java/com/liferay/application/list/util/PanelCategoryRegistryUtil.java
+++ b/modules/apps/application-list/application-list-api/src/main/java/com/liferay/application/list/util/PanelCategoryRegistryUtil.java
@@ -12,6 +12,7 @@ import com.liferay.osgi.service.tracker.collections.map.PropertyServiceReference
 import com.liferay.osgi.service.tracker.collections.map.ServiceReferenceMapperFactory;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -21,11 +22,13 @@ import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.util.ListUtil;
 
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceReference;
 
 /**
  * Provides methods for retrieving application category instances defined by
@@ -149,6 +152,45 @@ public class PanelCategoryRegistryUtil {
 		return panelCategory;
 	}
 
+	private static Comparator<ServiceReference<PanelCategory>>
+		_getServiceReferenceComparator(BundleContext bundleContext) {
+
+		PropertyServiceReferenceComparator<PanelCategory>
+			propertyServiceReferenceComparator =
+				new PropertyServiceReferenceComparator<>(
+					"panel.category.order");
+
+		return (serviceReference1, serviceReference2) -> {
+			int value = propertyServiceReferenceComparator.compare(
+				serviceReference1, serviceReference2);
+
+			if (value != 0) {
+				return value;
+			}
+
+			PanelCategory panelCategory1 = bundleContext.getService(
+				serviceReference1);
+			PanelCategory panelCategory2 = bundleContext.getService(
+				serviceReference2);
+
+			String key1 = panelCategory1.getKey();
+			String key2 = panelCategory2.getKey();
+
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					StringBundler.concat(
+						"The panel categories '", key1, "' and '", key2,
+						"' have the same order ",
+						serviceReference1.getProperty("panel.category.order"),
+						" and key '",
+						serviceReference1.getProperty("panel.category.key"),
+						"'"));
+			}
+
+			return key1.compareTo(key2);
+		};
+	}
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		PanelCategoryRegistryUtil.class);
 
@@ -168,8 +210,7 @@ public class PanelCategoryRegistryUtil {
 				bundleContext, PanelCategory.class, null,
 				new PropertyServiceReferenceMapper<>("panel.category.key"),
 				Collections.reverseOrder(
-					new PropertyServiceReferenceComparator<>(
-						"panel.category.order")));
+					_getServiceReferenceComparator(bundleContext)));
 
 		_panelCategoryServiceTrackerMap =
 			ServiceTrackerMapFactory.openSingleValueMap(

--- a/modules/apps/application-list/application-list-api/src/main/resources/META-INF/module-log4j.xml
+++ b/modules/apps/application-list/application-list-api/src/main/resources/META-INF/module-log4j.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+
+<Configuration strict="true">
+	<Loggers>
+		<Logger level="WARN" name="com.liferay.application.list.util.PanelCategoryRegistryUtil" />
+	</Loggers>
+</Configuration>

--- a/modules/apps/application-list/application-list-test/src/testIntegration/java/com/liferay/application/list/util/test/PanelCategoryRegistryUtilTest.java
+++ b/modules/apps/application-list/application-list-test/src/testIntegration/java/com/liferay/application/list/util/test/PanelCategoryRegistryUtilTest.java
@@ -1,0 +1,124 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.application.list.util.test;
+
+import com.liferay.application.list.BasePanelCategory;
+import com.liferay.application.list.PanelCategory;
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.HashMapDictionary;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LogEntry;
+import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.List;
+import java.util.Locale;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceRegistration;
+
+/**
+ * @author Thiago Buarque
+ */
+@RunWith(Arquillian.class)
+public class PanelCategoryRegistryUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testGetServiceReferenceComparator() {
+		ServiceRegistration<PanelCategory> serviceRegistration1 = null;
+		ServiceRegistration<PanelCategory> serviceRegistration2 = null;
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.application.list.util.PanelCategoryRegistryUtil",
+				LoggerTestUtil.WARN)) {
+
+			Bundle bundle = FrameworkUtil.getBundle(
+				PanelCategoryRegistryUtilTest.class);
+
+			BundleContext bundleContext = bundle.getBundleContext();
+
+			HashMapDictionary<String, String> serviceProperties =
+				HashMapDictionaryBuilder.put(
+					"panel.category.key", "panelCategoryKey"
+				).put(
+					"panel.category.order", "100"
+				).build();
+
+			serviceRegistration1 = bundleContext.registerService(
+				PanelCategory.class, new TestPanelCategory1(),
+				serviceProperties);
+
+			serviceRegistration2 = bundleContext.registerService(
+				PanelCategory.class, new TestPanelCategory2(),
+				serviceProperties);
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertEquals(logEntries.toString(), 1, logEntries.size());
+
+			LogEntry logEntry = logEntries.get(0);
+
+			Assert.assertEquals(
+				"The panel categories 'testKey2' and 'testKey1' have the " +
+					"same order 100 and key 'panelCategoryKey'",
+				logEntry.getMessage());
+		}
+		finally {
+			if (serviceRegistration1 != null) {
+				serviceRegistration1.unregister();
+			}
+
+			if (serviceRegistration2 != null) {
+				serviceRegistration2.unregister();
+			}
+		}
+	}
+
+	private static class TestPanelCategory1 extends BasePanelCategory {
+
+		@Override
+		public String getKey() {
+			return "testKey1";
+		}
+
+		@Override
+		public String getLabel(Locale locale) {
+			return RandomTestUtil.randomString();
+		}
+
+	}
+
+	private static class TestPanelCategory2 extends BasePanelCategory {
+
+		@Override
+		public String getKey() {
+			return "testKey2";
+		}
+
+		@Override
+		public String getLabel(Locale locale) {
+			return RandomTestUtil.randomString();
+		}
+
+	}
+
+}

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/java/com/liferay/product/navigation/site/administration/internal/application/list/DesignPanelCategory.java
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/java/com/liferay/product/navigation/site/administration/internal/application/list/DesignPanelCategory.java
@@ -21,7 +21,7 @@ import org.osgi.service.component.annotations.Reference;
 @Component(
 	property = {
 		"panel.category.key=" + PanelCategoryKeys.SITE_ADMINISTRATION,
-		"panel.category.order:Integer=100"
+		"panel.category.order:Integer=50"
 	},
 	service = PanelCategory.class
 )

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/java/com/liferay/product/navigation/site/administration/internal/application/list/NavigationPanelCategory.java
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/java/com/liferay/product/navigation/site/administration/internal/application/list/NavigationPanelCategory.java
@@ -21,7 +21,7 @@ import org.osgi.service.component.annotations.Reference;
 @Component(
 	property = {
 		"panel.category.key=" + PanelCategoryKeys.SITE_ADMINISTRATION,
-		"panel.category.order:Integer=600"
+		"panel.category.order:Integer=650"
 	},
 	service = PanelCategory.class
 )

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/application/list/SearchExperiencesPanelCategory.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/application/list/SearchExperiencesPanelCategory.java
@@ -23,7 +23,7 @@ import org.osgi.service.component.annotations.Reference;
 	enabled = false,
 	property = {
 		"panel.category.key=" + PanelCategoryKeys.APPLICATIONS_MENU_APPLICATIONS,
-		"panel.category.order:Integer=500"
+		"panel.category.order:Integer=450"
 	},
 	service = PanelCategory.class
 )


### PR DESCRIPTION
Story: https://liferay.atlassian.net/browse/LPD-49579
Task: https://liferay.atlassian.net/browse/LPD-54702

## Problem
Currently if two panel categories have the same key and order properties, the order in which they are listed may not be consistent. It simply depends on which one is registered first when portal starts up

## Solution

When two panel categories have the same order and key, we compare their [PanelEntry key](https://github.com/liferay-platform-experience/liferay-portal/blob/7067b46e5e1713876b3fe94f70c74546f1561ee8/modules/apps/application-list/application-list-api/src/main/java/com/liferay/application/list/PanelEntry.java#L31) and log a warning

## Screenshots

This is the final order of each panel section in applications menu
![image](https://github.com/user-attachments/assets/9fb2eed0-bbea-4f83-ae8b-7a176b7552d8)
![image](https://github.com/user-attachments/assets/41a86349-194b-42ce-a38e-5e0b9246e374)
![image](https://github.com/user-attachments/assets/c564d23f-d678-4be2-a768-d8a23b719ff4)
