### PR TITLE
LPD-85631 Use headless-admin-site API in SitesSelector

### DIFF
--- a/modules/apps/design-library/design-library-web/src/main/resources/META-INF/resources/js/components/sites/SitesSelector.tsx
+++ b/modules/apps/design-library/design-library-web/src/main/resources/META-INF/resources/js/components/sites/SitesSelector.tsx
@@ -49,7 +49,7 @@ export default function SitesSelector({
 					</label>
 
 					<ItemSelector
-						apiURL={`${location.origin}/o/headless-site/v1.0/sites?active=true`}
+						apiURL={`${location.origin}/o/headless-admin-site/v1.0/sites?active=true`}
 						id="siteSelector"
 						items={site ? [site] : []}
 						onItemsChange={(items: Site[]) => {


### PR DESCRIPTION
# What is this trying to solve?
   https://liferay.atlassian.net/browse/LPD-85631

   # How am I fixing it?
Updated `SitesSelector.tsx` in `design-library-web` to use the current `headless-admin-site` API instead of the legacy and deprecated `headless-site` API.

   NOTE: The 'Can connect and disconnect a site from a design library' Playwright test is currently non-functional in the CI/local environment due to other issues, but the changes were verified via manual testing.

   # How can you verify that it works?
   Manual Verification:
   1. Navigate to Design Libraries and open the "Connected Sites" dialog.
   2. Search for a site and verify the results appear.
   3. Verify via Network tab that `/o/headless-admin-site/v1.0/sites` is called.

   Automated Verification (if environment allows):
   In `modules/test/playwright`, run:
   `npm run playwright -- test modules/test/playwright/tests/design-library-web/main/designLibrary.spec.ts -g "Can connect and disconnect a site from a design library"`
