### PR TITLE
LPD-66342 - Remove unneeded dropdown height limit

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/css/components/AssetTypeInfoPanel.scss
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/css/components/AssetTypeInfoPanel.scss
@@ -90,7 +90,3 @@
 		font-size: 0.875rem;
 	}
 }
-
-.dropdown-menu.show ul {
-	max-height: 15rem;
-}


### PR DESCRIPTION
In autocomplete component, the [dropdown-menu](url) can contain the complementary class `autocomplete-dropdown-menu`, that already adds a limit of 10rem height. this is the correct way to add a dropdown customization, not by adding global style overwriting.

If we need an extra customization on this it should be done in Clay, so please just ask for it if needed, we will be happy to add it if make sense.

cc @monaco-fabio