### PR TITLE
LPD-59680 Configuration entries table not showing any entries for system scoped configurations

### DIFF
--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/util/ConfigurationModelRetrieverImpl.java
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/util/ConfigurationModelRetrieverImpl.java
@@ -194,63 +194,11 @@ public class ConfigurationModelRetrieverImpl
 	protected String getPidFilterString(
 		String pid, ExtendedObjectClassDefinition.Scope scope) {
 
-		String key = Constants.SERVICE_PID;
-
-		if (!scope.equals(ExtendedObjectClassDefinition.Scope.SYSTEM) ||
-			pid.contains("~")) {
-
-			key = ConfigurationAdmin.SERVICE_FACTORYPID;
-			pid = _getUnscopedPid(pid);
-		}
-
 		if (scope.equals(ExtendedObjectClassDefinition.Scope.SYSTEM)) {
-			return StringBundler.concat(
-				StringPool.OPEN_PARENTHESIS, StringPool.AMPERSAND,
-				_getPropertyFilterString(key, pid), "(!(",
-				ExtendedObjectClassDefinition.Scope.COMPANY.getPropertyKey(),
-				"=*))(!(dxp.lxc.liferay.com.virtualInstanceId=*))(!(",
-				ExtendedObjectClassDefinition.Scope.GROUP.getPropertyKey(),
-				"=*))(!(siteExternalReferenceCode=*)))");
+			return _getSystemPidFilterString(pid);
 		}
 
-		String scopedFilterString = StringBundler.concat(
-			StringPool.OPEN_PARENTHESIS, StringPool.PIPE,
-			_getPropertyFilterString(key, pid),
-			_getPropertyFilterString(key, pid + ".scoped"),
-			StringPool.CLOSE_PARENTHESIS);
-
-		if (scope.equals(ExtendedObjectClassDefinition.Scope.COMPANY)) {
-			return StringBundler.concat(
-				StringPool.OPEN_PARENTHESIS, StringPool.AMPERSAND,
-				scopedFilterString, "(|(",
-				ExtendedObjectClassDefinition.Scope.COMPANY.getPropertyKey(),
-				"=*)(dxp.lxc.liferay.com.virtualInstanceId=*))(!(",
-				ExtendedObjectClassDefinition.Scope.GROUP.getPropertyKey(),
-				"=*))(!(siteExternalReferenceCode=*))(!(",
-				ExtendedObjectClassDefinition.Scope.PORTLET_INSTANCE.
-					getPropertyKey(),
-				"=*)))");
-		}
-
-		if (scope.equals(ExtendedObjectClassDefinition.Scope.GROUP)) {
-			return StringBundler.concat(
-				StringPool.OPEN_PARENTHESIS, StringPool.AMPERSAND,
-				scopedFilterString, "(|(",
-				ExtendedObjectClassDefinition.Scope.GROUP.getPropertyKey(),
-				"=*)(siteExternalReferenceCode=*))(!(",
-				ExtendedObjectClassDefinition.Scope.PORTLET_INSTANCE.
-					getPropertyKey(),
-				"=*)))");
-		}
-
-		return StringBundler.concat(
-			StringPool.OPEN_PARENTHESIS, StringPool.AMPERSAND,
-			scopedFilterString, "(|(",
-			ExtendedObjectClassDefinition.Scope.GROUP.getPropertyKey(),
-			"=*)(siteExternalReferenceCode=*))(",
-			ExtendedObjectClassDefinition.Scope.PORTLET_INSTANCE.
-				getPropertyKey(),
-			"=*))");
+		return _getScopedPidFilterString(pid, scope);
 	}
 
 	private void _collectConfigurationModels(
@@ -379,8 +327,92 @@ public class ConfigurationModelRetrieverImpl
 			StringPool.CLOSE_PARENTHESIS);
 	}
 
