### PR TITLE
LPS-58939 

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-cms/src/css/_clay_variables.scss
+++ b/modules/apps/frontend-theme/frontend-theme-cms/src/css/_clay_variables.scss
@@ -1,18 +1,38 @@
 @import 'clay/atlas/variables/_globals';
 
-$border-radius: 0.5rem !default;
-$border-radius-lg: 0.5rem !default;
-$border-radius-sm: 0.5rem !default;
+$border-radius: 0.5rem;
+$border-radius-lg: 0.5rem;
+$border-radius-sm: 0.5rem;
 
-$breadcrumb-divider-svg-icon: clay-icon(slash, $gray-600) !default;
-$breadcrumb-divider-svg-icon-height: 0.9em !default;
+$breadcrumb-divider-svg-icon: clay-icon(slash, $gray-600);
+$breadcrumb-divider-svg-icon-height: 0.9em;
 
-$label-border-radius: 0.25rem !default;
+$btn-xs-border-radius: 0.25rem;
 
-$sticker-border-radius: 0.25rem !default;
+$label-border-radius: 0.25rem;
 
-$label-font-size: 0.75rem !default;
-$label-text-transform: capitalize !default;
+$sticker-sm-border-radius: 0.25rem;
+
+$label-font-size: 0.75rem;
+$label-text-transform: capitalize;
+
+$btn-sizes: () !default;
+$btn-sizes: map-deep-merge(
+	(
+		btn-xs: (
+			border-radius: $btn-xs-border-radius,
+		),
+	),
+	$btn-sizes
+);
+
+$label-lg: () !default;
+$label-lg: map-deep-merge(
+	(
+		border-radius: $border-radius-lg,
+	),
+	$label-lg
+);
 
 $label-primary-close: () !default;
 $label-primary-close: map-deep-merge(
@@ -252,6 +272,14 @@ $label-danger: map-deep-merge(
 		close: $label-danger-close,
 	),
 	$label-danger
+);
+
+$sticker-sm: () !default;
+$sticker-sm: map-deep-merge(
+	(
+		border-radius: $sticker-sm-border-radius,
+	),
+	$sticker-sm
 );
 
 $sticker-outline-1: () !default;

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/fragments/group/cms/fragments/sidebar/index.css
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/fragments/group/cms/fragments/sidebar/index.css
@@ -24,10 +24,6 @@
 		grid-template-columns: var(--sidebar-layout-width) minmax(0, 1fr);
 	}
 
-	.btn-monospaced.btn-xs {
-		border-radius: 4px;
-	}
-
 	.sidebar {
 		background-color: #f7f8f9;
 		max-height: var(--sidebar-layout-height);


### PR DESCRIPTION
Force SASS variables by removing `!default`
Exceptions for `btn-xs`, `label-sm` and `sticker-sm`

Result:
![image](https://github.com/user-attachments/assets/a8df3edc-a734-4a4c-b3fd-bcf34f71f9a9)
