### PR TITLE
LPD-58961 Control panel pages should not render for groups that aren't site or control panel itself

### DIFF
--- a/modules/apps/layout/layout-type-controller/layout-type-controller-control-panel/src/main/java/com/liferay/layout/type/controller/control/panel/internal/model/ControlPanelLayoutTypeAccessPolicy.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-control-panel/src/main/java/com/liferay/layout/type/controller/control/panel/internal/model/ControlPanelLayoutTypeAccessPolicy.java
@@ -6,6 +6,7 @@
 package com.liferay.layout.type.controller.control.panel.internal.model;
 
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.model.LayoutTypeAccessPolicy;
@@ -45,11 +46,15 @@ public class ControlPanelLayoutTypeAccessPolicy
 			(ThemeDisplay)httpServletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY);
 
-		if (PortletPermissionUtil.hasControlPanelAccessPermission(
+		Group scopeGroup = themeDisplay.getScopeGroup();
+
+		if ((scopeGroup != null) &&
+			(scopeGroup.isSite() || scopeGroup.isControlPanel()) &&
+			(PortletPermissionUtil.hasControlPanelAccessPermission(
 				permissionChecker, themeDisplay.getScopeGroupId(), portlet) ||
-			isAccessGrantedByRuntimePortlet(httpServletRequest) ||
-			isAccessGrantedByPortletAuthenticationToken(
-				httpServletRequest, layout, portlet)) {
+			 isAccessGrantedByRuntimePortlet(httpServletRequest) ||
+			 isAccessGrantedByPortletAuthenticationToken(
+				 httpServletRequest, layout, portlet))) {
 
 			return;
 		}

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-control-panel/src/main/java/com/liferay/layout/type/controller/control/panel/internal/model/ControlPanelLayoutTypeAccessPolicy.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-control-panel/src/main/java/com/liferay/layout/type/controller/control/panel/internal/model/ControlPanelLayoutTypeAccessPolicy.java
@@ -39,9 +39,6 @@ public class ControlPanelLayoutTypeAccessPolicy
 			Portlet portlet)
 		throws PortalException {
 
-		PermissionChecker permissionChecker =
-			PermissionThreadLocal.getPermissionChecker();
-
 		ThemeDisplay themeDisplay =
 			(ThemeDisplay)httpServletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY);
@@ -51,7 +48,8 @@ public class ControlPanelLayoutTypeAccessPolicy
 		if ((scopeGroup != null) &&
 			(scopeGroup.isSite() || scopeGroup.isControlPanel()) &&
 			(PortletPermissionUtil.hasControlPanelAccessPermission(
-				permissionChecker, themeDisplay.getScopeGroupId(), portlet) ||
+				PermissionThreadLocal.getPermissionChecker(),
+				themeDisplay.getScopeGroupId(), portlet) ||
 			 isAccessGrantedByRuntimePortlet(httpServletRequest) ||
 			 isAccessGrantedByPortletAuthenticationToken(
 				 httpServletRequest, layout, portlet))) {

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-control-panel/src/test/java/com/liferay/layout/type/controller/control/panel/internal/model/ControlPanelLayoutTypeAccessPolicyTest.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-control-panel/src/test/java/com/liferay/layout/type/controller/control/panel/internal/model/ControlPanelLayoutTypeAccessPolicyTest.java
@@ -1,0 +1,112 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.type.controller.control.panel.internal.model;
+
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Portlet;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.permission.PortletPermissionUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * @author Thiago Buarque
+ */
+public class ControlPanelLayoutTypeAccessPolicyTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testCheckAccessAllowedToPortlet() throws PortalException {
+		Group group = Mockito.mock(Group.class);
+
+		Mockito.when(
+			group.isSite()
+		).thenReturn(
+			false
+		);
+
+		Mockito.when(
+			group.isControlPanel()
+		).thenReturn(
+			false
+		);
+
+		ThemeDisplay themeDisplay = Mockito.mock(ThemeDisplay.class);
+
+		Mockito.when(
+			themeDisplay.getScopeGroup()
+		).thenReturn(
+			group
+		);
+
+		HttpServletRequest httpServletRequest = Mockito.mock(
+			HttpServletRequest.class);
+
+		Mockito.when(
+			httpServletRequest.getAttribute(WebKeys.THEME_DISPLAY)
+		).thenReturn(
+			themeDisplay
+		);
+
+		Portlet portlet = Mockito.mock(Portlet.class);
+
+		portlet.setPortletId(RandomTestUtil.randomString());
+
+		ControlPanelLayoutTypeAccessPolicy controlPanelLayoutTypeAccessPolicy =
+			new ControlPanelLayoutTypeAccessPolicy();
+
+		try {
+			controlPanelLayoutTypeAccessPolicy.checkAccessAllowedToPortlet(
+				httpServletRequest, null, portlet);
+
+			Assert.fail();
+		}
+		catch (PortalException portalException) {
+			Assert.assertEquals(
+				"User does not have permission to access Control Panel " +
+					"portlet " + portlet.getPortletId(),
+				portalException.getMessage());
+		}
+
+		Mockito.when(
+			group.isControlPanel()
+		).thenReturn(
+			true
+		);
+
+		MockedStatic<PortletPermissionUtil> portletPermissionUtilMockedStatic =
+			Mockito.mockStatic(PortletPermissionUtil.class);
+
+		portletPermissionUtilMockedStatic.when(
+			() -> PortletPermissionUtil.hasControlPanelAccessPermission(
+				PermissionThreadLocal.getPermissionChecker(),
+				themeDisplay.getScopeGroupId(), portlet)
+		).thenReturn(
+			true
+		);
+
+		controlPanelLayoutTypeAccessPolicy.checkAccessAllowedToPortlet(
+			httpServletRequest, null, portlet);
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-58961

# Issue

Control panel pages were being rendered for groups that weren't sites or the control panel group itself.

Steps to reproduce: see https://liferay.atlassian.net/browse/LPP-59206

# Approach

Prevent control panel pages rendering for groups that aren't sites or the control panel itself.

# Image

This is the user view when trying to access a control panel page for a group that isn't a site
![image](https://github.com/user-attachments/assets/dead02bc-dacd-474f-aded-82e2961f378f)