+	private String _getScopedPidFilterString(
+		String pid, ExtendedObjectClassDefinition.Scope scope) {
+
+		String unscopedPId = _getUnscopedPid(pid);
+
+		String filterString = StringBundler.concat(
+			StringPool.OPEN_PARENTHESIS, StringPool.PIPE,
+			_getPropertyFilterString(
+				ConfigurationAdmin.SERVICE_FACTORYPID, unscopedPId),
+			_getPropertyFilterString(
+				ConfigurationAdmin.SERVICE_FACTORYPID, unscopedPId + ".scoped"),
+			StringPool.CLOSE_PARENTHESIS);
+
+		if (pid.contains("~")) {
+			filterString = StringBundler.concat(
+				StringPool.OPEN_PARENTHESIS, StringPool.AMPERSAND, filterString,
+				_getPropertyFilterString(Constants.SERVICE_PID, pid),
+				StringPool.CLOSE_PARENTHESIS);
+		}
+
+		if (scope.equals(ExtendedObjectClassDefinition.Scope.COMPANY)) {
+			return StringBundler.concat(
+				StringPool.OPEN_PARENTHESIS, StringPool.AMPERSAND, filterString,
+				"(|(",
+				ExtendedObjectClassDefinition.Scope.COMPANY.getPropertyKey(),
+				"=*)(dxp.lxc.liferay.com.virtualInstanceId=*))(!(",
+				ExtendedObjectClassDefinition.Scope.GROUP.getPropertyKey(),
+				"=*))(!(siteExternalReferenceCode=*))(!(",
+				ExtendedObjectClassDefinition.Scope.PORTLET_INSTANCE.
+					getPropertyKey(),
+				"=*)))");
+		}
+
+		if (scope.equals(ExtendedObjectClassDefinition.Scope.GROUP)) {
+			return StringBundler.concat(
+				StringPool.OPEN_PARENTHESIS, StringPool.AMPERSAND, filterString,
+				"(|(",
+				ExtendedObjectClassDefinition.Scope.GROUP.getPropertyKey(),
+				"=*)(siteExternalReferenceCode=*))(!(",
+				ExtendedObjectClassDefinition.Scope.PORTLET_INSTANCE.
+					getPropertyKey(),
+				"=*)))");
+		}
+
+		return StringBundler.concat(
+			StringPool.OPEN_PARENTHESIS, StringPool.AMPERSAND, filterString,
+			"(|(", ExtendedObjectClassDefinition.Scope.GROUP.getPropertyKey(),
+			"=*)(siteExternalReferenceCode=*))(",
+			ExtendedObjectClassDefinition.Scope.PORTLET_INSTANCE.
+				getPropertyKey(),
+			"=*))");
+	}
+
+	private String _getSystemPidFilterString(String pid) {
+		String filterString = StringBundler.concat(
+			StringPool.OPEN_PARENTHESIS, StringPool.PIPE,
+			_getPropertyFilterString(
+				ConfigurationAdmin.SERVICE_FACTORYPID, pid),
+			_getPropertyFilterString(Constants.SERVICE_PID, pid),
+			StringPool.CLOSE_PARENTHESIS);
+
+		if (pid.contains("~")) {
+			filterString = StringBundler.concat(
+				StringPool.OPEN_PARENTHESIS, StringPool.AMPERSAND,
+				_getPropertyFilterString(
+					ConfigurationAdmin.SERVICE_FACTORYPID,
+					_getUnscopedPid(pid)),
+				_getPropertyFilterString(Constants.SERVICE_PID, pid),
+				StringPool.CLOSE_PARENTHESIS);
+		}
+
+		return StringBundler.concat(
+			StringPool.OPEN_PARENTHESIS, StringPool.AMPERSAND, filterString,
+			"(|(!(",
+			ExtendedObjectClassDefinition.Scope.COMPANY.getPropertyKey(),
+			"=*))(",
+			ExtendedObjectClassDefinition.Scope.COMPANY.getPropertyKey(),
+			"=0))(!(dxp.lxc.liferay.com.virtualInstanceId=*))(!(",
+			ExtendedObjectClassDefinition.Scope.GROUP.getPropertyKey(),
+			"=*))(!(siteExternalReferenceCode=*)))");
+	}
+
 	private String _getUnscopedPid(String pid) {
-		return pid.replaceFirst("\\.scoped.*", StringPool.BLANK);
+		pid = pid.replaceFirst("\\.scoped.*", StringPool.BLANK);
+
+		return pid.replaceFirst("~.*", StringPool.BLANK);
 	}
 
 	private BundleContext _bundleContext;

