### PR TITLE
LPD-81222 Align Item Selector filters with CMS Data Set filters

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/java/com/liferay/frontend/data/set/taglib/servlet/taglib/HeadlessDisplayTag.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/java/com/liferay/frontend/data/set/taglib/servlet/taglib/HeadlessDisplayTag.java
@@ -46,6 +46,8 @@ public class HeadlessDisplayTag extends BaseDisplayTag {
 			}
 
 			_setFiltersJSONArray();
+
+			_setGroupedFiltersJSONArray();
 		}
 		catch (Exception exception) {
 			_log.error(exception);
@@ -258,6 +260,7 @@ public class HeadlessDisplayTag extends BaseDisplayTag {
 		_filtersJSONArray = null;
 		_formId = null;
 		_formName = null;
+		_groupedFiltersJSONArray = null;
 		_nestedItemsKey = null;
 		_nestedItemsReferenceKey = null;
 		_selectedItemsKey = null;
@@ -296,6 +299,8 @@ public class HeadlessDisplayTag extends BaseDisplayTag {
 				"formId", _validateDataAttribute(_formId)
 			).put(
 				"formName", _validateDataAttribute(_formName)
+			).put(
+				"groupedFilters", _groupedFiltersJSONArray
 			).put(
 				"id", getId()
 			).put(
@@ -338,6 +343,11 @@ public class HeadlessDisplayTag extends BaseDisplayTag {
 			getFdsFilters(), getId(), getRequest());
 	}
 
+	private void _setGroupedFiltersJSONArray() {
+		_groupedFiltersJSONArray = fdsSerializer.serializeGroupedFilters(
+			getId(), getRequest());
+	}
+
 	private Object _validateDataAttribute(Object object) {
 		if (Validator.isNull(object)) {
 			return null;
@@ -361,6 +371,7 @@ public class HeadlessDisplayTag extends BaseDisplayTag {
 	private JSONArray _filtersJSONArray;
 	private String _formId;
 	private String _formName;
+	private JSONArray _groupedFiltersJSONArray;
 	private String _nestedItemsKey;
 	private String _nestedItemsReferenceKey;
 	private String _selectedItemsKey;

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/plugins/HeadlessItemSelector.ts
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/plugins/HeadlessItemSelector.ts
@@ -10,7 +10,11 @@ import {
 	EConfigInURLBehavior,
 	IFrontendDataSetProps,
 } from '@liferay/frontend-data-set-web';
-import {openItemSelectorModal} from '@liferay/frontend-js-item-selector-web';
+import {
+	getCMSItemSelectorFilters,
+	getCMSItemSelectorGroupedFilters,
+	openItemSelectorModal,
+} from '@liferay/frontend-js-item-selector-web';
 import {mimeTypeUtils} from 'frontend-js-web';
 import React from 'react';
 
@@ -44,21 +48,8 @@ const CMS_FILE_SEARCH_API_URL = `${location.origin}/o/search/v1.0/search?${[
 	'nestedFields=embedded,file.thumbnailURL',
 ].join('&')}`;
 
-const FDS_PROPS: IFrontendDataSetProps = {
+const FDS_PROPS: Omit<IFrontendDataSetProps, 'filters' | 'id'> = {
 	configInURLBehavior: EConfigInURLBehavior.OFF,
-	filters: [
-		{
-			apiURL: '/o/headless-asset-library/v1.0/asset-libraries',
-			entityFieldType: 'collection',
-			id: 'groupIds',
-			itemKey: 'siteId',
-			itemLabel: 'name',
-			label: Liferay.Language.get('space'),
-			multiple: true,
-			type: 'selection',
-		},
-	],
-	id: '',
 	pagination: {
 		deltas: [{label: 20}, {label: 40}, {label: 60}],
 		initialDelta: 20,
@@ -171,6 +162,10 @@ class HeadlessItemSelector extends Plugin {
 					apiURL: `${CMS_FILE_SEARCH_API_URL}&filter=(cmsKind eq 'object') and (cmsSection eq 'files') and (status in (0, 2, 3) and (extension in ('${ALLOWED_IMAGE_FILE_EXTENSIONS.join("','")}')))`,
 					fdsProps: {
 						...FDS_PROPS,
+						filters: getCMSItemSelectorFilters(
+							Liferay.ThemeDisplay.getSiteGroupId()
+						),
+						groupedFilters: getCMSItemSelectorGroupedFilters(),
 						id: `ImageHeadlessItemSelectorFDS_${getRandomId()}`,
 					},
 					itemTypeLabel: Liferay.Language.get('image'),
@@ -212,6 +207,10 @@ class HeadlessItemSelector extends Plugin {
 					apiURL: `${CMS_FILE_SEARCH_API_URL}&filter=(cmsKind eq 'object') and (cmsSection eq 'files') and (status in (0, 2, 3))`,
 					fdsProps: {
 						...FDS_PROPS,
+						filters: getCMSItemSelectorFilters(
+							Liferay.ThemeDisplay.getSiteGroupId()
+						),
+						groupedFilters: getCMSItemSelectorGroupedFilters(),
 						id: `VideoHeadlessItemSelectorFDS_${getRandomId()}`,
 					},
 					itemTypeLabel: Liferay.Language.get('video'),

--- a/modules/apps/frontend-js/frontend-js-item-selector-sample-web/src/main/resources/META-INF/resources/js/CMSFilesItemSelectorModal.tsx
+++ b/modules/apps/frontend-js/frontend-js-item-selector-sample-web/src/main/resources/META-INF/resources/js/CMSFilesItemSelectorModal.tsx
@@ -14,6 +14,8 @@ import {
 import {
 	IItemSelectorModalProps,
 	ItemSelectorModal,
+	getCMSItemSelectorFilters,
+	getCMSItemSelectorGroupedFilters,
 } from '@liferay/frontend-js-item-selector-web';
 import {useBrowserTabVisibility} from '@liferay/frontend-js-react-web';
 import {fetch} from 'frontend-js-web';
@@ -239,18 +241,10 @@ function CMSFilesItemSelectorModal({
 						},
 					],
 				},
-				filters: [
-					{
-						apiURL: '/o/headless-asset-library/v1.0/asset-libraries',
-						entityFieldType: 'collection',
-						id: 'groupIds',
-						itemKey: 'siteId',
-						itemLabel: 'name',
-						label: Liferay.Language.get('space'),
-						multiple: true,
-						type: 'selection',
-					},
-				],
+				filters: getCMSItemSelectorFilters(
+					Liferay.ThemeDisplay.getSiteGroupId()
+				),
+				groupedFilters: getCMSItemSelectorGroupedFilters(),
 				id: `itemSelectorModal-cms-${uuidv4()}`,
 				inlineNotificationComponent: NewItemsNotificationComponent,
 				pagination: {

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/index.ts
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/index.ts
@@ -4,9 +4,14 @@
  */
 
 export {default as ItemSelector} from './item_selector/ItemSelector';
+export * from './item_selector/types';
 export type {IItemSelectorProps} from './item_selector/ItemSelector';
 export {default as ItemSelectorModal} from './item_selector/ItemSelectorModal';
 export type {FilesUploaderComponent} from './item_selector/ItemSelectorModal';
 export type {IItemSelectorModalProps} from './item_selector/ItemSelectorModal';
+export {
+	getCMSItemSelectorFilters,
+	getCMSItemSelectorGroupedFilters,
+} from './item_selector/getCMSItemSelectorFilters';
 export {default as openCMSFileSelectorModal} from './item_selector/openCMSFileSelectorModal';
 export {default as openItemSelectorModal} from './item_selector/openItemSelectorModal';

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/getCMSItemSelectorFilters.ts
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/getCMSItemSelectorFilters.ts
@@ -1,0 +1,163 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {EEntityFieldType, IGroupedFilterConfig, TFilterConfig} from './types';
+
+/**
+ * Returns the full set of filters for CMS Item Selector data sets.
+ * These filters align with the CMS "Contents" data set filters.
+ */
+export function getCMSItemSelectorFilters(
+	groupId: number | string
+): TFilterConfig[] {
+	return [
+		{
+			apiURL: '/o/headless-asset-library/v1.0/asset-libraries',
+			entityFieldType: EEntityFieldType.COLLECTION,
+			id: 'groupIds',
+			itemKey: 'siteId',
+			itemLabel: 'name',
+			label: Liferay.Language.get('space'),
+			multiple: true,
+			type: 'selection',
+		},
+		{
+			apiURL: "/o/object-admin/v1.0/object-definitions?filter=objectFolderExternalReferenceCode eq 'L_CMS_FILE_TYPES'",
+			entityFieldType: EEntityFieldType.INTEGER,
+			id: 'objectDefinitionId',
+			itemKey: 'id',
+			itemLabel: 'label.LANG',
+			label: Liferay.Language.get('type'),
+			multiple: true,
+			type: 'selection',
+		},
+		{
+			apiURL: `/o/headless-admin-taxonomy/v1.0/sites/${groupId}/taxonomy-categories`,
+			entityFieldType: EEntityFieldType.COLLECTION,
+			id: 'taxonomyCategoryIds',
+			itemKey: 'id',
+			itemLabel: 'name',
+			label: Liferay.Language.get('category'),
+			multiple: true,
+			type: 'selection',
+		},
+		{
+			apiURL: `/o/headless-admin-taxonomy/v1.0/sites/${groupId}/keywords`,
+			entityFieldType: EEntityFieldType.COLLECTION,
+			id: 'keywords',
+			itemKey: 'name',
+			itemLabel: 'name',
+			label: Liferay.Language.get('tags'),
+			multiple: true,
+			type: 'selection',
+		},
+		{
+			apiURL: `/o/headless-admin-user/v1.0/user-accounts`,
+			autocompleteEnabled: true,
+			entityFieldType: EEntityFieldType.INTEGER,
+			id: 'creatorId',
+			itemKey: 'id',
+			itemLabel: 'name',
+			label: Liferay.Language.get('author'),
+			multiple: true,
+			type: 'selection',
+		},
+		{
+			entityFieldType: EEntityFieldType.INTEGER,
+			id: 'status',
+			items: [
+				{
+					label: Liferay.Language.get('approved'),
+					value: '0',
+				},
+				{
+					label: Liferay.Language.get('pending'),
+					value: '1',
+				},
+				{
+					label: Liferay.Language.get('draft'),
+					value: '2',
+				},
+				{
+					label: Liferay.Language.get('expired'),
+					value: '3',
+				},
+				{
+					label: Liferay.Language.get('scheduled'),
+					value: '8',
+				},
+			],
+			label: Liferay.Language.get('status'),
+			multiple: true,
+			type: 'selection',
+		},
+		{
+			entityFieldType: EEntityFieldType.DATE_TIME,
+			id: 'dateCreated',
+			label: Liferay.Language.get('create-date'),
+			type: 'dateRange',
+		},
+		{
+			entityFieldType: EEntityFieldType.DATE_TIME,
+			id: 'dateDisplay',
+			label: Liferay.Language.get('display-date'),
+			type: 'dateRange',
+		},
+		{
+			entityFieldType: EEntityFieldType.DATE_TIME,
+			id: 'dateExpiration',
+			label: Liferay.Language.get('expiration-date'),
+			type: 'dateRange',
+		},
+		{
+			entityFieldType: EEntityFieldType.DATE_TIME,
+			id: 'dateModified',
+			label: Liferay.Language.get('modified-date'),
+			type: 'dateRange',
+		},
+		{
+			entityFieldType: EEntityFieldType.DATE_TIME,
+			id: 'datePublish',
+			label: Liferay.Language.get('publish-date'),
+			type: 'dateRange',
+		},
+		{
+			entityFieldType: EEntityFieldType.DATE_TIME,
+			id: 'dateReview',
+			label: Liferay.Language.get('review-date'),
+			type: 'dateRange',
+		},
+	];
+}
+
+/**
+ * Returns the grouped filters configuration for CMS Item Selector data sets.
+ */
+export function getCMSItemSelectorGroupedFilters(): IGroupedFilterConfig[] {
+	return [
+		{
+			filters: [
+				'groupIds',
+				'objectDefinitionId',
+				'taxonomyCategoryIds',
+				'keywords',
+				'creatorId',
+				'status',
+			],
+			label: Liferay.Language.get('filter-by'),
+		},
+		{
+			filters: [
+				'dateCreated',
+				'dateDisplay',
+				'dateExpiration',
+				'dateModified',
+				'datePublish',
+				'dateReview',
+			],
+			label: Liferay.Language.get('filter-by-date'),
+		},
+	];
+}

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/openCMSFileSelectorModal.ts
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/openCMSFileSelectorModal.ts
@@ -8,6 +8,10 @@ import {render} from '@liferay/frontend-js-react-web';
 import CMSFileUploaderComponent from '../item_selector_file_uploader/CMSFileUploaderComponent';
 import DetachedCMSFilesItemSelectorModal from './DetachedCMSFilesItemSelectorModal';
 import {IItemSelectorModalProps} from './ItemSelectorModal';
+import {
+	getCMSItemSelectorFilters,
+	getCMSItemSelectorGroupedFilters,
+} from './getCMSItemSelectorFilters';
 
 interface CMSFile {
 	description: string;
@@ -71,20 +75,8 @@ const CMS_FILE_ITEM_SELECTOR_CONFIG: CMSFileItemSelectorModalConfig = {
 
 const FDS_PROPS: Omit<
 	CMSFileItemSelectorModalProps['fdsProps'],
-	'id' | 'items'
+	'filters' | 'id' | 'items'
 > = {
-	filters: [
-		{
-			apiURL: '/o/headless-asset-library/v1.0/asset-libraries',
-			entityFieldType: 'collection',
-			id: 'groupIds',
-			itemKey: 'siteId',
-			itemLabel: 'name',
-			label: Liferay.Language.get('space'),
-			multiple: true,
-			type: 'selection',
-		},
-	],
 	pagination: {
 		deltas: [{label: 20}, {label: 40}, {label: 60}],
 		initialDelta: 20,
@@ -189,6 +181,8 @@ export default function openCMSFileSelectorModal({
 			allowedExtensions,
 			fdsProps: {
 				...FDS_PROPS,
+				filters: getCMSItemSelectorFilters(groupId),
+				groupedFilters: getCMSItemSelectorGroupedFilters(),
 				...fdsProps,
 				id: `CMSItemSelectorFDS_${getRandomId()}`,
 			},

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/types.ts
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/types.ts
@@ -5,6 +5,42 @@
 
 import {IItemSelectorModalProps} from './ItemSelectorModal';
 
+export enum EEntityFieldType {
+	COLLECTION = 'collection',
+	DATE = 'date',
+	DATE_TIME = 'date-time',
+	INTEGER = 'integer',
+	STRING = 'string',
+}
+
+export interface IBaseFilterConfig {
+	entityFieldType: EEntityFieldType | `${EEntityFieldType}`;
+	id: string;
+	label: string;
+	type: 'selection' | 'dateRange' | 'clientExtension';
+}
+
+export interface ISelectionFilterConfig extends IBaseFilterConfig {
+	apiURL?: string;
+	autocompleteEnabled?: boolean;
+	itemKey?: string;
+	itemLabel?: string;
+	items?: Array<{label: string; value: string}>;
+	multiple?: boolean;
+	type: 'selection';
+}
+
+export interface IDateRangeFilterConfig extends IBaseFilterConfig {
+	type: 'dateRange';
+}
+
+export type TFilterConfig = ISelectionFilterConfig | IDateRangeFilterConfig;
+
+export interface IGroupedFilterConfig {
+	filters: string[];
+	label: string;
+}
+
 export type TDetachedItemSelectorModal<T> = Omit<
 	IItemSelectorModalProps<T>,
 	'observer' | 'onOpenChange' | 'open'

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/test/getCMSItemSelectorFilters.test.ts
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/test/getCMSItemSelectorFilters.test.ts
@@ -1,0 +1,81 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {
+	getCMSItemSelectorFilters,
+	getCMSItemSelectorGroupedFilters,
+} from '../src/main/resources/META-INF/resources/item_selector/getCMSItemSelectorFilters';
+import {
+	EEntityFieldType,
+	ISelectionFilterConfig,
+} from '../src/main/resources/META-INF/resources/item_selector/types';
+
+const Liferay = {
+	Language: {
+		get: (key: string) => key,
+	},
+};
+
+(global as any).Liferay = Liferay;
+
+describe('getCMSItemSelectorFilters', () => {
+	it('returns the correct filter configurations', () => {
+		const filters = getCMSItemSelectorFilters(12345);
+
+		expect(filters.length).toBe(12);
+
+		expect(filters.map((f) => f.id)).toEqual([
+			'groupIds',
+			'objectDefinitionId',
+			'taxonomyCategoryIds',
+			'keywords',
+			'creatorId',
+			'status',
+			'dateCreated',
+			'dateDisplay',
+			'dateExpiration',
+			'dateModified',
+			'datePublish',
+			'dateReview',
+		]);
+
+		const typeFilter = filters.find(
+			(f) => f.id === 'objectDefinitionId'
+		) as ISelectionFilterConfig;
+
+		expect(typeFilter?.apiURL).toContain(
+			"objectFolderExternalReferenceCode eq 'L_CMS_FILE_TYPES'"
+		);
+		expect(typeFilter?.entityFieldType).toBe(EEntityFieldType.INTEGER);
+		expect(typeFilter?.itemLabel).toBe('label.LANG');
+
+		const categoryFilter = filters.find(
+			(f) => f.id === 'taxonomyCategoryIds'
+		) as ISelectionFilterConfig;
+		expect(categoryFilter?.entityFieldType).toBe(
+			EEntityFieldType.COLLECTION
+		);
+
+		const authorFilter = filters.find(
+			(f) => f.id === 'creatorId'
+		) as ISelectionFilterConfig;
+		expect(authorFilter?.autocompleteEnabled).toBe(true);
+
+		const statusFilter = filters.find(
+			(f) => f.id === 'status'
+		) as ISelectionFilterConfig;
+
+		expect(statusFilter.items).toBeDefined();
+		expect(statusFilter.items?.length).toBe(5);
+	});
+
+	it('returns the correct grouped filter configurations', () => {
+		const groupedFilters = getCMSItemSelectorGroupedFilters();
+
+		expect(groupedFilters.length).toBe(2);
+		expect(groupedFilters[0].filters.length).toBe(6);
+		expect(groupedFilters[1].filters.length).toBe(6);
+	});
+});

--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Attachment/util/CMSFilesItemSelectorModal.tsx
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Attachment/util/CMSFilesItemSelectorModal.tsx
@@ -8,6 +8,8 @@ import {IView} from '@liferay/frontend-data-set-web';
 import {
 	IItemSelectorModalProps,
 	ItemSelectorModal,
+	getCMSItemSelectorFilters,
+	getCMSItemSelectorGroupedFilters,
 } from '@liferay/frontend-js-item-selector-web';
 import React, {useState} from 'react';
 import {v4 as uuidv4} from 'uuid';
@@ -146,18 +148,10 @@ function CMSFilesItemSelectorModal({
 						},
 					],
 				},
-				filters: [
-					{
-						apiURL: '/o/headless-asset-library/v1.0/asset-libraries',
-						entityFieldType: 'collection',
-						id: 'groupIds',
-						itemKey: 'siteId',
-						itemLabel: 'name',
-						label: Liferay.Language.get('space'),
-						multiple: true,
-						type: 'selection',
-					},
-				],
+				filters: getCMSItemSelectorFilters(
+					Liferay.ThemeDisplay.getSiteGroupId()
+				),
+				groupedFilters: getCMSItemSelectorGroupedFilters(),
 				id: `itemSelectorModal-cms-${uuidv4()}`,
 				views: [
 					{

--- a/modules/test/playwright/tests/frontend-js-item-selector-web/main/itemSelectorModalForCMS.spec.ts
+++ b/modules/test/playwright/tests/frontend-js-item-selector-web/main/itemSelectorModalForCMS.spec.ts
@@ -29,6 +29,7 @@ const test = mergeTests(
 	isolatedSiteTest,
 	loginTest()
 );
+
 interface SpaceTest {
 	assetLibraryKey: string;
 	name: string;
@@ -64,7 +65,7 @@ function createObjectEntryData({title}: {title: string}) {
 	return {
 		file: {
 			fileBase64:
-				'iVBORw0KGgoAAAANSUhEUgAAAD0AAAAXCAIAAAA3N9DuAAAAA3NCSVQICAjb4U/gAAAAEHRFWHRTb2Z0d2FyZQBTaHV0dGVyY4LQCQAABX9JREFUWMOVWFuS3EgOA8BUlXpifuYee4u9/3nWdonEfDAzS91+RKw+HOooKUmCAEiZ//3nP7ZJ4jeX7XR+v15VBizSgO2Q+iarAIoMMcv9FgkbBAyMoI0s7yD9EwkDNiJYZRshAihb69Eqg+igJLheV7k66XKVqxPtd668Ml8kg3GOI0QDaZRB8qrKLBtlhEjilSXO2B24k77SWRbRvxIQYVjiDGV4HbLfLTurIkiybAAE+qiyh6jOUlRnTLI7MGIs8Bgc58C36+XGwBhS2SGGomEWmeURFJHlhr9DShB5pUmTrLKkKneRIEIsG4bIxluk55M03ijMbAFU1c7vfpOZmyrllMZfj49DDFFilm280k2ARqtrLlti2VfWBK9w5aytyiJg9yEkYPRpNsiJ9ysL8xxwVtcs8JUWAElfON0ZR8QuQ5z3j3Gex5PElfXKJPDKjFVGh5EaRhxDG6QmdFcIshbBslxLFTN6OctDnKcRV7rFAGAEI6gvisxKAArh95crz/E8H3FEADgivv3IbnRnUGUDIb6yMn2lR9ALrbJhj+BOdyfUD4zgFGhZxMYbt+q0VdgFhALAEu6vr4ijKs/xHEECIzhCTfFGtNEt4zyi/2ySvH1GrCUAACGGeGWrhd9fWSurMmxzNSHTACo9GyryXQC6AP1siLsnZJD6OD4eQ53T5mWVSXT3s/y6agRJRNx8xsDUH0hg8afsso8Rn6AlSYok0ZIAIc+y3g8aBpDVnlir7uKqLRSc9eIxzueYTduV2t7AP4/49iNtvK7qVofocsu3jCuduTGZNkoR7AtdTKO+K1HbwB3O+8Xlkv0Mya6EoO02osc4/36em7sSSdrdQ2R5hNq5bVSrkOBS6tD0uJ5BTYw2l+m5mHNHYmdvW+0/d1f55ey8WeRE13C/UlVS/PV4PoeaBp3QHpDdm86AgFaik4qk4a6n/ZHLOwiQ7ZPommcGPXS6Hz1rCKBe+pS6vyi1n3oPLAmAGOfx8YiYLxiA28WwPDHEgv3WnNuwuyEjKPEqw+b0ykYeLu9zRFRZk453auuoT5zh/uVP5mjbPsbjHNEairZxslqFbR3kPuhtmkY1hYwRcsO7RHyne/fqjXfd3PBO9DtnWK/fyaCqloo44nlE9LwkcGW1XZI0sCcMyRFqF+KyvKZKO49tENIcMS6X3fvJMhnM/Ysk8/vPDti2aB2/ZL9dWxvdlqHjHM8h7r2KxFX+VLMXCTits827DdQAyUz3iWWDcwtoAxAA4p0o49zrivJ/70iebvgHz7nbDqnz+BihKtjIdFZdWe8dkGvxMLD/bZdsmqwFBvd6PcmjBql5Uq50eU1NHX8DDomLlEOB/+c6x3kOHYMGhjRC0wRbW0trIf7IypwDq6dYdeprLRHZm8n0KIF7Tx+KoAj2lnJVAr3Ru9ybHT+p9feV0NeykXN0yB4oBBaPq3xllZ3pI9QEaOPvydKCjlVeD/krTUCe697sdboM3ylu1Oa089tbvr0nVeJXVmOOfX+M8zxOco5MrY1A0wHfHttxehXZnrNJomDvFK8srR2ogkpXCz+rdurBaLcu23p82VUIhiKoPxNG0DnOj0d01LTJxeP+7tLien9kiHMuqpcldltG0Pb5CO0RaDT+L4G9nzRtyiYIWGtO3SVoOKvSRXDb7c9jyzDJ8/h4jngewcasU19LIoCmafvCVuf+eCNxpY+hKy3DdpGCC2Dx0V0biqtyB+51oNuy8rm2LbK+++bsWQnnZyFMLzri+RzPkHr1bZb3l47IH9ccJFWG3Z8dNvZe1VwfncS0IApoRZfITjp9I7dNMF2ihsKMTRjrKdLvOSDwq15FNQSiPo5nEPu7rtlse4i5uFHzvwB4rc60b/aU/Rc6sWizbSKbGQAAAABJRU5ErkJggg==',
+				'iVBORw0KGgoAAAANSUhEUgAAAD0AAAAXCAIAAAA3N9DuAAAAA3NCSVQICAjb4U/gAAAAEHRFWHRTb2Z0d2FyZQBTaHV0dGVyY4LQCQAABX9JREFUWMOVWFuS3EgOA8BUlXpifuYee4u9/3nWdonEfDAzS91+RKw+HOooKUmCAEiZ//3nP7ZJ4jeX7XR+v15VBizSgO2Q+iarAIoMMcv9FgkbBAyMoI0s7yD9EwkDNiJYZRshAihb69Eqg+igJLheV7k66XKVqxPtd668Ml8kg3GOI0QDaZRB8qrKLBtlhEjilSXO2B24k77SWRbRvxIQYVjiDGV4HbLfLTurIkiybAAE+qiyh6jOUlRnTLI7MGIs8Bgc58C36+XGwBhS2SGGomEWmeURFJHlhr9DShB5pUmTrLKkKneRIEIsG4bIxluk55M03ijMbAFU1c7vfpOZmyrllMZfj49DDFFilm280k2ARqtrLlti2VfWBK9w5aytyiJg9yEkYPRpNsiJ9ysL8xxwVtcs8JUWAElfON0ZR8QuQ5z3j3Gex5PElfXKJPDKjFVGh5EaRhxDG6QmdFcIshbBslxLFTN6OctDnKcRV7rFAGAEI6gvisxKAArh95crz/E8H3FEADgivv3IbnRnUGUDIb6yMn2lR9ALrbJhj+BOdyfUD4zgFGhZxMYbt+q0VdgFhALAEu6vr4ijKs/xHEECIzhCTfFGtNEt4zyi/2ySvH1GrCUAACGGeGWrhd9fWSurMmxzNSHTACo9GyryXQC6AP1siLsnZJD6OD4eQ53T5mWVSXT3s/y6agRJRNx8xsDUH0hg8afsso8Rn6AlSYok0ZIAIc+y3g8aBpDVnlir7uKqLRSc9eIxzueYTduV2t7AP4/49iNtvK7qVofocsu3jCuduTGZNkoR7AtdTKO+K1HbwB3O+8Xlkv0Mya6EoO02osc4/36em7sSSdrdQ2R5hNq5bVSrkOBS6tD0uJ5BTYw2l+m5mHNHYmdvW+0/d1f55ey8WeRE13C/UlVS/PV4PoeaBp3QHpDdm86AgFaik4qk4a6n/ZHLOwiQ7ZPommcGPXS6Hz1rCKBe+pS6vyi1n3oPLAmAGOfx8YiYLxiA28WwPDHEgv3WnNuwuyEjKPEqw+b0ykYeLu9zRFRZk453auuoT5zh/uVP5mjbPsbjHNEairZxslqFbR3kPuhtmkY1hYwRcsO7RHyne/fqjXfd3PBO9DtnWK/fyaCqloo44nlE9LwkcGW1XZI0sCcMyRFqF+KyvKZKO49tENIcMS6X3fvJMhnM/Ysk8/vPDti2aB2/ZL9dWxvdlqHjHM8h7r2KxFX+VLMXCTits827DdQAyUz3iWWDcwtoAxAA4p0o49zrivJ/70iebvgHz7nbDqnz+BihKtjIdFZdWe8dkGvxMLD/bZdsmqwFBvd6PcmjBql5Uq50eU1NHX8DDomLlEOB/+c6x3kOHYMGhjRC0wRbW0trIf7IypwDq6dYdeprLRHZm8n0KIF7Tx+KoAj2lnJVAr3Ru9ybHT+p9feV0NeykXN0yB4oBBaPq3xllZ3pI9QEaOPvydKCjlVeD/krTUCe697sdboM3ylu1Oa089tbvr0nVeJXVmOOfX+M8zxOco5MrY1A0wHfHttxehXZnrNJomDvFK8srR2ogkpXCz+rdurBaLcu23p82VUIhiKoPxNG0DnOj0d01LTJxeP+7tLien9kiHMuqpcldltG0Pb5CO0RaDT+L4G9nzRtyiYIWGtO3SVoOKvSRXDb7c9jyzDJ8/h4jngewcasU19LIoCmafvCVuf+eCNxpY+hKy3DdpGCC2Dx0V0biqtyB+51oNuy8rm2LbK+++bsWQnnZyFMLzri+RzPkHr1bZb3l47IH9ccJFWG3Z8dNvZe1VwfncS0IApoRZfITjp9I7dNMF2ihsKMTRjrKdLvOSDwq15FNQSiPo5nEPu7rtlse4i5uFHzvwB4rc60b/aU/Rc6sWizbSKbGQA',
 			name: `${newTitle.replace(' ', '_')}.png`,
 		},
 		objectEntryFolderExternalReferenceCode: 'L_FILES',
@@ -81,18 +82,6 @@ async function createSpace(
 		settings: {},
 		type: 'Space',
 	});
-}
-
-async function deleteSampleFile(
-	apiHelpers: DataApiHelpers,
-	id?: number
-): Promise<void> {
-	if (id) {
-		await apiHelpers.objectEntry.deleteObjectEntry(
-			APPLICATION_NAME,
-			String(id)
-		);
-	}
 }
 
 async function uploadSampleFile(
@@ -148,20 +137,11 @@ test.beforeEach(async ({apiHelpers, itemSelectorSamplePage, site}) => {
 	await itemSelectorSamplePage.goToPage({layout, site});
 });
 
-test.afterEach(async ({apiHelpers}) => {
-	await deleteSampleFile(apiHelpers, firstSpaceObjectEntry.id);
-	await deleteSampleFile(apiHelpers, secondSpaceObjectEntry.id);
-});
-
-test('Item Selector Modal with Spaces filter for when selecting CMS Files', async ({
+test('Item Selector Modal filters availability for CMS Files', async ({
 	itemSelectorSamplePage,
 	page,
 }) => {
-	await test.step('Check that an Item Selector Modal appears in the page', async () => {
-		await expect(page.getByText('Item Selector Modal')).toBeVisible();
-	});
-
-	await test.step('Check if Spaces filter is available', async () => {
+	await test.step('Check if Item Selector Modal appears and open filters', async () => {
 		await itemSelectorSamplePage.selectCMSFileButton.click();
 
 		await expect(
@@ -170,24 +150,72 @@ test('Item Selector Modal with Spaces filter for when selecting CMS Files', asyn
 
 		waitForFDS({page, visualizationMode: EFDSVisualizationMode.CARDS});
 
-		await expect(
-			page.getByText(firstSpaceObjectEntry.title, {exact: true})
-		).toBeVisible();
+		await itemSelectorSamplePage.filtersButton.click();
+	});
 
-		await expect(
-			page.getByText(secondSpaceObjectEntry.title, {exact: true})
-		).toBeVisible();
+	await test.step('Check that all CMS filters are present in the dropdown', async () => {
+		const expectedFilterLabels = [
+			'Space',
+			'Type',
+			'Category',
+			'Tags',
+			'Author',
+			'Status',
+			'Create Date',
+			'Display Date',
+			'Expiration Date',
+			'Modified Date',
+			'Publish Date',
+			'Review Date',
+		];
 
-		await expect(itemSelectorSamplePage.filtersButton).toBeVisible();
+		for (const label of expectedFilterLabels) {
+			await expect(
+				page.getByRole('menuitem', {name: label})
+			).toBeVisible();
+		}
+	});
+
+	await test.step('Verify Type filter is not empty', async () => {
+		await page.getByRole('menuitem', {name: 'Type'}).click();
+
+		await expect(page.getByText('No items were found')).toBeHidden();
+
+		await expect(page.getByRole('checkbox').first()).toBeVisible();
+
+		await page.getByRole('button', {name: 'Back'}).click();
+	});
+
+	await test.step('Verify Status filter options', async () => {
+		await page.getByRole('menuitem', {name: 'Status'}).click();
+
+		const expectedStatusLabels = [
+			'Approved',
+			'Pending',
+			'Draft',
+			'Expired',
+			'Scheduled',
+		];
+
+		for (const label of expectedStatusLabels) {
+			await expect(page.getByLabel(label)).toBeVisible();
+		}
+	});
+});
+
+test('Item Selector Modal Space filter functionality', async ({
+	itemSelectorSamplePage,
+	page,
+}) => {
+	await test.step('Open Item Selector Modal', async () => {
+		await itemSelectorSamplePage.selectCMSFileButton.click();
+		waitForFDS({page, visualizationMode: EFDSVisualizationMode.CARDS});
 	});
 
 	await test.step(`Filter CMS Files by ${firstSpace.name}`, async () => {
 		await itemSelectorSamplePage.filtersButton.click();
-
 		await page.getByRole('menuitem', {name: 'Space'}).click();
-
 		await page.getByLabel(firstSpace.name).click();
-
 		await page.getByRole('button', {name: 'Add Filter'}).click();
 
 		waitForFDS({page, visualizationMode: EFDSVisualizationMode.CARDS});


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPD-80771

#### Summary
This PR aligns the filters available in the CMS Item Selector (used in CKEditor and Object Attachment fields) with the CMS "Contents" data set. It also introduces grouped filter support to the `HeadlessDisplayTag`, enabling categorized filters in the CMS dashboard and other headless FDS instances.

#### Changes
- **Core Filtering Utility**: Introduced `getCMSItemSelectorFilters.ts` to centralize filter definitions for CMS contexts, including Space, Type, Category, Tags, Author, Status, and 6 Date Range filters.
- **Backend Taglib Update**: Updated `HeadlessDisplayTag.java` to serialize and pass `groupedFilters` to the frontend, fulfilling a feature gap and enabling categorized filters in the CMS "Contents" view.
- **Modal Integrations**: Integrated the new filters into `openCMSFileSelectorModal.ts`, CKEditor's `HeadlessItemSelector.ts`, and the Object Attachment field's modal.
- **Bug Fixes**:
    - Fixed the "Status" filter by renaming `options` to `items` in type definitions and logic to match component requirements.
    - Corrected the "Category" filter to use the proper headless taxonomy endpoint.
    - Restricted "Type" filters to file-related object definitions and fixed localized label mapping (`label.LANG`).
- **Tests**: Added Jest unit tests for the filter utility and enhanced Playwright functional tests to verify UI visibility and functionality.

#### How to test it
1. Go to **CMS -> Contents**.
2. Verify that the filters are now grouped (e.g., a "Filter By Date" section) instead of a flat list.
3. Open a Web Content or any content with a CKEditor instance.
4. Click on **Select Image** or **Select Video**.
5. Click on the **Filter and Order** button.
6. Verify that all 12 filters are present and correctly grouped.
7. Verify that the **Status** filter has the correct options (Approved, Pending, etc.).
8. Verify that the **Type** filter is functional and contains file types.
9. Run unit tests: `yarn test test/getCMSItemSelectorFilters.test.ts` in `modules/apps/frontend-js/frontend-js-item-selector-web`.
10. Run Playwright tests: `npx playwright test tests/frontend-js-item-selector-web/main/itemSelectorModalForCMS.spec.ts` in `modules/test/playwright`.

<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/a9c3f0f6-b5db-4de8-9df5-a9ccbc0cc3d4" />
