### PR TITLE
LPD-58394 Remove low priority Platform Experience tests from Acceptance

### DIFF
--- a/modules/apps/accessibility/accessibility-test/src/testFunctional/tests/AccessibilityMenu.testcase
+++ b/modules/apps/accessibility/accessibility-test/src/testFunctional/tests/AccessibilityMenu.testcase
@@ -387,8 +387,6 @@ definition {
 	@description = "LPS-178192. Verifies ON state can persist to first login user."
 	@priority = 3
 	test GuestConfigurationOnStateWillPersistForFirstLogin {
-		property portal.acceptance = "true";
-
 		task ("Given create a new user") {
 			JSONUser.addUser(
 				userEmailAddress = "userea@liferay.com",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/administration/portalconfiguration/systemmanagement/InstanceSettings.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/administration/portalconfiguration/systemmanagement/InstanceSettings.testcase
@@ -841,7 +841,6 @@ definition {
 	@description = "Verify the default company can be set to a virtual instance via property."
 	@priority = 3
 	test ChangeDefaultCompanyToDifferentInstance {
-		property portal.acceptance = "true";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 


### PR DESCRIPTION
Hello,
The Release team is looking to remove Poshi tests that are marked as priority 3 or lower from running on the Acceptance Test Suite.
If you believe any of these tests should not be removed, please let us know so we can update the priority and keep the test running on Acceptance.
Thank you!

https://liferay.atlassian.net/browse/LPD-58394
https://liferay.atlassian.net/browse/LPD-58065