--- a/modules/apps/configuration-admin/configuration-admin-web/src/test/java/com/liferay/configuration/admin/web/internal/util/ConfigurationModelRetrieverImplTest.java
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/test/java/com/liferay/configuration/admin/web/internal/util/ConfigurationModelRetrieverImplTest.java
@@ -24,6 +24,7 @@ import org.osgi.service.cm.ConfigurationAdmin;
 
 /**
  * @author Raymond Augé
+ * @author Thiago Buarque
  */
 public class ConfigurationModelRetrieverImplTest {
 
@@ -202,35 +203,43 @@ public class ConfigurationModelRetrieverImplTest {
 			).put(
 				"groupId", "any"
 			).build());
-		_test(
-			false, pidFilterString,
-			HashMapBuilder.put(
-				key, pid + ".scoped"
-			).build());
 
-		key = ConfigurationAdmin.SERVICE_FACTORYPID;
-
-		pid = "foo~1234";
+		String factoryInstancePID = "foo~1234";
 
 		pidFilterString = _configurationModelRetrieverImpl.getPidFilterString(
-			pid, ExtendedObjectClassDefinition.Scope.SYSTEM);
+			factoryInstancePID, ExtendedObjectClassDefinition.Scope.SYSTEM);
 
 		_test(
 			true, pidFilterString,
 			HashMapBuilder.put(
-				key, pid
+				ConfigurationAdmin.SERVICE_FACTORYPID, pid
+			).put(
+				key, factoryInstancePID
+			).build());
+		_test(
+			true, pidFilterString,
+			HashMapBuilder.put(
+				ConfigurationAdmin.SERVICE_FACTORYPID, pid
+			).put(
+				key, factoryInstancePID
+			).put(
+				"companyId", "0"
 			).build());
 		_test(
 			false, pidFilterString,
 			HashMapBuilder.put(
-				key, pid
+				ConfigurationAdmin.SERVICE_FACTORYPID, pid
+			).put(
+				key, factoryInstancePID
 			).put(
 				"companyId", "any"
 			).build());
 		_test(
 			false, pidFilterString,
 			HashMapBuilder.put(
-				key, pid
+				ConfigurationAdmin.SERVICE_FACTORYPID, pid
+			).put(
+				key, factoryInstancePID
 			).put(
 				"groupId", "any"
 			).build());

