### PR TITLE
LPD-64513 - Add icons to the vertical navigation in the CMS.

### DIFF
--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/util/configuration/FragmentEntryMenuDisplayConfiguration.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/util/configuration/FragmentEntryMenuDisplayConfiguration.java
@@ -5,6 +5,7 @@
 
 package com.liferay.fragment.util.configuration;
 
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONException;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
@@ -32,10 +33,15 @@ public class FragmentEntryMenuDisplayConfiguration {
 				source = ContextualMenu.parse(
 					jsonObject.getString("contextualMenu"));
 			}
-			else if (jsonObject.has("siteNavigationMenuId")) {
+			else if (jsonObject.has("siteNavigationMenuId") ||
+					 jsonObject.has(
+						 "siteNavigationMenuExternalReferenceCode")) {
+
 				source = new SiteNavigationMenuSource(
 					jsonObject.getLong("parentSiteNavigationMenuItemId"),
 					jsonObject.getBoolean("privateLayout"),
+					jsonObject.getString(
+						"siteNavigationMenuExternalReferenceCode"),
 					jsonObject.getLong("siteNavigationMenuId"));
 			}
 		}
@@ -109,6 +115,18 @@ public class FragmentEntryMenuDisplayConfiguration {
 		return "select";
 	}
 
+	public String getSiteNavigationMenuExternalReferenceCode() {
+		if (_source instanceof SiteNavigationMenuSource) {
+			SiteNavigationMenuSource siteNavigationMenuSource =
+				(SiteNavigationMenuSource)_source;
+
+			return siteNavigationMenuSource.
+				getSiteNavigationMenuExternalReferenceCode();
+		}
+
+		return StringPool.BLANK;
+	}
+
 	public long getSiteNavigationMenuId() {
 		if (_source instanceof SiteNavigationMenuSource) {
 			SiteNavigationMenuSource siteNavigationMenuSource =
@@ -147,15 +165,22 @@ public class FragmentEntryMenuDisplayConfiguration {
 
 		public SiteNavigationMenuSource(
 			long parentSiteNavigationMenuItemId, boolean privateLayout,
+			String siteNavigationMenuExternalReferenceCode,
 			long siteNavigationMenuId) {
 
 			_parentSiteNavigationMenuItemId = parentSiteNavigationMenuItemId;
 			_privateLayout = privateLayout;
+			_siteNavigationMenuExternalReferenceCode =
+				siteNavigationMenuExternalReferenceCode;
 			_siteNavigationMenuId = siteNavigationMenuId;
 		}
 
 		public long getParentSiteNavigationMenuItemId() {
 			return _parentSiteNavigationMenuItemId;
+		}
+
+		public String getSiteNavigationMenuExternalReferenceCode() {
+			return _siteNavigationMenuExternalReferenceCode;
 		}
 
 		public long getSiteNavigationMenuId() {
@@ -168,6 +193,7 @@ public class FragmentEntryMenuDisplayConfiguration {
 
 		private final long _parentSiteNavigationMenuItemId;
 		private final boolean _privateLayout;
+		private final String _siteNavigationMenuExternalReferenceCode;
 		private final long _siteNavigationMenuId;
 
 	}

--- a/modules/apps/fragment/fragment-impl/build.gradle
+++ b/modules/apps/fragment/fragment-impl/build.gradle
@@ -38,6 +38,7 @@ dependencies {
 	compileOnly project(":apps:ratings:ratings-taglib")
 	compileOnly project(":apps:saved-content:saved-content-taglib")
 	compileOnly project(":apps:segments:segments-api")
+	compileOnly project(":apps:site-navigation:site-navigation-api")
 	compileOnly project(":apps:site-navigation:site-navigation-taglib")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	compileOnly project(":apps:translation:translation-api")

--- a/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/util/configuration/FragmentEntryConfigurationParserImpl.java
+++ b/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/util/configuration/FragmentEntryConfigurationParserImpl.java
@@ -47,6 +47,8 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.site.navigation.model.SiteNavigationMenu;
+import com.liferay.site.navigation.service.SiteNavigationMenuLocalService;
 import com.liferay.site.navigation.taglib.servlet.taglib.util.NavItemUtil;
 
 import java.util.ArrayList;
@@ -754,13 +756,35 @@ public class FragmentEntryConfigurationParserImpl
 			fragmentEntryMenuDisplayConfiguration =
 				new FragmentEntryMenuDisplayConfiguration(value);
 
+		long siteNavigationMenuId =
+			fragmentEntryMenuDisplayConfiguration.getSiteNavigationMenuId();
+
+		if (siteNavigationMenuId <= 0) {
+			String siteNavigationMenuExternalReferenceCode =
+				fragmentEntryMenuDisplayConfiguration.
+					getSiteNavigationMenuExternalReferenceCode();
+
+			if (Validator.isNotNull(siteNavigationMenuExternalReferenceCode)) {
+				SiteNavigationMenu siteNavigationMenu =
+					_siteNavigationMenuLocalService.
+						fetchSiteNavigationMenuByExternalReferenceCode(
+							siteNavigationMenuExternalReferenceCode,
+							serviceContext.getScopeGroupId());
+
+				if (siteNavigationMenu != null) {
+					siteNavigationMenuId =
+						siteNavigationMenu.getSiteNavigationMenuId();
+				}
+			}
+		}
+
 		return NavItemUtil.getNavigationMenuContext(
 			1, "auto", serviceContext.getRequest(),
 			fragmentEntryMenuDisplayConfiguration.getNavigationMenuMode(),
 			false, fragmentEntryMenuDisplayConfiguration.getRootItemId(),
 			fragmentEntryMenuDisplayConfiguration.getRootItemLevel(),
 			fragmentEntryMenuDisplayConfiguration.getRootItemType(),
-			fragmentEntryMenuDisplayConfiguration.getSiteNavigationMenuId());
+			siteNavigationMenuId);
 	}
 
 	private Object _getURLValue(String value) {
@@ -904,5 +928,8 @@ public class FragmentEntryConfigurationParserImpl
 
 	@Reference
 	private Portal _portal;
+
+	@Reference
+	private SiteNavigationMenuLocalService _siteNavigationMenuLocalService;
 
 }

--- a/modules/apps/fragment/fragment-renderer-menu-display-impl/build.gradle
+++ b/modules/apps/fragment/fragment-renderer-menu-display-impl/build.gradle
@@ -7,6 +7,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")
 	compileOnly project(":apps:fragment:fragment-api")
+	compileOnly project(":apps:site-navigation:site-navigation-api")
 	compileOnly project(":apps:site-navigation:site-navigation-taglib")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	compileOnly project(":core:petra:petra-string")

--- a/modules/apps/fragment/fragment-renderer-menu-display-impl/src/main/java/com/liferay/fragment/renderer/menu/display/internal/MenuDisplayFragmentRenderer.java
+++ b/modules/apps/fragment/fragment-renderer-menu-display-impl/src/main/java/com/liferay/fragment/renderer/menu/display/internal/MenuDisplayFragmentRenderer.java
@@ -29,7 +29,10 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.site.navigation.model.SiteNavigationMenu;
+import com.liferay.site.navigation.service.SiteNavigationMenuLocalService;
 import com.liferay.site.navigation.taglib.servlet.taglib.NavigationMenuTag;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -121,7 +124,8 @@ public class MenuDisplayFragmentRenderer implements FragmentRenderer {
 					WebKeys.THEME_DISPLAY);
 
 			NavigationMenuTag navigationMenuTag = _getNavigationMenuTag(
-				themeDisplay.getCompanyId(), configurationJSONObject,
+				themeDisplay.getCompanyId(), themeDisplay.getScopeGroupId(),
+				configurationJSONObject,
 				fragmentEntryLink.getEditableValuesJSONObject());
 
 			navigationMenuTag.doTag(httpServletRequest, httpServletResponse);
@@ -134,7 +138,7 @@ public class MenuDisplayFragmentRenderer implements FragmentRenderer {
 	}
 
 	private NavigationMenuTag _getNavigationMenuTag(
-			long companyId, JSONObject configurationJSONObject,
+			long companyId, long groupId, JSONObject configurationJSONObject,
 			JSONObject editableValuesJSONObject)
 		throws PortalException {
 
@@ -176,8 +180,27 @@ public class MenuDisplayFragmentRenderer implements FragmentRenderer {
 			fragmentEntryMenuDisplayConfiguration.getRootItemLevel());
 		navigationMenuTag.setRootItemType(
 			fragmentEntryMenuDisplayConfiguration.getRootItemType());
-		navigationMenuTag.setSiteNavigationMenuId(
-			fragmentEntryMenuDisplayConfiguration.getSiteNavigationMenuId());
+
+		long siteNavigationMenuId =
+			fragmentEntryMenuDisplayConfiguration.getSiteNavigationMenuId();
+
+		if (siteNavigationMenuId <= 0) {
+			String siteNavigationMenuExternalReferenceCode =
+				fragmentEntryMenuDisplayConfiguration.
+					getSiteNavigationMenuExternalReferenceCode();
+
+			if (Validator.isNotNull(siteNavigationMenuExternalReferenceCode)) {
+				SiteNavigationMenu siteNavigationMenu =
+					_siteNavigationMenuLocalService.
+						fetchSiteNavigationMenuByExternalReferenceCode(
+							siteNavigationMenuExternalReferenceCode, groupId);
+
+				siteNavigationMenuId =
+					siteNavigationMenu.getSiteNavigationMenuId();
+			}
+		}
+
+		navigationMenuTag.setSiteNavigationMenuId(siteNavigationMenuId);
 
 		return navigationMenuTag;
 	}
@@ -250,5 +273,8 @@ public class MenuDisplayFragmentRenderer implements FragmentRenderer {
 
 	@Reference
 	private Portal _portal;
+
+	@Reference
+	private SiteNavigationMenuLocalService _siteNavigationMenuLocalService;
 
 }

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/item_selector_value/itemSelectorValueToSiteNavigationMenuItem.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/item_selector_value/itemSelectorValueToSiteNavigationMenuItem.js
@@ -11,6 +11,7 @@ export default function itemSelectorValueToSiteNavigationMenuItem(
 		parentSiteNavigationMenuItemId,
 		privateLayout,
 		returnType,
+		siteNavigationMenuExternalReferenceCode,
 		siteNavigationMenuId,
 		title,
 	} = siteNavigationMenuItem;
@@ -19,6 +20,7 @@ export default function itemSelectorValueToSiteNavigationMenuItem(
 		contextualMenu,
 		parentSiteNavigationMenuItemId,
 		privateLayout,
+		siteNavigationMenuExternalReferenceCode,
 		siteNavigationMenuId,
 		title,
 		type: returnType,

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/fragments/group/cms/fragments/vertical-navigation/index.html
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/fragments/group/cms/fragments/vertical-navigation/index.html
@@ -97,7 +97,7 @@
 			</li>
 
 			[#assign
-				navItemsJSONArray = navItemsJSONArray + '"icon": "${(navItem.getIcon??)?then(navItem.getIcon(), "")}", "id": "${navItem.getLayoutId()}", "label": "${navItem.getName()}"}'
+				navItemsJSONArray = navItemsJSONArray + '"icon": "${(navItem.getDisplayIcon??)?then(navItem.getDisplayIcon(), "")}", "id": "${navItem.getLayoutId()}", "label": "${navItem.getName()}"}'
 			/]
 
 			[#if navItem?has_next]
@@ -111,7 +111,7 @@
 
 [#macro labelWithIcon navItem]
 	<div class="autofit-row">
-		[#assign icon = (navItem.getIcon??)?then(navItem.getIcon(), "") /]
+		[#assign icon = (navItem.getDisplayIcon??)?then(navItem.getDisplayIcon(), "") /]
 
 		[#if icon?length > 0]
 			<div class="autofit-col">

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layout-page-templates/master-pages/cms-master/page-definition.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layout-page-templates/master-pages/cms-master/page-definition.json
@@ -118,7 +118,7 @@
 										"displayStyle": "stacked",
 										"hoveredItemColor": "",
 										"selectedItemColor": "",
-										"source": "",
+										"source": "{\"parentSiteNavigationMenuItemId\": \"0\", \"privateLayout\": \"false\", \"siteNavigationMenuExternalReferenceCode\": \"CMSPRIMARYNAVIGATION\", \"title\": \"CMS Primary Navigation\", \"type\": \"class com.liferay.site.navigation.item.selector.SiteNavigationMenuItemSelectorReturnType\"}",
 										"sublevels": "-1"
 									},
 									"fragmentFields": [

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layout-page-templates/master-pages/cms-space-master/page-definition.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layout-page-templates/master-pages/cms-space-master/page-definition.json
@@ -118,7 +118,7 @@
 										"displayStyle": "stacked",
 										"hoveredItemColor": "",
 										"selectedItemColor": "",
-										"source": "",
+										"source": "{\"parentSiteNavigationMenuItemId\": \"0\", \"privateLayout\": \"false\", \"siteNavigationMenuExternalReferenceCode\": \"CMSPRIMARYNAVIGATION\", \"title\": \"CMS Primary Navigation\", \"type\": \"class com.liferay.site.navigation.item.selector.SiteNavigationMenuItemSelectorReturnType\"}",
 										"sublevels": "-1"
 									},
 									"fragmentFields": [

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/site-navigation-menus.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/site-navigation-menus.json
@@ -1,0 +1,89 @@
+[
+	{
+		"externalReferenceCode": "CMSPRIMARYNAVIGATION",
+		"menuItems": [
+			{
+				"displayIcon": "home",
+				"externalReferenceCode": "CMSPRIMARYNAVIGATION1",
+				"friendlyURL": "/home",
+				"privateLayout": false,
+				"type": "layout"
+			},
+			{
+				"displayIcon": "analytics",
+				"externalReferenceCode": "CMSPRIMARYNAVIGATION2",
+				"friendlyURL": "/dashboard",
+				"privateLayout": false,
+				"type": "layout"
+			},
+			{
+				"externalReferenceCode": "CMSPRIMARYNAVIGATION3",
+				"menuItems": [
+					{
+						"displayIcon": "sheets",
+						"externalReferenceCode": "CMSPRIMARYNAVIGATION4",
+						"friendlyURL": "/all",
+						"privateLayout": false,
+						"type": "layout"
+					},
+					{
+						"displayIcon": "catalog",
+						"externalReferenceCode": "CMSPRIMARYNAVIGATION5",
+						"friendlyURL": "/contents",
+						"privateLayout": false,
+						"type": "layout"
+					},
+					{
+						"displayIcon": "documents-and-media",
+						"externalReferenceCode": "CMSPRIMARYNAVIGATION6",
+						"friendlyURL": "/files",
+						"privateLayout": false,
+						"type": "layout"
+					}
+				],
+				"name_i18n": {
+					"en_US": "Assets"
+				},
+				"type": "node"
+			},
+			{
+				"displayIcon": "users",
+				"externalReferenceCode": "CMSPRIMARYNAVIGATION7",
+				"friendlyURL": "/shared-with-me",
+				"privateLayout": false,
+				"type": "layout"
+			},
+			{
+				"externalReferenceCode": "CMSPRIMARYNAVIGATION8",
+				"menuItems": [
+					{
+						"displayIcon": "edit-layout",
+						"externalReferenceCode": "CMSPRIMARYNAVIGATION9",
+						"friendlyURL": "/structures",
+						"privateLayout": false,
+						"type": "layout"
+					},
+					{
+						"displayIcon": "vocabulary",
+						"externalReferenceCode": "CMSPRIMARYNAVIGATION10",
+						"friendlyURL": "/categorization",
+						"privateLayout": false,
+						"type": "layout"
+					},
+					{
+						"displayIcon": "trash",
+						"externalReferenceCode": "CMSPRIMARYNAVIGATION11",
+						"friendlyURL": "/recycle-bin",
+						"privateLayout": false,
+						"type": "layout"
+					}
+				],
+				"name_i18n": {
+					"en_US": "Admin"
+				},
+				"type": "node"
+			}
+		],
+		"name": "CMS Primary Navigation"
+	}
+]

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test-bundle-1/src/main/resources/site-initializer/site-navigation-menus.json
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test-bundle-1/src/main/resources/site-initializer/site-navigation-menus.json
@@ -3,6 +3,7 @@
 		"externalReferenceCode": "SITENAVIGATIONMENU1",
 		"menuItems": [
 			{
+				"displayIcon": "home",
 				"externalReferenceCode": "TESTSITENAVIGATIONMENUITEM1",
 				"friendlyURL": "/test-public-layout",
 				"privateLayout": false,

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test/src/testIntegration/java/com/liferay/site/initializer/extender/internal/test/BundleSiteInitializerTest.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test/src/testIntegration/java/com/liferay/site/initializer/extender/internal/test/BundleSiteInitializerTest.java
@@ -188,6 +188,7 @@ import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
@@ -1737,6 +1738,22 @@ public class BundleSiteInitializerTest {
 			0.1, expandoBridge.getAttribute("Test Expando Column 1"));
 		Assert.assertEquals(
 			"Test Value", expandoBridge.getAttribute("Test Expando Column 2"));
+	}
+
+	private void _assertNavigationItemDisplayIcon() throws Exception {
+		SiteNavigationMenuItem siteNavigationMenuItem =
+			_siteNavigationMenuItemLocalService.
+				fetchSiteNavigationMenuItemByExternalReferenceCode(
+					"TESTSITENAVIGATIONMENUITEM1", _group.getGroupId());
+
+
+		UnicodeProperties unicodeProperties = UnicodePropertiesBuilder.fastLoad(
+			siteNavigationMenuItem.getTypeSettings()
+		).build();
+
+		String displayIcon = unicodeProperties.getProperty("displayIcon", StringPool.BLANK);
+
+		Assert.assertEquals("home", displayIcon);
 	}
 
 	private void _assertExpandoValues2() throws Exception {
@@ -4524,6 +4541,7 @@ public class BundleSiteInitializerTest {
 		_assertLayouts1();
 		_assertLayoutUtilityPageEntries();
 		_assertListTypeDefinitions1();
+		_assertNavigationItemDisplayIcon();
 		_assertNotificationTemplate1();
 		_assertObjectDefinitions1();
 		_assertObjectFolders1();

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
@@ -4012,6 +4012,16 @@ public class BundleSiteInitializer implements SiteInitializer {
 				).buildString();
 			}
 
+			String displayIcon = menuItemJSONObject.getString("displayIcon");
+
+			if (Validator.isNotNull(displayIcon)) {
+				typeSettings = UnicodePropertiesBuilder.load(
+					typeSettings
+				).put(
+					"displayIcon", displayIcon
+				).buildString();
+			}
+
 			SiteNavigationMenuItem siteNavigationMenuItem =
 				_siteNavigationMenuItemLocalService.
 					addOrUpdateSiteNavigationMenuItem(

--- a/modules/apps/site-navigation/site-navigation-item-selector-web/src/main/java/com/liferay/site/navigation/item/selector/web/internal/display/context/SelectSiteNavigationMenuDisplayContext.java
+++ b/modules/apps/site-navigation/site-navigation-item-selector-web/src/main/java/com/liferay/site/navigation/item/selector/web/internal/display/context/SelectSiteNavigationMenuDisplayContext.java
@@ -169,6 +169,23 @@ public class SelectSiteNavigationMenuDisplayContext {
 		return portletURL.toString();
 	}
 
+	public String getSiteNavigationMenuExternalReferenceCode() {
+		if (_siteNavigationMenuExternalReferenceCode != null) {
+			return _siteNavigationMenuExternalReferenceCode;
+		}
+
+		SiteNavigationMenu siteNavigationMenu =
+			SiteNavigationMenuLocalServiceUtil.fetchSiteNavigationMenu(
+				getSiteNavigationMenuId());
+
+		if (siteNavigationMenu != null) {
+			_siteNavigationMenuExternalReferenceCode =
+				siteNavigationMenu.getExternalReferenceCode();
+		}
+
+		return _siteNavigationMenuExternalReferenceCode;
+	}
+
 	public long getSiteNavigationMenuId() {
 		if (_siteNavigationMenuId != null) {
 			return _siteNavigationMenuId;
@@ -535,6 +552,7 @@ public class SelectSiteNavigationMenuDisplayContext {
 	private Long _parentSiteNavigationMenuItemId;
 	private final PortletURL _portletURL;
 	private Boolean _privateLayout;
+	private String _siteNavigationMenuExternalReferenceCode;
 	private Long _siteNavigationMenuId;
 	private final SiteNavigationMenuItemTypeRegistry
 		_siteNavigationMenuItemTypeRegistry;

--- a/modules/apps/site-navigation/site-navigation-item-selector-web/src/main/resources/META-INF/resources/select_site_navigation_menu_level.jsp
+++ b/modules/apps/site-navigation/site-navigation-item-selector-web/src/main/resources/META-INF/resources/select_site_navigation_menu_level.jsp
@@ -26,6 +26,7 @@ SelectSiteNavigationMenuDisplayContext selectSiteNavigationMenuDisplayContext = 
 			cssClass="site-navigation-menu-selector"
 			data-parent-site-navigation-menu-item-id="<%= selectSiteNavigationMenuDisplayContext.getParentSiteNavigationMenuItemId() %>"
 			data-private-layout="<%= selectSiteNavigationMenuDisplayContext.isPrivateLayout() %>"
+			data-site-navigation-menu-external-reference-code="<%= selectSiteNavigationMenuDisplayContext.getSiteNavigationMenuExternalReferenceCode() %>"
 			data-site-navigation-menu-id="<%= selectSiteNavigationMenuDisplayContext.getSiteNavigationMenuId() %>"
 			data-title="<%= selectSiteNavigationMenuDisplayContext.getCurrentLevelTitle() %>"
 			displayType="primary"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-64513

In order to add icons to the vertical nav in the CMS we have to switch to using a navigation menu rather than the default public pages menu. Icons can only be added using a navigation menu. Additionally we needed to update the site initializer framework to include importing display icons for navigation menus.

We then ran into a problem that when using the MenuDisplay configuration type it was not referencing navigation menus by an external reference code. This needed to be updated in order to connect the fragment configuration on page definition with the navigation menu included in the site initializer.

The result is the following:

<img width="432" height="839" alt="Screenshot 2025-09-24 at 5 59 27 PM" src="https://github.com/user-attachments/assets/934cae8f-a965-4413-9691-ca85e1a0a7f1" />
