### PR TITLE
LPD-59151 LPD-58961  take into account the asset libraries on permission check to control panel

### DIFF
--- a/modules/apps/layout/layout-type-controller/layout-type-controller-control-panel/src/main/java/com/liferay/layout/type/controller/control/panel/internal/model/ControlPanelLayoutTypeAccessPolicy.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-control-panel/src/main/java/com/liferay/layout/type/controller/control/panel/internal/model/ControlPanelLayoutTypeAccessPolicy.java
@@ -46,7 +46,8 @@ public class ControlPanelLayoutTypeAccessPolicy
 		Group scopeGroup = themeDisplay.getScopeGroup();
 
 		if ((scopeGroup != null) &&
-			(scopeGroup.isSite() || scopeGroup.isControlPanel()) &&
+			(scopeGroup.isControlPanel() || scopeGroup.isDepot() ||
+			 scopeGroup.isSite()) &&
 			(PortletPermissionUtil.hasControlPanelAccessPermission(
 				PermissionThreadLocal.getPermissionChecker(),
 				themeDisplay.getScopeGroupId(), portlet) ||

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-control-panel/src/test/java/com/liferay/layout/type/controller/control/panel/internal/model/ControlPanelLayoutTypeAccessPolicyTest.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-control-panel/src/test/java/com/liferay/layout/type/controller/control/panel/internal/model/ControlPanelLayoutTypeAccessPolicyTest.java
@@ -45,6 +45,12 @@ public class ControlPanelLayoutTypeAccessPolicyTest {
 		Group group = Mockito.mock(Group.class);
 
 		Mockito.when(
+			group.isDepot()
+		).thenReturn(
+			false
+		);
+
+		Mockito.when(
 			group.isSite()
 		).thenReturn(
 			false

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-control-panel/src/test/java/com/liferay/layout/type/controller/control/panel/internal/model/ControlPanelLayoutTypeAccessPolicyTest.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-control-panel/src/test/java/com/liferay/layout/type/controller/control/panel/internal/model/ControlPanelLayoutTypeAccessPolicyTest.java
@@ -113,6 +113,29 @@ public class ControlPanelLayoutTypeAccessPolicyTest {
 
 		controlPanelLayoutTypeAccessPolicy.checkAccessAllowedToPortlet(
 			httpServletRequest, null, portlet);
+
+		Mockito.when(
+			group.isControlPanel()
+		).thenReturn(
+			false
+		);
+
+		Mockito.when(
+			group.isDepot()
+		).thenReturn(
+			true
+		);
+
+		portletPermissionUtilMockedStatic.when(
+			() -> PortletPermissionUtil.hasControlPanelAccessPermission(
+				PermissionThreadLocal.getPermissionChecker(),
+				themeDisplay.getScopeGroupId(), portlet)
+		).thenReturn(
+			true
+		);
+
+		controlPanelLayoutTypeAccessPolicy.checkAccessAllowedToPortlet(
+			httpServletRequest, null, portlet);
 	}
 
 }


### PR DESCRIPTION
LPD-59151 take into account that an asset library has to have access too

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-59151


LPD-58961 is causing a regression do not letting users to access to asset libraries. This is a blocker for the release.

# How am I fixing it?

Adding the case that the group is an asset library too.

# How can you verify that it works?

Run the included automated tests.


# Commits





- **LPD-59151 LPD-58961 take into account that an asset library has to have access too**
- **LPD-59151 LPD-58961 modify test**
- **LPD-59151 LPD-58961 add case for asset libraries**