--- a/modules/apps/portal-security/portal-security-ldap-api/src/main/java/com/liferay/portal/security/ldap/authenticator/configuration/LDAPAuthConfiguration.java
+++ b/modules/apps/portal-security/portal-security-ldap-api/src/main/java/com/liferay/portal/security/ldap/authenticator/configuration/LDAPAuthConfiguration.java
@@ -14,7 +14,8 @@ import com.liferay.portal.security.ldap.configuration.CompanyScopedConfiguration
  * @author Michael C. Han
  */
 @ExtendedObjectClassDefinition(
-	category = "ldap", scope = ExtendedObjectClassDefinition.Scope.COMPANY
+	category = "ldap", scope = ExtendedObjectClassDefinition.Scope.COMPANY,
+	visibilityControllerKey = "ldap-auth"
 )
 @Meta.OCD(
 	id = "com.liferay.portal.security.ldap.authenticator.configuration.LDAPAuthConfiguration",

--- a/modules/apps/portal-security/portal-security-ldap-api/src/main/java/com/liferay/portal/security/ldap/configuration/LDAPServerConfiguration.java
+++ b/modules/apps/portal-security/portal-security-ldap-api/src/main/java/com/liferay/portal/security/ldap/configuration/LDAPServerConfiguration.java
@@ -16,7 +16,8 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ExtendedObjectClassDefinition(
 	category = "ldap", factoryInstanceLabelAttribute = "ldapServerId",
-	scope = ExtendedObjectClassDefinition.Scope.COMPANY
+	scope = ExtendedObjectClassDefinition.Scope.COMPANY,
+	visibilityControllerKey = "ldap-server"
 )
 @Meta.OCD(
 	factory = true,

--- a/modules/apps/portal-security/portal-security-ldap-api/src/main/java/com/liferay/portal/security/ldap/exportimport/configuration/LDAPExportConfiguration.java
+++ b/modules/apps/portal-security/portal-security-ldap-api/src/main/java/com/liferay/portal/security/ldap/exportimport/configuration/LDAPExportConfiguration.java
@@ -14,7 +14,8 @@ import com.liferay.portal.security.ldap.configuration.CompanyScopedConfiguration
  * @author Michael C. Han
  */
 @ExtendedObjectClassDefinition(
-	category = "ldap", scope = ExtendedObjectClassDefinition.Scope.COMPANY
+	category = "ldap", scope = ExtendedObjectClassDefinition.Scope.COMPANY,
+	visibilityControllerKey = "ldap-export"
 )
 @Meta.OCD(
 	id = "com.liferay.portal.security.ldap.exportimport.configuration.LDAPExportConfiguration",

--- a/modules/apps/portal-security/portal-security-ldap-api/src/main/java/com/liferay/portal/security/ldap/exportimport/configuration/LDAPImportConfiguration.java
+++ b/modules/apps/portal-security/portal-security-ldap-api/src/main/java/com/liferay/portal/security/ldap/exportimport/configuration/LDAPImportConfiguration.java
@@ -14,7 +14,8 @@ import com.liferay.portal.security.ldap.configuration.CompanyScopedConfiguration
  * @author Michael C. Han
  */
 @ExtendedObjectClassDefinition(
-	category = "ldap", scope = ExtendedObjectClassDefinition.Scope.COMPANY
+	category = "ldap", scope = ExtendedObjectClassDefinition.Scope.COMPANY,
+	visibilityControllerKey = "ldap-import"
 )
 @Meta.OCD(
 	id = "com.liferay.portal.security.ldap.exportimport.configuration.LDAPImportConfiguration",

--- a/modules/apps/portal-security/portal-security-ldap-api/src/main/resources/com/liferay/portal/security/ldap/authenticator/configuration/packageinfo
+++ b/modules/apps/portal-security/portal-security-ldap-api/src/main/resources/com/liferay/portal/security/ldap/authenticator/configuration/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.2
+version 1.0.3

--- a/modules/apps/portal-security/portal-security-ldap-api/src/main/resources/com/liferay/portal/security/ldap/configuration/packageinfo
+++ b/modules/apps/portal-security/portal-security-ldap-api/src/main/resources/com/liferay/portal/security/ldap/configuration/packageinfo
@@ -1,1 +1,1 @@
-version 3.3.0
+version 3.3.1

--- a/modules/apps/portal-security/portal-security-ldap-api/src/main/resources/com/liferay/portal/security/ldap/exportimport/configuration/packageinfo
+++ b/modules/apps/portal-security/portal-security-ldap-api/src/main/resources/com/liferay/portal/security/ldap/exportimport/configuration/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.4
+version 1.0.5

--- a/modules/apps/portal-security/portal-security-ldap-impl/build.gradle
+++ b/modules/apps/portal-security/portal-security-ldap-impl/build.gradle
@@ -23,6 +23,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
+	compileOnly project(":apps:configuration-admin:configuration-admin-api")
 	compileOnly project(":apps:expando:expando-api")
 	compileOnly project(":apps:portal-configuration:portal-configuration-module-configuration-api")
 	compileOnly project(":apps:portal-security:portal-security-export-import-api")

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/authenticator/configuration/admin/display/LDAPAuthConfigurationVisibilityController.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/authenticator/configuration/admin/display/LDAPAuthConfigurationVisibilityController.java
@@ -1,0 +1,34 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.ldap.internal.authenticator.configuration.admin.display;
+
+import com.liferay.configuration.admin.display.ConfigurationVisibilityController;
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
+
+import java.io.Serializable;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Thiago Buarque
+ */
+@Component(service = ConfigurationVisibilityController.class)
+public class LDAPAuthConfigurationVisibilityController
+	implements ConfigurationVisibilityController {
+
+	@Override
+	public String getKey() {
+		return "ldap-auth";
+	}
+
+	@Override
+	public boolean isVisible(
+		ExtendedObjectClassDefinition.Scope scope, Serializable scopePK) {
+
+		return scope.equals(ExtendedObjectClassDefinition.Scope.SYSTEM);
+	}
+
+}

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/configuration/admin/display/LDAPServerConfigurationVisibilityController.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/configuration/admin/display/LDAPServerConfigurationVisibilityController.java
@@ -1,0 +1,34 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.ldap.internal.configuration.admin.display;
+
+import com.liferay.configuration.admin.display.ConfigurationVisibilityController;
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
+
+import java.io.Serializable;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Thiago Buarque
+ */
+@Component(service = ConfigurationVisibilityController.class)
+public class LDAPServerConfigurationVisibilityController
+	implements ConfigurationVisibilityController {
+
+	@Override
+	public String getKey() {
+		return "ldap-server";
+	}
+
+	@Override
+	public boolean isVisible(
+		ExtendedObjectClassDefinition.Scope scope, Serializable scopePK) {
+
+		return scope.equals(ExtendedObjectClassDefinition.Scope.SYSTEM);
+	}
+
+}

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/configuration/admin/display/LDAPExportConfigurationVisibilityController.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/configuration/admin/display/LDAPExportConfigurationVisibilityController.java
@@ -1,0 +1,34 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.ldap.internal.exportimport.configuration.admin.display;
+
+import com.liferay.configuration.admin.display.ConfigurationVisibilityController;
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
+
+import java.io.Serializable;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Thiago Buarque
+ */
+@Component(service = ConfigurationVisibilityController.class)
+public class LDAPExportConfigurationVisibilityController
+	implements ConfigurationVisibilityController {
+
+	@Override
+	public String getKey() {
+		return "ldap-export";
+	}
+
+	@Override
+	public boolean isVisible(
+		ExtendedObjectClassDefinition.Scope scope, Serializable scopePK) {
+
+		return scope.equals(ExtendedObjectClassDefinition.Scope.SYSTEM);
+	}
+
+}

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/configuration/admin/display/LDAPImportConfigurationVisibilityController.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/configuration/admin/display/LDAPImportConfigurationVisibilityController.java
@@ -1,0 +1,34 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.ldap.internal.exportimport.configuration.admin.display;
+
+import com.liferay.configuration.admin.display.ConfigurationVisibilityController;
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
+
+import java.io.Serializable;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Thiago Buarque
+ */
+@Component(service = ConfigurationVisibilityController.class)
+public class LDAPImportConfigurationVisibilityController
+	implements ConfigurationVisibilityController {
+
+	@Override
+	public String getKey() {
+		return "ldap-import";
+	}
+
+	@Override
+	public boolean isVisible(
+		ExtendedObjectClassDefinition.Scope scope, Serializable scopePK) {
+
+		return scope.equals(ExtendedObjectClassDefinition.Scope.SYSTEM);
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-59680
https://liferay.atlassian.net/browse/LPD-59758

I am fixing two tickets here, both caused by https://liferay.atlassian.net/browse/LPD-58514 ([see this comment for context](https://liferay.atlassian.net/browse/LPD-58514?focusedCommentId=2955186))

# Context

I'll give some context that might help you understand my decisions in code.

## Non-factory configurations

Consider a configuration with pid `com.foo.BarConfiguration`. That configuration is scoped to system and instance with auto-generated UI.

If I go to system scope and save that configuration, I'll get something like this
```properties
:org.apache.felix.configadmin.revision:=L"1"
enabledFoo=B"false"
service.bundleLocation="?"
service.pid="com.foo.BarConfiguration"
```

If I go to the instance scope and save the configuration, I'll get something like this
```properties
:org.apache.felix.configadmin.revision:=L"1"
companyId=L"1234"
enabledFoo=B"false"
service.bundleLocation="?"
service.factoryPid="com.foo.BarConfiguration.scoped"
service.pid="com.foo.BarConfiguration.scoped~35268262-fb19-418e-9839-bb942641ef89"
```
Although it's not actually a configuration factory instance, it is saved as such.

---
## Factory configurations

Consider a factory configuration with pid `com.foo.BarFactoryConfiguration`. That configuration is scoped to system and instance with auto-generated UI.

If I go to system scope and save that configuration, I'll get something like this
```properties
:org.apache.felix.configadmin.revision:=L"1"
configuration.cleaner.ignore="true"
enabled=B"true"
service.bundleLocation="?"
service.factoryPid="com.foo.BarFactoryConfiguration"
service.pid="com.foo.BarFactoryConfiguration~e21ab273-e845-4a26-8523-005aa2f20926"
```

If I go to the instance scope and save the configuration, I'll get something like this
```properties
:org.apache.felix.configadmin.revision:=L"1"
companyId=L"1234"
configuration.cleaner.ignore="true"
enabled=B"true"
service.bundleLocation="?"
service.factoryPid="com.foo.BarFactoryConfiguration.scoped"
service.pid="com.foo.BarFactoryConfiguration.scoped~7ac934d7-a9a8-43d9-be60-ce6a12893a5f"
```
There were times that such configuration in the instance scope would be saved without the `.scoped`:

```properties
:org.apache.felix.configadmin.revision:=L"1"
companyId=L"1234"
configuration.cleaner.ignore="true"
enabled=B"true"
service.bundleLocation="?"
service.factoryPid="com.foo.BarFactoryConfiguration"
service.pid="com.foo.BarFactoryConfiguration~7ac934d7-a9a8-43d9-be60-ce6a12893a5f"
```

That is the reason why we have retro-compatibility in our filter string

```java
String factoryPIDFilterString = StringBundler.concat(
  StringPool.OPEN_PARENTHESIS, StringPool.PIPE,
    _getPropertyFilterString(
      ConfigurationAdmin.SERVICE_FACTORYPID, unscopedPId),
    _getPropertyFilterString(
      ConfigurationAdmin.SERVICE_FACTORYPID, unscopedPId + ".scoped"),
  StringPool.CLOSE_PARENTHESIS);
```

## Regarding https://liferay.atlassian.net/browse/LPD-59680

System factory instances have id `<pid>~1234` while company factory instances have `<pid>.scoped~1234`. The method `_getUnscopedPid` in `ConfigurationModelRetrieverImpl` was not considering that scenario. Compare the two system scoped examples I gave in the `context` section above.

## Regarding https://liferay.atlassian.net/browse/LPD-59758

The LDAP framework uses its [own configuration provider](https://github.com/liferay/liferay-portal/blob/6ce0b9eb049e99a50285a324a3bd4afd76d340ab/modules/apps/portal-security/portal-security-ldap-api/src/main/java/com/liferay/portal/security/ldap/configuration/CompanyScopedConfigurationProvider.java#L33) to manage LDAP-related configurations.

LDAP configurations are saved with the `companyId` parameter **_even if the configuration is system scoped_**.

Our system string filter filters out configurations that have any value for the `companyId` attribute. **_In this PR I am allowing `companyId=0` until the AppSec team migrate their code to use the configuration framework and remove the companyId=0 from the system configurations._** This will be handled by @manuelecastro.

cc: @caio-farias

