### PR TITLE
LPD-85711 Enable opt-in search functionality in Picker component

### DIFF
--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/docs/picker.mdx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/docs/picker.mdx
@@ -402,3 +402,85 @@ Native select for mobile devices offers a better experience compared to Picker i
 	</Picker>
 </Form.Group>
 ```
+
+## Search
+
+The Picker component supports searching within the panel to filter options. This feature is fully opt-in and can be enabled explicitly using the `searchable` prop or automatically based on a threshold of items using the `searchableThreshold` prop.
+
+If neither `searchable` nor `searchableThreshold` are provided, the search input will not be rendered.
+
+```jsx preview
+import {Provider, Option, Picker} from '@clayui/core';
+import {useId} from '@clayui/shared';
+import Form from '@clayui/form';
+import React from 'react';
+
+import '@clayui/css/lib/css/atlas.css';
+
+export default function App() {
+	const pickerId1 = useId();
+	const labelId1 = useId();
+	const pickerId2 = useId();
+	const labelId2 = useId();
+
+	return (
+		<Provider spritemap="/public/icons.svg">
+			<div className="p-4">
+				<div style={{display: 'flex', gap: '20px'}}>
+					<div style={{width: '200px'}}>
+						<Form.Group>
+							<label htmlFor={pickerId1} id={labelId1}>
+								Searchable
+							</label>
+							<Picker
+								aria-labelledby={labelId1}
+								id={pickerId1}
+								searchable
+								items={[
+									'Apple',
+									'Banana',
+									'Blueberry',
+									'Cherry',
+									'Grape',
+									'Lemon',
+									'Lime',
+									'Mango',
+									'Orange',
+									'Peach',
+									'Pear',
+									'Plum',
+								]}
+							>
+								{(item) => <Option key={item}>{item}</Option>}
+							</Picker>
+						</Form.Group>
+					</div>
+
+					<div style={{width: '200px'}}>
+						<Form.Group>
+							<label htmlFor={pickerId2} id={labelId2}>
+								Threshold (5 items)
+							</label>
+							<Picker
+								aria-labelledby={labelId2}
+								id={pickerId2}
+								searchableThreshold={5}
+								items={[
+									'Apple',
+									'Banana',
+									'Blueberry',
+									'Cherry',
+									'Grape',
+									'Lemon',
+								]}
+							>
+								{(item) => <Option key={item}>{item}</Option>}
+							</Picker>
+						</Form.Group>
+					</div>
+				</div>
+			</div>
+		</Provider>
+	);
+}
+```

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/picker/Picker.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/picker/Picker.tsx
@@ -636,6 +636,7 @@ export function Picker<T extends Record<string, any> | string | number>({
 					>
 						<Search
 							activeDescendant={activeDescendant}
+							ariaControls={ariaControls}
 							getOptions={getOptions}
 							messages={messages}
 							onActiveChange={setActive}

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/picker/Picker.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/picker/Picker.tsx
@@ -4,6 +4,7 @@
  */
 
 import Button from '@clayui/button';
+import {ClayInput} from '@clayui/form';
 import Icon from '@clayui/icon';
 import {
 	InternalDispatch,
@@ -19,6 +20,7 @@ import {
 	useIsMobileDevice,
 	useNavigation,
 	useOverlayPosition,
+	usePrevious,
 } from '@clayui/shared';
 import classNames from 'classnames';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
@@ -99,6 +101,12 @@ type Props<T> = {
 	'disabled'?: boolean;
 
 	/**
+	 * Defines the name of the property key that is used in the items filter
+	 * test.
+	 */
+	'filterKey'?: string;
+
+	/**
 	 * The id of the component.
 	 */
 	'id'?: string;
@@ -109,8 +117,10 @@ type Props<T> = {
 	'messages'?: {
 		itemDescribedby?: string;
 		itemSelected?: string;
+		noResultsFound?: string;
 		scrollToBottomAriaLabel?: string;
 		scrollToTopAriaLabel?: string;
+		searchPlaceholder?: string;
 	};
 
 	/**
@@ -135,6 +145,16 @@ type Props<T> = {
 	'placeholder'?: string;
 
 	/**
+	 * Flag to indicate if the component should be searchable.
+	 */
+	'searchable'?: boolean;
+
+	/**
+	 * The threshold of items to show the search input.
+	 */
+	'searchableThreshold'?: number;
+
+	/**
 	 * The currently selected key (controlled).
 	 */
 	'selectedKey'?: React.Key;
@@ -156,8 +176,10 @@ const defaultMessages = {
 	itemDescribedby:
 		'You are currently on a text element, inside of a list box.',
 	itemSelected: '{0}, selected',
+	noResultsFound: 'No results found',
 	scrollToBottomAriaLabel: 'Scroll to bottom',
 	scrollToTopAriaLabel: 'Scroll to top',
+	searchPlaceholder: 'Search',
 };
 
 export function Picker<T extends Record<string, any> | string | number>({
@@ -171,6 +193,7 @@ export function Picker<T extends Record<string, any> | string | number>({
 	defaultSelectedKey,
 	direction = 'bottom',
 	disabled,
+	filterKey,
 	id,
 	items,
 	messages: externalMessages,
@@ -178,6 +201,8 @@ export function Picker<T extends Record<string, any> | string | number>({
 	onActiveChange,
 	onSelectionChange,
 	placeholder = 'Select an option',
+	searchable,
+	searchableThreshold,
 	selectedKey: externalSelectedKey,
 	shrink,
 	width,
@@ -206,14 +231,32 @@ export function Picker<T extends Record<string, any> | string | number>({
 		value: externalSelectedKey,
 	});
 
+	const [searchValue, setSearchValue] = useState('');
+
+	const filterFn = useCallback(
+		(value: string) =>
+			value.toLowerCase().includes(searchValue.toLowerCase()),
+		[searchValue]
+	);
+
 	// We initialize the collection in the picker and then pass it down so the
 	// collection can be cached even before the listbox is not mounted.
 
 	const collection = useCollection<T, unknown>({
 		children,
+		filter: filterFn,
+		filterKey: filterKey ?? 'textValue',
 		items,
 		suppressTextValueWarning: false,
 	});
+
+	const totalItems = items ? items.length : React.Children.count(children);
+
+	const isSearchable =
+		searchable === true ||
+		(searchable === undefined &&
+			searchableThreshold !== undefined &&
+			totalItems > searchableThreshold);
 
 	const [activeDescendant, setActiveDescendant] = useState(() =>
 		selectedKey || selectedKey === 0
@@ -224,12 +267,39 @@ export function Picker<T extends Record<string, any> | string | number>({
 	const ariaControls = useId();
 
 	const triggerRef = useRef<HTMLButtonElement | null>(null);
+	const searchRef = useRef<HTMLInputElement | null>(null);
 	const menuRef = useRef<HTMLDivElement | null>(null);
 	const listRef = useRef<HTMLUListElement | null>(null);
 
 	const announcerAPIRef = useRef<AnnouncerAPI>(null);
 
+	const getOptions = useCallback(
+		() =>
+			getFocusableList(menuRef).filter(
+				(element) => element.getAttribute('role') === 'option'
+			),
+		[]
+	);
+
 	const {isFocusVisible} = useInteractionFocus();
+
+	const previousActive = usePrevious(active);
+
+	useEffect(() => {
+		if (active && !previousActive && isSearchable) {
+			searchRef.current?.focus();
+		}
+
+		if (!active && previousActive) {
+			setSearchValue('');
+		}
+	}, [active, isSearchable]);
+
+	useEffect(() => {
+		if (collection.getSize() === 0 && searchValue !== '') {
+			announcerAPIRef.current?.announce(messages.noResultsFound);
+		}
+	}, [collection.getSize(), searchValue]);
 
 	useOverlayPosition(
 		{
@@ -310,7 +380,7 @@ export function Picker<T extends Record<string, any> | string | number>({
 		) {
 			setActiveDescendant(collection.getFirstItem().key);
 		}
-	}, [items]);
+	}, [items, searchValue]);
 
 	const [isArrowVisible, setIsArrowVisible] = useState<
 		null | 'top' | 'bottom' | 'both'
@@ -488,7 +558,7 @@ export function Picker<T extends Record<string, any> | string | number>({
 
 							event.preventDefault();
 
-							const list = getFocusableList(menuRef);
+							const list = getOptions();
 
 							onMoveFocus(
 								event.key,
@@ -574,6 +644,86 @@ export function Picker<T extends Record<string, any> | string | number>({
 									: undefined,
 						}}
 					>
+						{isSearchable && (
+							<form onSubmit={(event) => event.preventDefault()}>
+								<div className="pb-2 pt-3 px-3">
+									<ClayInput.Group small>
+										<ClayInput.GroupItem className="input-group-item-focusable">
+											<ClayInput
+												aria-label={
+													messages.searchPlaceholder
+												}
+												insetAfter
+												onChange={(event) =>
+													setSearchValue(
+														event.target.value
+													)
+												}
+												onKeyDown={(
+													event: React.KeyboardEvent<HTMLInputElement>
+												) => {
+													if (
+														event.key === Keys.Enter
+													) {
+														onPress();
+													}
+
+													if (
+														event.key === Keys.Esc
+													) {
+														setActive(false);
+														triggerRef.current?.focus();
+													}
+
+													if (
+														event.key ===
+															'PageUp' ||
+														event.key === 'PageDown'
+													) {
+														event.preventDefault();
+
+														const list =
+															getOptions();
+
+														onMoveFocus(
+															event.key,
+															list.findIndex(
+																(element) =>
+																	element.getAttribute(
+																		'id'
+																	) ===
+																	String(
+																		activeDescendant
+																	)
+															),
+															list
+														);
+													}
+
+													navigationProps.onKeyDown(
+														event as React.KeyboardEvent<HTMLElement>
+													);
+												}}
+												placeholder={
+													messages.searchPlaceholder
+												}
+												ref={searchRef}
+												type="text"
+												value={searchValue}
+											/>
+
+											<ClayInput.GroupInsetItem
+												after
+												tag="span"
+											>
+												<Icon symbol="search" />
+											</ClayInput.GroupInsetItem>
+										</ClayInput.GroupItem>
+									</ClayInput.Group>
+								</div>
+							</form>
+						)}
+
 						{UNSAFE_behavior === 'secondary' &&
 							(isArrowVisible === 'top' ||
 								isArrowVisible === 'both') && (
@@ -605,11 +755,28 @@ export function Picker<T extends Record<string, any> | string | number>({
 							aria-labelledby={otherProps['aria-labelledby']}
 							className="inline-scroller list-unstyled"
 							id={ariaControls}
-							onFocus={() => triggerRef.current?.focus()}
+							onFocus={() => {
+								if (isSearchable) {
+									searchRef.current?.focus();
+								}
+								else {
+									triggerRef.current?.focus();
+								}
+							}}
 							ref={listRef}
 							role="listbox"
 							tabIndex={-1}
 						>
+							{collection.getSize() === 0 &&
+								searchValue !== '' && (
+									<li
+										className="dropdown-item"
+										role="presentation"
+									>
+										{messages.noResultsFound}
+									</li>
+								)}
+
 							<PickerContext.Provider value={context}>
 								<Collection<T> collection={collection} />
 							</PickerContext.Provider>

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/picker/Picker.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/picker/Picker.tsx
@@ -634,21 +634,22 @@ export function Picker<T extends Record<string, any> | string | number>({
 									: undefined,
 						}}
 					>
-						<Search
-							activeDescendant={activeDescendant}
-							ariaControls={ariaControls}
-							getOptions={getOptions}
-							messages={messages}
-							onActiveChange={setActive}
-							onChange={setSearchValue}
-							onKeyDown={navigationProps.onKeyDown}
-							onMoveFocus={onMoveFocus}
-							onPress={onPress}
-							ref={searchRef}
-							triggerRef={triggerRef}
-							value={searchValue}
-							visible={isSearchable}
-						/>
+						{isSearchable && (
+							<Search
+								activeDescendant={activeDescendant}
+								ariaControls={ariaControls}
+								getOptions={getOptions}
+								onActiveChange={setActive}
+								onChange={setSearchValue}
+								onKeyDown={navigationProps.onKeyDown}
+								onMoveFocus={onMoveFocus}
+								onPress={onPress}
+								placeholder={messages.searchPlaceholder}
+								ref={searchRef}
+								triggerRef={triggerRef}
+								value={searchValue}
+							/>
+						)}
 
 						{UNSAFE_behavior === 'secondary' &&
 							(isArrowVisible === 'top' ||

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/picker/Picker.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/picker/Picker.tsx
@@ -4,7 +4,6 @@
  */
 
 import Button from '@clayui/button';
-import {ClayInput} from '@clayui/form';
 import Icon from '@clayui/icon';
 import {
 	InternalDispatch,
@@ -20,17 +19,27 @@ import {
 	useIsMobileDevice,
 	useNavigation,
 	useOverlayPosition,
-	usePrevious,
 } from '@clayui/shared';
 import classNames from 'classnames';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 
 import {Collection, useCollection} from '../collection';
 import {LiveAnnouncer} from '../live-announcer';
+import {Search} from './Search';
 import {PickerContext} from './context';
+import {useSearch} from './useSearch';
 
 import type {ICollectionProps} from '../collection';
 import type {AnnouncerAPI} from '../live-announcer';
+
+export type PickerMessages = {
+	itemDescribedby: string;
+	itemSelected: string;
+	noResultsFound: string;
+	scrollToBottomAriaLabel: string;
+	scrollToTopAriaLabel: string;
+	searchPlaceholder: string;
+};
 
 type Props<T> = {
 
@@ -114,14 +123,7 @@ type Props<T> = {
 	/**
 	 * Messages for the Picker.
 	 */
-	'messages'?: {
-		itemDescribedby?: string;
-		itemSelected?: string;
-		noResultsFound?: string;
-		scrollToBottomAriaLabel?: string;
-		scrollToTopAriaLabel?: string;
-		searchPlaceholder?: string;
-	};
+	'messages'?: Partial<PickerMessages>;
 
 	/**
 	 * Flag to make the component hybrid, when identified it is on a mobile
@@ -172,7 +174,7 @@ type Props<T> = {
 	[key: string]: any;
 } & Omit<ICollectionProps<T, unknown>, 'virtualize'>;
 
-const defaultMessages = {
+const defaultMessages: PickerMessages = {
 	itemDescribedby:
 		'You are currently on a text element, inside of a list box.',
 	itemSelected: '{0}, selected',
@@ -231,32 +233,26 @@ export function Picker<T extends Record<string, any> | string | number>({
 		value: externalSelectedKey,
 	});
 
-	const [searchValue, setSearchValue] = useState('');
+	const totalItems = items ? items.length : React.Children.count(children);
 
-	const filterFn = useCallback(
-		(value: string) =>
-			value.toLowerCase().includes(searchValue.toLowerCase()),
-		[searchValue]
-	);
+	const {filter, isSearchable, searchRef, searchValue, setSearchValue} =
+		useSearch({
+			active,
+			searchable,
+			searchableThreshold,
+			totalItems,
+		});
 
 	// We initialize the collection in the picker and then pass it down so the
 	// collection can be cached even before the listbox is not mounted.
 
 	const collection = useCollection<T, unknown>({
 		children,
-		filter: filterFn,
+		filter,
 		filterKey: filterKey ?? 'textValue',
 		items,
 		suppressTextValueWarning: false,
 	});
-
-	const totalItems = items ? items.length : React.Children.count(children);
-
-	const isSearchable =
-		searchable === true ||
-		(searchable === undefined &&
-			searchableThreshold !== undefined &&
-			totalItems > searchableThreshold);
 
 	const [activeDescendant, setActiveDescendant] = useState(() =>
 		selectedKey || selectedKey === 0
@@ -267,7 +263,6 @@ export function Picker<T extends Record<string, any> | string | number>({
 	const ariaControls = useId();
 
 	const triggerRef = useRef<HTMLButtonElement | null>(null);
-	const searchRef = useRef<HTMLInputElement | null>(null);
 	const menuRef = useRef<HTMLDivElement | null>(null);
 	const listRef = useRef<HTMLUListElement | null>(null);
 
@@ -283,23 +278,18 @@ export function Picker<T extends Record<string, any> | string | number>({
 
 	const {isFocusVisible} = useInteractionFocus();
 
-	const previousActive = usePrevious(active);
-
-	useEffect(() => {
-		if (active && !previousActive && isSearchable) {
-			searchRef.current?.focus();
-		}
-
-		if (!active && previousActive) {
-			setSearchValue('');
-		}
-	}, [active, isSearchable]);
-
-	useEffect(() => {
-		if (collection.getSize() === 0 && searchValue !== '') {
-			announcerAPIRef.current?.announce(messages.noResultsFound);
-		}
-	}, [collection.getSize(), searchValue]);
+	useEffect(
+		function announceEmptyStateWhenSearching() {
+			if (
+				isSearchable &&
+				collection.getSize() === 0 &&
+				totalItems !== 0
+			) {
+				announcerAPIRef.current?.announce(messages.noResultsFound);
+			}
+		},
+		[collection.getSize(), searchValue, totalItems]
+	);
 
 	useOverlayPosition(
 		{
@@ -644,85 +634,20 @@ export function Picker<T extends Record<string, any> | string | number>({
 									: undefined,
 						}}
 					>
-						{isSearchable && (
-							<form onSubmit={(event) => event.preventDefault()}>
-								<div className="pb-2 pt-3 px-3">
-									<ClayInput.Group small>
-										<ClayInput.GroupItem className="input-group-item-focusable">
-											<ClayInput
-												aria-label={
-													messages.searchPlaceholder
-												}
-												insetAfter
-												onChange={(event) =>
-													setSearchValue(
-														event.target.value
-													)
-												}
-												onKeyDown={(
-													event: React.KeyboardEvent<HTMLInputElement>
-												) => {
-													if (
-														event.key === Keys.Enter
-													) {
-														onPress();
-													}
-
-													if (
-														event.key === Keys.Esc
-													) {
-														setActive(false);
-														triggerRef.current?.focus();
-													}
-
-													if (
-														event.key ===
-															'PageUp' ||
-														event.key === 'PageDown'
-													) {
-														event.preventDefault();
-
-														const list =
-															getOptions();
-
-														onMoveFocus(
-															event.key,
-															list.findIndex(
-																(element) =>
-																	element.getAttribute(
-																		'id'
-																	) ===
-																	String(
-																		activeDescendant
-																	)
-															),
-															list
-														);
-													}
-
-													navigationProps.onKeyDown(
-														event as React.KeyboardEvent<HTMLElement>
-													);
-												}}
-												placeholder={
-													messages.searchPlaceholder
-												}
-												ref={searchRef}
-												type="text"
-												value={searchValue}
-											/>
-
-											<ClayInput.GroupInsetItem
-												after
-												tag="span"
-											>
-												<Icon symbol="search" />
-											</ClayInput.GroupInsetItem>
-										</ClayInput.GroupItem>
-									</ClayInput.Group>
-								</div>
-							</form>
-						)}
+						<Search
+							activeDescendant={activeDescendant}
+							getOptions={getOptions}
+							messages={messages}
+							onActiveChange={setActive}
+							onChange={setSearchValue}
+							onKeyDown={navigationProps.onKeyDown}
+							onMoveFocus={onMoveFocus}
+							onPress={onPress}
+							ref={searchRef}
+							triggerRef={triggerRef}
+							value={searchValue}
+							visible={isSearchable}
+						/>
 
 						{UNSAFE_behavior === 'secondary' &&
 							(isArrowVisible === 'top' ||

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/picker/Search.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/picker/Search.tsx
@@ -12,6 +12,7 @@ import {PickerMessages} from './Picker';
 
 type Props = {
 	activeDescendant: React.Key;
+	ariaControls: string;
 	getOptions: () => Array<HTMLElement>;
 	messages: PickerMessages;
 	onActiveChange: InternalDispatch<boolean>;
@@ -31,6 +32,7 @@ type Props = {
 export const Search = React.forwardRef<HTMLInputElement, Props>(function Search(
 	{
 		activeDescendant,
+		ariaControls,
 		getOptions,
 		messages,
 		onActiveChange,
@@ -50,12 +52,16 @@ export const Search = React.forwardRef<HTMLInputElement, Props>(function Search(
 
 	function onKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
 		if (event.key === Keys.Enter) {
+			event.preventDefault();
+			event.stopPropagation();
 			onPress();
 
 			return;
 		}
 
 		if (event.key === Keys.Esc) {
+			event.preventDefault();
+			event.stopPropagation();
 			onActiveChange(false);
 			triggerRef.current?.focus();
 
@@ -89,6 +95,13 @@ export const Search = React.forwardRef<HTMLInputElement, Props>(function Search(
 				<ClayInput.Group small>
 					<ClayInput.GroupItem className="input-group-item-focusable">
 						<ClayInput
+							aria-activedescendant={
+								activeDescendant
+									? String(activeDescendant)
+									: undefined
+							}
+							aria-autocomplete="list"
+							aria-controls={ariaControls}
 							aria-label={messages.searchPlaceholder}
 							insetAfter
 							onChange={onChange}

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/picker/Search.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/picker/Search.tsx
@@ -1,0 +1,110 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {ClayInput} from '@clayui/form';
+import ClayIcon from '@clayui/icon';
+import {InternalDispatch, Keys} from '@clayui/shared';
+import React from 'react';
+
+import {PickerMessages} from './Picker';
+
+type Props = {
+	activeDescendant: React.Key;
+	getOptions: () => Array<HTMLElement>;
+	messages: PickerMessages;
+	onActiveChange: InternalDispatch<boolean>;
+	onChange: InternalDispatch<string>;
+	onKeyDown: InternalDispatch<React.KeyboardEvent<HTMLElement>>;
+	onMoveFocus: (
+		key: 'PageUp' | 'PageDown',
+		position: number,
+		list: Array<HTMLElement> | Array<React.Key>
+	) => void;
+	onPress: () => void;
+	triggerRef: React.RefObject<HTMLButtonElement | null>;
+	value: string;
+	visible: boolean;
+};
+
+export const Search = React.forwardRef<HTMLInputElement, Props>(function Search(
+	{
+		activeDescendant,
+		getOptions,
+		messages,
+		onActiveChange,
+		onChange: externalOnChange,
+		onKeyDown: externalOnKeyDown,
+		onMoveFocus,
+		onPress,
+		triggerRef,
+		value,
+		visible,
+	},
+	ref
+) {
+	function onChange(event: React.ChangeEvent<HTMLInputElement>) {
+		externalOnChange(event.target.value);
+	}
+
+	function onKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
+		if (event.key === Keys.Enter) {
+			onPress();
+
+			return;
+		}
+
+		if (event.key === Keys.Esc) {
+			onActiveChange(false);
+			triggerRef.current?.focus();
+
+			return;
+		}
+
+		if (event.key === 'PageUp' || event.key === 'PageDown') {
+			event.preventDefault();
+
+			const list = getOptions();
+
+			onMoveFocus(
+				event.key,
+				list.findIndex(
+					(element) =>
+						element instanceof HTMLElement &&
+						element.getAttribute('id') === String(activeDescendant)
+				),
+				list
+			);
+
+			return;
+		}
+
+		externalOnKeyDown(event as React.KeyboardEvent<HTMLElement>);
+	}
+
+	return (
+		visible && (
+			<div className="pb-2 pt-3 px-3">
+				<ClayInput.Group small>
+					<ClayInput.GroupItem className="input-group-item-focusable">
+						<ClayInput
+							aria-label={messages.searchPlaceholder}
+							insetAfter
+							onChange={onChange}
+							onKeyDown={onKeyDown}
+							placeholder={messages.searchPlaceholder}
+							ref={ref}
+							type="text"
+							value={value}
+						/>
+
+						<ClayInput.GroupInsetItem after tag="span">
+							<ClayIcon symbol="search" />
+						</ClayInput.GroupInsetItem>
+					</ClayInput.GroupItem>
+				</ClayInput.Group>
+			</div>
+		)
+	);
+});

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/picker/Search.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/picker/Search.tsx
@@ -8,13 +8,10 @@ import ClayIcon from '@clayui/icon';
 import {InternalDispatch, Keys} from '@clayui/shared';
 import React from 'react';
 
-import {PickerMessages} from './Picker';
-
 type Props = {
 	activeDescendant: React.Key;
 	ariaControls: string;
 	getOptions: () => Array<HTMLElement>;
-	messages: PickerMessages;
 	onActiveChange: InternalDispatch<boolean>;
 	onChange: InternalDispatch<string>;
 	onKeyDown: InternalDispatch<React.KeyboardEvent<HTMLElement>>;
@@ -24,9 +21,9 @@ type Props = {
 		list: Array<HTMLElement> | Array<React.Key>
 	) => void;
 	onPress: () => void;
+	placeholder: string;
 	triggerRef: React.RefObject<HTMLButtonElement | null>;
 	value: string;
-	visible: boolean;
 };
 
 export const Search = React.forwardRef<HTMLInputElement, Props>(function Search(
@@ -34,22 +31,17 @@ export const Search = React.forwardRef<HTMLInputElement, Props>(function Search(
 		activeDescendant,
 		ariaControls,
 		getOptions,
-		messages,
 		onActiveChange,
-		onChange: externalOnChange,
+		onChange,
 		onKeyDown: externalOnKeyDown,
 		onMoveFocus,
 		onPress,
+		placeholder,
 		triggerRef,
 		value,
-		visible,
 	},
 	ref
 ) {
-	function onChange(event: React.ChangeEvent<HTMLInputElement>) {
-		externalOnChange(event.target.value);
-	}
-
 	function onKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
 		if (event.key === Keys.Enter) {
 			event.preventDefault();
@@ -90,34 +82,32 @@ export const Search = React.forwardRef<HTMLInputElement, Props>(function Search(
 	}
 
 	return (
-		visible && (
-			<div className="pb-2 pt-3 px-3">
-				<ClayInput.Group small>
-					<ClayInput.GroupItem className="input-group-item-focusable">
-						<ClayInput
-							aria-activedescendant={
-								activeDescendant
-									? String(activeDescendant)
-									: undefined
-							}
-							aria-autocomplete="list"
-							aria-controls={ariaControls}
-							aria-label={messages.searchPlaceholder}
-							insetAfter
-							onChange={onChange}
-							onKeyDown={onKeyDown}
-							placeholder={messages.searchPlaceholder}
-							ref={ref}
-							type="text"
-							value={value}
-						/>
+		<div className="pb-2 pt-3 px-3">
+			<ClayInput.Group small>
+				<ClayInput.GroupItem className="input-group-item-focusable">
+					<ClayInput
+						aria-activedescendant={
+							activeDescendant
+								? String(activeDescendant)
+								: undefined
+						}
+						aria-autocomplete="list"
+						aria-controls={ariaControls}
+						aria-label={placeholder}
+						insetAfter
+						onChange={(event) => onChange(event.target.value)}
+						onKeyDown={onKeyDown}
+						placeholder={placeholder}
+						ref={ref}
+						type="text"
+						value={value}
+					/>
 
-						<ClayInput.GroupInsetItem after tag="span">
-							<ClayIcon symbol="search" />
-						</ClayInput.GroupInsetItem>
-					</ClayInput.GroupItem>
-				</ClayInput.Group>
-			</div>
-		)
+					<ClayInput.GroupInsetItem after tag="span">
+						<ClayIcon symbol="search" />
+					</ClayInput.GroupInsetItem>
+				</ClayInput.GroupItem>
+			</ClayInput.Group>
+		</div>
 	);
 });

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/picker/__tests__/Search.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/picker/__tests__/Search.tsx
@@ -227,4 +227,20 @@ describe('Picker search', () => {
 		expect(onSelectionChange).toHaveBeenCalledWith('Mango');
 		expect(combobox).toHaveTextContent('Mango');
 	});
+
+	it('renders search input with correct accessibility attributes', () => {
+		const {getByPlaceholderText, getByRole} = render(
+			<Picker items={items} searchable>
+				{(item) => <Option key={item}>{item}</Option>}
+			</Picker>
+		);
+
+		fireEvent.click(getByRole('combobox'));
+
+		const searchInput = getByPlaceholderText('Search');
+
+		expect(searchInput).toHaveAttribute('aria-autocomplete', 'list');
+		expect(searchInput).toHaveAttribute('aria-controls');
+		expect(searchInput).toHaveAttribute('aria-activedescendant');
+	});
 });

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/picker/__tests__/Search.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/picker/__tests__/Search.tsx
@@ -1,0 +1,230 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {cleanup, fireEvent, render, waitFor} from '@testing-library/react';
+import React from 'react';
+
+import {Option, Picker} from '../index';
+
+describe('Picker search', () => {
+	afterEach(cleanup);
+
+	const items = [
+		'Apple',
+		'Banana',
+		'Blueberry',
+		'Cherry',
+		'Grape',
+		'Lemon',
+		'Lime',
+		'Mango',
+		'Orange',
+		'Peach',
+		'Pear',
+		'Plum',
+	];
+
+	it('does not render search input when props are not provided', () => {
+		const {getByRole, queryByPlaceholderText} = render(
+			<Picker items={items}>
+				{(item) => <Option key={item}>{item}</Option>}
+			</Picker>
+		);
+
+		fireEvent.click(getByRole('combobox'));
+
+		expect(queryByPlaceholderText('Search')).not.toBeInTheDocument();
+	});
+
+	it('renders search input when searchableThreshold is provided and exceeded', () => {
+		const {getByPlaceholderText, getByRole} = render(
+			<Picker items={items} searchableThreshold={5}>
+				{(item) => <Option key={item}>{item}</Option>}
+			</Picker>
+		);
+
+		fireEvent.click(getByRole('combobox'));
+
+		expect(getByPlaceholderText('Search')).toBeInTheDocument();
+	});
+
+	it('does not render search input when searchableThreshold is provided but not exceeded', () => {
+		const {getByRole, queryByPlaceholderText} = render(
+			<Picker items={['Apple', 'Banana']} searchableThreshold={5}>
+				{(item) => <Option key={item}>{item}</Option>}
+			</Picker>
+		);
+
+		fireEvent.click(getByRole('combobox'));
+
+		expect(queryByPlaceholderText('Search')).not.toBeInTheDocument();
+	});
+
+	it('renders search input when searchable prop is true, even if items are below threshold', () => {
+		const {getByPlaceholderText, getByRole} = render(
+			<Picker items={['Apple']} searchable>
+				{(item) => <Option key={item}>{item}</Option>}
+			</Picker>
+		);
+
+		fireEvent.click(getByRole('combobox'));
+
+		expect(getByPlaceholderText('Search')).toBeInTheDocument();
+	});
+
+	it('does not render search input when searchable prop is false, even if items are above threshold', () => {
+		const {getByRole, queryByPlaceholderText} = render(
+			<Picker items={items} searchable={false} searchableThreshold={5}>
+				{(item) => <Option key={item}>{item}</Option>}
+			</Picker>
+		);
+
+		fireEvent.click(getByRole('combobox'));
+
+		expect(queryByPlaceholderText('Search')).not.toBeInTheDocument();
+	});
+
+	it('filters items correctly based on search value', async () => {
+		const {getAllByRole, getByPlaceholderText, getByRole} = render(
+			<Picker items={items} searchable>
+				{(item) => <Option key={item}>{item}</Option>}
+			</Picker>
+		);
+
+		fireEvent.click(getByRole('combobox'));
+
+		const searchInput = getByPlaceholderText('Search');
+
+		fireEvent.change(searchInput, {target: {value: 'Blue'}});
+
+		await waitFor(() => {
+			const filteredItems = getAllByRole('option');
+			expect(filteredItems).toHaveLength(1);
+			expect(filteredItems[0]).toHaveTextContent('Blueberry');
+		});
+	});
+
+	it('displays empty state message when no items match', async () => {
+		const {getAllByText, getByPlaceholderText, getByRole, queryByRole} =
+			render(
+				<Picker items={items} searchable>
+					{(item) => <Option key={item}>{item}</Option>}
+				</Picker>
+			);
+
+		fireEvent.click(getByRole('combobox'));
+
+		const searchInput = getByPlaceholderText('Search');
+
+		fireEvent.change(searchInput, {target: {value: 'Zzz'}});
+
+		await waitFor(() => {
+			expect(queryByRole('option')).not.toBeInTheDocument();
+			expect(getAllByText('No results found').length).toBeGreaterThan(0);
+		});
+	});
+
+	it('filters items correctly based on filterKey', async () => {
+		const objectItems = [
+			{id: 1, label: 'Apple'},
+			{id: 2, label: 'Banana'},
+		];
+		const {getAllByRole, getByPlaceholderText, getByRole} = render(
+			<Picker filterKey="label" items={objectItems} searchable>
+				{(item) => <Option key={item.id}>{item.label}</Option>}
+			</Picker>
+		);
+
+		fireEvent.click(getByRole('combobox'));
+
+		const searchInput = getByPlaceholderText('Search');
+
+		fireEvent.change(searchInput, {target: {value: 'Ban'}});
+
+		await waitFor(() => {
+			const filteredItems = getAllByRole('option');
+			expect(filteredItems).toHaveLength(1);
+			expect(filteredItems[0]).toHaveTextContent('Banana');
+		});
+	});
+
+	it('focuses search input automatically when opened', () => {
+		const {getByPlaceholderText, getByRole} = render(
+			<Picker items={items} searchable>
+				{(item) => <Option key={item}>{item}</Option>}
+			</Picker>
+		);
+
+		fireEvent.click(getByRole('combobox'));
+
+		const searchInput = getByPlaceholderText('Search');
+
+		expect(document.activeElement).toBe(searchInput);
+	});
+
+	it('navigates through filtered items using arrow keys from search input', async () => {
+		const {getByPlaceholderText, getByRole} = render(
+			<Picker items={items} searchable>
+				{(item) => <Option key={item}>{item}</Option>}
+			</Picker>
+		);
+
+		const combobox = getByRole('combobox');
+
+		fireEvent.click(combobox);
+
+		const searchInput = getByPlaceholderText('Search');
+
+		fireEvent.change(searchInput, {target: {value: 'P'}}); // Apple, Grape, Peach, Pear, Plum
+
+		// activeDescendant should be the first item (Apple)
+
+		await waitFor(() =>
+			expect(combobox).toHaveAttribute('aria-activedescendant', 'Apple')
+		);
+
+		fireEvent.keyDown(searchInput, {key: 'ArrowDown'});
+		expect(combobox).toHaveAttribute('aria-activedescendant', 'Grape');
+
+		fireEvent.keyDown(searchInput, {key: 'ArrowDown'});
+		expect(combobox).toHaveAttribute('aria-activedescendant', 'Peach');
+
+		fireEvent.keyDown(searchInput, {key: 'ArrowDown'});
+		expect(combobox).toHaveAttribute('aria-activedescendant', 'Pear');
+
+		fireEvent.keyDown(searchInput, {key: 'ArrowDown'});
+		expect(combobox).toHaveAttribute('aria-activedescendant', 'Plum');
+	});
+
+	it('selects an item using Enter key from search input', async () => {
+		const onSelectionChange = jest.fn();
+		const {getByPlaceholderText, getByRole} = render(
+			<Picker
+				items={items}
+				onSelectionChange={onSelectionChange}
+				searchable
+			>
+				{(item) => <Option key={item}>{item}</Option>}
+			</Picker>
+		);
+
+		const combobox = getByRole('combobox');
+
+		fireEvent.click(combobox);
+
+		const searchInput = getByPlaceholderText('Search');
+
+		fireEvent.change(searchInput, {target: {value: 'Mango'}});
+
+		await waitFor(() =>
+			expect(combobox).toHaveAttribute('aria-activedescendant', 'Mango')
+		);
+
+		fireEvent.keyDown(searchInput, {key: 'Enter'});
+
+		expect(onSelectionChange).toHaveBeenCalledWith('Mango');
+		expect(combobox).toHaveTextContent('Mango');
+	});
+});

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/picker/useSearch.ts
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/picker/useSearch.ts
@@ -1,0 +1,54 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {usePrevious} from '@clayui/shared';
+import {useCallback, useEffect, useRef, useState} from 'react';
+
+type Props = {
+	active: boolean;
+	searchable?: boolean;
+	searchableThreshold?: number;
+	totalItems: number;
+};
+
+export function useSearch({
+	active,
+	searchable,
+	searchableThreshold,
+	totalItems,
+}: Props) {
+	const searchRef = useRef<HTMLInputElement | null>(null);
+
+	const [searchValue, setSearchValue] = useState('');
+
+	const previousActive = usePrevious(active);
+
+	const isSearchable =
+		searchable === true ||
+		(searchable === undefined &&
+			searchableThreshold !== undefined &&
+			totalItems > searchableThreshold);
+
+	const filter = useCallback(
+		(value: string) =>
+			value.toLowerCase().includes(searchValue.toLowerCase()),
+		[searchValue]
+	);
+
+	useEffect(
+		function focusSearchInputWhenBecomingActive() {
+			if (active && !previousActive && isSearchable) {
+				searchRef.current?.focus();
+			}
+
+			if (!active && previousActive) {
+				setSearchValue('');
+			}
+		},
+		[active, isSearchable]
+	);
+
+	return {filter, isSearchable, searchRef, searchValue, setSearchValue};
+}

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/stories/Picker.stories.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/stories/Picker.stories.tsx
@@ -60,38 +60,61 @@ export function Default() {
 		</div>
 	);
 }
-export function Dynamic() {
-	const pickerId = useId();
-	const labelId = useId();
+export function Search() {
+	const pickerId1 = useId();
+	const labelId1 = useId();
+	const pickerId2 = useId();
+	const labelId2 = useId();
 
 	return (
-		<div style={{width: '150px'}}>
-			<Form.Group>
-				<label htmlFor={pickerId} id={labelId}>
-					Choose a fruit
-				</label>
+		<div style={{display: 'flex', gap: '20px'}}>
+			<div style={{width: '200px'}}>
+				<Form.Group>
+					<label htmlFor={pickerId1} id={labelId1}>
+						Searchable (Explicit)
+					</label>
 
-				<Picker
-					aria-labelledby={labelId}
-					id={pickerId}
-					items={[
-						'Apple',
-						'Banana',
-						'Mangos',
-						'Blueberry',
-						'Boysenberry',
-						'Cherry',
-						'Cranberry',
-						'Eggplant',
-						'Fig',
-						'Grape',
-						'Guava',
-						'Huckleberry',
-					]}
-				>
-					{(item) => <Option key={item}>{item}</Option>}
-				</Picker>
-			</Form.Group>
+					<Picker
+						aria-labelledby={labelId1}
+						id={pickerId1}
+						searchable
+					>
+						<Option key="apple">Apple</Option>
+
+						<Option key="banana">Banana</Option>
+
+						<Option key="mangos">Mangos</Option>
+
+						<Option key="blueberry">Blueberry</Option>
+					</Picker>
+				</Form.Group>
+			</div>
+
+			<div style={{width: '200px'}}>
+				<Form.Group>
+					<label htmlFor={pickerId2} id={labelId2}>
+						Automatic (Threshold 5)
+					</label>
+
+					<Picker
+						aria-labelledby={labelId2}
+						id={pickerId2}
+						items={[
+							'Apple',
+							'Banana',
+							'Blueberry',
+							'Cherry',
+							'Grape',
+							'Lemon',
+							'Lime',
+							'Mango',
+						]}
+						searchableThreshold={5}
+					>
+						{(item) => <Option key={item}>{item}</Option>}
+					</Picker>
+				</Form.Group>
+			</div>
 		</div>
 	);
 }


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPD-85709

#### Summary
This PR introduces a real-time search filter within the Picker component's panel. This feature helps users efficiently locate options in large lists. The implementation is fully opt-in to ensure no impact on existing component consumers.

#### Changes
- **Logic:** Integrated case-insensitive partial matching into the useCollection hook used by Picker.
- **API:** Added searchable (boolean) and searchableThreshold (number) props to control the search UI.
- **UI:** Added a search input styled with Lexicon patterns at the top of the dropdown menu.
- **UX:** Implemented automatic focus on the search input upon opening the panel and maintained keyboard navigation support (ArrowKeys, Enter, Esc, PageUp/Down).
- **Tests:** Created a new test suite Search.tsx covering all search-related scenarios and edge cases.
- **Docs:** Updated picker.mdx documentation and added a Search story to the Storybook.

#### How to test it
1. Navigate to modules/apps/frontend-js/frontend-js-clay-web.
2. Run unit tests: yarn test clay/clay-core/src/picker/__tests__/Search.tsx. Verify all tests pass.
3. Run Storybook: yarn storybook.
4. Find the Design System > Components > Picker > Search story.
5. Verify that:
    - The 'Searchable (Explicit)' picker shows the search bar immediately.
    - The 'Automatic (Threshold 5)' picker shows the search bar since it has more than 5 items.
    - Typing in the search bar filters the list in real-time.
    - Keyboard navigation (arrows and Enter) works while the search input is focused.

<img width="689" height="390" alt="image" src="https://github.com/user-attachments/assets/38318f5d-f948-4521-bb97-59d4f952f8d6" />
