### PR TITLE
LPD-65856 - Support 8-digit Hex Values in Style Book Editor and Page Editor

### DIFF
--- a/modules/apps/layout/layout-js-components-web/src/main/resources/META-INF/resources/js/components/color_picker/ColorPicker.tsx
+++ b/modules/apps/layout/layout-js-components-web/src/main/resources/META-INF/resources/js/components/color_picker/ColorPicker.tsx
@@ -314,8 +314,7 @@ export default function ColorPicker({
 									className: 'cadmin',
 								}}
 								onActiveChange={setActiveColorPicker}
-								onColorsChange={setCustomColors}
-								onValueChange={(color) => {
+								onChange={(color: String) => {
 									debouncedOnValueSelect(
 										field.name,
 										`#${color}`
@@ -330,6 +329,7 @@ export default function ColorPicker({
 										deleteStyleError(field.name);
 									}
 								}}
+								onColorsChange={setCustomColors}
 								showHex={false}
 								showPalette={false}
 								value={

--- a/modules/apps/layout/layout-js-components-web/src/main/resources/META-INF/resources/js/utils/getValidHexColor.ts
+++ b/modules/apps/layout/layout-js-components-web/src/main/resources/META-INF/resources/js/utils/getValidHexColor.ts
@@ -3,16 +3,22 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-const MAX_HEX_LENGTH = 6;
-const REGEX_HEX = /^([0-9A-F]{3}){1,2}$/i;
+const HEX_LENGTH_6 = 6;
+const MAX_HEX_LENGTH = 8;
+const REGEX_HEX = /^([0-9A-F]{3}|[0-9A-F]{4}|[0-9A-F]{6}|[0-9A-F]{8})$/i;
 
 export default function getValidHexColor(value: string) {
-	const hexColor = value.replace('#', '').substring(0, MAX_HEX_LENGTH);
+	let hexColor = value.replace('#', '').substring(0, MAX_HEX_LENGTH);
+
+	if (hexColor.length === 7) {
+		hexColor = hexColor.substring(0, HEX_LENGTH_6);
+	}
+
 	const isValid = REGEX_HEX.test(hexColor);
 
 	if (isValid) {
 		return `#${
-			value.length < MAX_HEX_LENGTH
+			value.length < HEX_LENGTH_6
 				? hexColor
 						.split('')
 						.map((hex) => hex + hex)

--- a/modules/apps/layout/layout-js-components-web/test/components/color_picker/ColorPicker.test.tsx
+++ b/modules/apps/layout/layout-js-components-web/test/components/color_picker/ColorPicker.test.tsx
@@ -239,15 +239,37 @@ describe('ColorPicker', () => {
 			expect(input).toHaveValue('#444444');
 		});
 
-		it('takes a 6-digit hexcolor even if the input value has more digits', async () => {
+		it('takes a 6-digit hexcolor if the input value has 7 digits', async () => {
 			const {baseElement} = renderColorPicker({
 				value: '#444444',
 			});
 			const input = baseElement.querySelector('input')!;
 
+			await onTypeValue(input, '#123456A');
+
+			expect(input).toHaveValue('#123456');
+		});
+
+		it('takes an 8-digit hexcolor', async () => {
+			const {baseElement} = renderColorPicker({
+				value: '#44444444',
+			});
+			const input = baseElement.querySelector('input')!;
+
+			await onTypeValue(input, '#AABBCCDD');
+
+			expect(input).toHaveValue('#AABBCCDD');
+		});
+
+		it('takes an 8-digit hexcolor even if the input value has more digits', async () => {
+			const {baseElement} = renderColorPicker({
+				value: '#44444444',
+			});
+			const input = baseElement.querySelector('input')!;
+
 			await onTypeValue(input, '#55555555555');
 
-			expect(input).toHaveValue('#555555');
+			expect(input).toHaveValue('#55555555');
 		});
 
 		it('converts the 3-digit hexcolor to a 6-digit hexcolor', async () => {
@@ -259,6 +281,17 @@ describe('ColorPicker', () => {
 			await onTypeValue(input, '#abc');
 
 			expect(input).toHaveValue('#AABBCC');
+		});
+
+		it('converts the 4-digit hexcolor to an 8-digit hexcolor', async () => {
+			const {baseElement} = renderColorPicker({
+				value: '#444444',
+			});
+			const input = baseElement.querySelector('input')!;
+
+			await onTypeValue(input, '#abcd');
+
+			expect(input).toHaveValue('#AABBCCDD');
 		});
 
 		describe('Input errors', () => {


### PR DESCRIPTION
[Support 8-digit Hex Values in Style Book Editor](https://liferay.atlassian.net/browse/LPD-65856)

This updates the getValidHexColors function to allow for 8 digit hex values. This also adds the behavior that if a 7 digit value is added it removes the seventh digit so that it will be a valid 6 digit hex color.