### PR TITLE
LPD-56542 add themeId to style books from site initializers

### DIFF
--- a/modules/apps/commerce/commerce-site-initializer/commerce-site-initializer/src/main/resources/site-initializer/style-books/commerce-classic/style-book.json
+++ b/modules/apps/commerce/commerce-site-initializer/commerce-site-initializer/src/main/resources/site-initializer/style-books/commerce-classic/style-book.json
@@ -2,5 +2,6 @@
 	"defaultStyleBookEntry": true,
 	"frontendTokensValuesPath": "frontend-tokens-values.json",
 	"name": "Commerce Classic",
+	"themeId": "classic_WAR_classictheme",
 	"thumbnailPath": "thumbnail.png"
 }

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test-bundle-1/src/main/resources/site-initializer/style-books/test-style-book/style-book.json
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test-bundle-1/src/main/resources/site-initializer/style-books/test-style-book/style-book.json
@@ -1,5 +1,6 @@
 {
 	"frontendTokensValuesPath": "frontend-tokens-values.json",
 	"name": "Test Style Book Entry",
+	"themeId": "classic_WAR_classictheme",
 	"thumbnailPath": "thumbnail.png"
 }

--- a/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/style-books/masterclass-classic/style-book.json
+++ b/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/style-books/masterclass-classic/style-book.json
@@ -2,5 +2,6 @@
 	"defaultStyleBookEntry": true,
 	"frontendTokensValuesPath": "frontend-tokens-values.json",
 	"name": "Masterclass Classic",
+	"themeId": "classic_WAR_classictheme",
 	"thumbnailPath": "thumbnail.png"
 }

--- a/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/style-books/masterclass-modern/style-book.json
+++ b/modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/style-books/masterclass-modern/style-book.json
@@ -1,5 +1,6 @@
 {
 	"frontendTokensValuesPath": "frontend-tokens-values.json",
 	"name": "Masterclass Modern",
+	"themeId": "classic_WAR_classictheme",
 	"thumbnailPath": "thumbnail.png"
 }

--- a/modules/apps/site-initializer/site-initializer-team-extranet/src/main/resources/site-initializer/style-books/stylebook-one/style-book.json
+++ b/modules/apps/site-initializer/site-initializer-team-extranet/src/main/resources/site-initializer/style-books/stylebook-one/style-book.json
@@ -2,5 +2,6 @@
 	"defaultStyleBookEntry": true,
 	"frontendTokensValuesPath": "frontend-tokens-values.json",
 	"name": "Stylebook One",
+	"themeId": "classic_WAR_classictheme",
 	"thumbnailPath": "thumbnail.png"
 }

--- a/modules/test/playwright/tests/setup/page-management-site/main/site-initializer/style-books/page-management-style-book/style-book.json
+++ b/modules/test/playwright/tests/setup/page-management-site/main/site-initializer/style-books/page-management-style-book/style-book.json
@@ -1,4 +1,5 @@
 {
 	"frontendTokensValuesPath": "frontend-tokens-values.json",
-	"name": "Page Management Style Book"
+	"name": "Page Management Style Book",
+	"themeId": "classic_WAR_classictheme"
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-56542

## Issue

We forgot to add `themeId` for the style books in site initializers. Because of that, we get an error when creating a site and the feature flag LPD-30204 is enabled.
![image](https://github.com/user-attachments/assets/41e23324-85ba-4d1a-99c5-0acbf8f98fb3)


I checked those site initializers and they all seem to be using classic theme for the public layout.

