### PR TITLE
LPD-85675 Missing icons in Panel Apps

### DIFF
--- a/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/application/list/BatchPlannerPanelApp.java
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/application/list/BatchPlannerPanelApp.java
@@ -31,6 +31,11 @@ import org.osgi.service.component.annotations.Reference;
 public class BatchPlannerPanelApp extends BasePanelApp {
 
 	@Override
+	public String getIcon() {
+		return "database";
+	}
+
+	@Override
 	public Portlet getPortlet() {
 		return _portlet;
 	}

--- a/modules/apps/commerce/commerce-order-web/src/main/java/com/liferay/commerce/order/web/internal/application/list/CommerceReturnPanelApp.java
+++ b/modules/apps/commerce/commerce-order-web/src/main/java/com/liferay/commerce/order/web/internal/application/list/CommerceReturnPanelApp.java
@@ -31,6 +31,11 @@ import org.osgi.service.component.annotations.Reference;
 public class CommerceReturnPanelApp extends BasePanelApp {
 
 	@Override
+	public String getIcon() {
+		return "redo";
+	}
+
+	@Override
 	public Portlet getPortlet() {
 		return _portlet;
 	}


### PR DESCRIPTION
Link to issue: https://liferay.atlassian.net/browse/LPD-85675 - Missing icons in Commerce Home (Returns) and Applications Home (Data Migration Centre)

### Commerce - Returns (FF LPD-10562) 

<img width="1708" height="848" alt="Screenshot 2026-04-09 at 14 47 52" src="https://github.com/user-attachments/assets/5686b8f3-1222-4fd6-ba4b-26034e05b3f8" />


### Applications - Data Migration Center (FF COMMERCE-8087)
<img width="1709" height="875" alt="Screenshot 2026-04-09 at 14 47 37" src="https://github.com/user-attachments/assets/6166beb7-6112-4480-80fc-83266a414817" />


No tests are needed for this. 