### PR TITLE
LPD-53881 Replace uses of info-panel-open/closed.svg

### DIFF
--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/feature_indicator/FeatureIndicator.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/feature_indicator/FeatureIndicator.tsx
@@ -54,7 +54,7 @@ export default function FeatureIndicator({
 	let learnMessageResourceKey = 'beta-features';
 	let popoverText = Liferay.Language.get('this-feature-is-in-testing');
 	let popoverTitle = Liferay.Language.get('beta-feature');
-	let symbol = 'info-panel-open';
+	let symbol = 'info-circle-open';
 	let tooltipTitle = Liferay.Language.get('open-beta-definition');
 
 	if (type === 'deprecated') {

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/js/item_selector_preview/Header.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/js/item_selector_preview/Header.js
@@ -69,7 +69,7 @@ const Header = ({
 										monospaced
 										ref={infoButtonRef}
 									>
-										<ClayIcon symbol="info-panel-open" />
+										<ClayIcon symbol="info-circle-open" />
 									</ClayButton>
 								</li>
 							)}

--- a/modules/apps/item-selector/item-selector-taglib/test/item_selector_preview/Header.es.js
+++ b/modules/apps/item-selector/item-selector-taglib/test/item_selector_preview/Header.es.js
@@ -85,23 +85,23 @@ describe('Header', () => {
 		expect(headerProps.handleClickAdd).toHaveBeenCalled();
 	});
 
-	it('renders the "info-panel-open" icon when "showInfoIcon" prop is set to true', () => {
+	it('renders the "info-circle-open" icon when "showInfoIcon" prop is set to true', () => {
 		const {container} = render(<Header {...headerProps} />);
 
 		const infoIcon = container.querySelector(
-			'.lexicon-icon-info-panel-open'
+			'.lexicon-icon-info-circle-open'
 		);
 
 		expect(infoIcon).not.toBeNull();
 	});
 
-	it('does not render the "info-panel-open" icon when "showInfoIcon" prop is set to false', () => {
+	it('does not render the "info-circle-open" icon when "showInfoIcon" prop is set to false', () => {
 		const props = {...headerProps, showInfoIcon: false};
 
 		const {container} = render(<Header {...props} />);
 
 		const infoIcon = container.querySelector(
-			'.lexicon-icon-info-panel-open'
+			'.lexicon-icon-info-circle-open'
 		);
 
 		expect(infoIcon).toBeNull();

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/CollectionSelector.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/CollectionSelector.js
@@ -59,7 +59,7 @@ export default function CollectionSelector({
 
 			{isPrefiltered && (
 				<p className="text-info">
-					<ClayIcon className="mr-2 mt-0" symbol="info-panel-open" />
+					<ClayIcon className="mr-2 mt-0" symbol="info-circle-open" />
 
 					<span className="text-2">
 						{Liferay.Language.get('collection-filtered')}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/RepeatableOptionsSelector.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/RepeatableOptionsSelector.js
@@ -97,7 +97,7 @@ export default function RepeatableOptionsSelector({
 						>
 							<ClayIcon
 								className="mr-2"
-								symbol="info-panel-open"
+								symbol="info-circle-open"
 							/>
 						</div>
 

--- a/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/CodeEditor/Element.tsx
+++ b/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/CodeEditor/Element.tsx
@@ -42,7 +42,7 @@ export function Element({disabled, helpText, label, onClick}: IProps) {
 								onFocus={() => setShowPreview(true)}
 								onMouseLeave={() => setShowPreview(false)}
 								onMouseOver={() => setShowPreview(true)}
-								symbol="info-panel-closed"
+								symbol="info-circle"
 							/>
 						}
 					>

--- a/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/Panel/PanelHeader.tsx
+++ b/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/Panel/PanelHeader.tsx
@@ -64,7 +64,7 @@ export function PanelHeader({
 						>
 							<ClayIcon
 								className="object-admin-panel__tooltip-icon"
-								symbol="info-panel-open"
+								symbol="info-circle-open"
 							/>
 						</span>
 					</ClayTooltipProvider>

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ViewObjectDefinitions/objectDefinitionUtil.ts
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ViewObjectDefinitions/objectDefinitionUtil.ts
@@ -230,7 +230,7 @@ export function getObjectDefinitionNodeActions({
 					type: TYPES.UPDATE_VISIBILITY_MODEL_BUILDER_MODALS,
 				});
 			},
-			symbolLeft: 'info-panel-closed',
+			symbolLeft: 'info-circle',
 		},
 		{type: 'divider'},
 		{

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/ItemSelector.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/ItemSelector.path
@@ -139,7 +139,7 @@
 </tr>
 <tr>
 	<td>VIEWER_INFO</td>
-	<td>//button[*[name()='svg'][contains(@class,'lexicon-icon-info-panel-open')]]</td>
+	<td>//button[*[name()='svg'][contains(@class,'lexicon-icon-info-circle-open')]]</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-53881
Deprecate info-panel-closed.svg (replaced with info-circle.svg) and info-panel-open.svg (replaced with info-circle-open.svg).