### PR TITLE
LPD-85965 Replace “Maintenance” label with low-impact informational icon

### DIFF
--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/feature_indicator/FeatureIndicator.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/feature_indicator/FeatureIndicator.tsx
@@ -109,6 +109,8 @@ export default function FeatureIndicator({
 		tooltipTitle = Liferay.Language.get('open-maintenance-mode-definition');
 	}
 
+	const showLabel = type !== 'maintenance';
+
 	return (
 		<LearnResourcesContext.Provider value={learnResourceContext}>
 			{interactive ? (
@@ -135,12 +137,18 @@ export default function FeatureIndicator({
 								title={tooltipTitle}
 								translucent
 							>
-								<span className="inline-item text-uppercase">
-									{label}
-								</span>
+								{showLabel && (
+									<span className="inline-item text-uppercase">
+										{label}
+									</span>
+								)}
 
 								{symbol && (
-									<span className="inline-item inline-item-after ml-2">
+									<span
+										className={classNames('inline-item', {
+											'inline-item-after ml-2': showLabel,
+										})}
+									>
 										<ClayIcon symbol={symbol} />
 									</span>
 								)}
@@ -175,7 +183,7 @@ export default function FeatureIndicator({
 					className={classNames('text-uppercase', className)}
 					dark={dark}
 					displayType={displayType}
-					label={label}
+					label={showLabel ? label : undefined}
 					symbol={symbol}
 					translucent
 				/>

--- a/modules/apps/frontend-js/frontend-js-components-web/test/feature_indicator/FeatureIndicator.test.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/test/feature_indicator/FeatureIndicator.test.tsx
@@ -8,64 +8,102 @@ import React from 'react';
 
 import '@testing-library/jest-dom';
 
-import { FeatureIndicator } from '../../src/main/resources/META-INF/resources';
-
+import {FeatureIndicator} from '../../src/main/resources/META-INF/resources';
 
 describe('FeatureIndicator', () => {
-    
-    describe('Type: Maintenance', () => {
-        it('does NOT render the text label when type is maintenance', () => {
-            render(<FeatureIndicator interactive={true} learnResourceContext="https://learn.liferay.com/test-url" type="maintenance" />);
-            
-            const label = screen.queryByText('maintenance');
-            expect(label).not.toBeInTheDocument();
-        });
+	describe('Type: Maintenance', () => {
+		it('does NOT render the text label when type is maintenance', () => {
+			render(
+				<FeatureIndicator
+					interactive={true}
+					learnResourceContext="https://learn.liferay.com/test-url"
+					type="maintenance"
+				/>
+			);
 
-        it('renders the info icon when type is maintenance', () => {
-            const {container} = render(<FeatureIndicator interactive={true} learnResourceContext="https://learn.liferay.com/test-url" type="maintenance"/>);
-            
-            const icon = container.querySelector('svg.lexicon-icon-info-circle-open');
-            expect(icon).toBeInTheDocument();
-        });
+			const label = screen.queryByText('maintenance');
+			expect(label).not.toBeInTheDocument();
+		});
 
-        it('does NOT have "inline-item-after" class on the icon span when maintenance', () => {
-            const {container} = render(<FeatureIndicator interactive={true}  learnResourceContext="https://learn.liferay.com/test-url" type="maintenance"/>);
-            
-            const iconSpan = container.querySelector('.inline-item');
-            expect(iconSpan).not.toHaveClass('inline-item-after');
-        });
-    });
+		it('renders the info icon when type is maintenance', () => {
+			const {container} = render(
+				<FeatureIndicator
+					interactive={true}
+					learnResourceContext="https://learn.liferay.com/test-url"
+					type="maintenance"
+				/>
+			);
 
-    describe('Type: Beta (Standard Behavior)', () => {
-        it('renders both label and icon for beta type', () => {
-            render(<FeatureIndicator interactive={true} learnResourceContext="https://learn.liferay.com/test-url" type="beta" />);
-            
-            const label = screen.getByText('beta');
-            expect(label).toBeInTheDocument();
-            expect(label).toHaveClass('inline-item');
-        });
+			const icon = container.querySelector(
+				'svg.lexicon-icon-info-circle-open'
+			);
+			expect(icon).toBeInTheDocument();
+		});
 
-        it('has "inline-item-after" class on the icon span when label is present', () => {
-            const {container} = render(<FeatureIndicator interactive={true} learnResourceContext="https://learn.liferay.com/test-url" type="beta" />);
-            
-            const iconSpan = container.querySelector('span.inline-item-after');
-            expect(iconSpan).toBeInTheDocument();
-        });
-    });
+		it('does NOT have "inline-item-after" class on the icon span when maintenance', () => {
+			const {container} = render(
+				<FeatureIndicator
+					interactive={true}
+					learnResourceContext="https://learn.liferay.com/test-url"
+					type="maintenance"
+				/>
+			);
 
-    describe('Interactive Mode', () => {
-        it('renders a button when interactive is true', () => {
-            render(<FeatureIndicator interactive={true} learnResourceContext="https://learn.liferay.com/test-url" type="maintenance" />);
-            
-            const button = screen.getByRole('button');
-            expect(button).toBeInTheDocument();
-        });
+			const iconSpan = container.querySelector('.inline-item');
+			expect(iconSpan).not.toHaveClass('inline-item-after');
+		});
+	});
 
-        it('renders a badge when interactive is false', () => {
-            const {container} = render(<FeatureIndicator interactive={false} type="maintenance" />);
-            
-            const badge = container.querySelector('.badge');
-            expect(badge).toBeInTheDocument();
-        });
-    });
+	describe('Type: Beta (Standard Behavior)', () => {
+		it('renders both label and icon for beta type', () => {
+			render(
+				<FeatureIndicator
+					interactive={true}
+					learnResourceContext="https://learn.liferay.com/test-url"
+					type="beta"
+				/>
+			);
+
+			const label = screen.getByText('beta');
+			expect(label).toBeInTheDocument();
+			expect(label).toHaveClass('inline-item');
+		});
+
+		it('has "inline-item-after" class on the icon span when label is present', () => {
+			const {container} = render(
+				<FeatureIndicator
+					interactive={true}
+					learnResourceContext="https://learn.liferay.com/test-url"
+					type="beta"
+				/>
+			);
+
+			const iconSpan = container.querySelector('span.inline-item-after');
+			expect(iconSpan).toBeInTheDocument();
+		});
+	});
+
+	describe('Interactive Mode', () => {
+		it('renders a button when interactive is true', () => {
+			render(
+				<FeatureIndicator
+					interactive={true}
+					learnResourceContext="https://learn.liferay.com/test-url"
+					type="maintenance"
+				/>
+			);
+
+			const button = screen.getByRole('button');
+			expect(button).toBeInTheDocument();
+		});
+
+		it('renders a badge when interactive is false', () => {
+			const {container} = render(
+				<FeatureIndicator interactive={false} type="maintenance" />
+			);
+
+			const badge = container.querySelector('.badge');
+			expect(badge).toBeInTheDocument();
+		});
+	});
 });

--- a/modules/apps/frontend-js/frontend-js-components-web/test/feature_indicator/FeatureIndicator.test.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/test/feature_indicator/FeatureIndicator.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {render, screen} from '@testing-library/react';
+import React from 'react';
+
+import '@testing-library/jest-dom';
+
+import { FeatureIndicator } from '../../src/main/resources/META-INF/resources';
+
+
+describe('FeatureIndicator', () => {
+    
+    describe('Type: Maintenance', () => {
+        it('does NOT render the text label when type is maintenance', () => {
+            render(<FeatureIndicator interactive={true} learnResourceContext="https://learn.liferay.com/test-url" type="maintenance" />);
+            
+            const label = screen.queryByText('maintenance');
+            expect(label).not.toBeInTheDocument();
+        });
+
+        it('renders the info icon when type is maintenance', () => {
+            const {container} = render(<FeatureIndicator interactive={true} learnResourceContext="https://learn.liferay.com/test-url" type="maintenance"/>);
+            
+            const icon = container.querySelector('svg.lexicon-icon-info-circle-open');
+            expect(icon).toBeInTheDocument();
+        });
+
+        it('does NOT have "inline-item-after" class on the icon span when maintenance', () => {
+            const {container} = render(<FeatureIndicator interactive={true}  learnResourceContext="https://learn.liferay.com/test-url" type="maintenance"/>);
+            
+            const iconSpan = container.querySelector('.inline-item');
+            expect(iconSpan).not.toHaveClass('inline-item-after');
+        });
+    });
+
+    describe('Type: Beta (Standard Behavior)', () => {
+        it('renders both label and icon for beta type', () => {
+            render(<FeatureIndicator interactive={true} learnResourceContext="https://learn.liferay.com/test-url" type="beta" />);
+            
+            const label = screen.getByText('beta');
+            expect(label).toBeInTheDocument();
+            expect(label).toHaveClass('inline-item');
+        });
+
+        it('has "inline-item-after" class on the icon span when label is present', () => {
+            const {container} = render(<FeatureIndicator interactive={true} learnResourceContext="https://learn.liferay.com/test-url" type="beta" />);
+            
+            const iconSpan = container.querySelector('span.inline-item-after');
+            expect(iconSpan).toBeInTheDocument();
+        });
+    });
+
+    describe('Interactive Mode', () => {
+        it('renders a button when interactive is true', () => {
+            render(<FeatureIndicator interactive={true} learnResourceContext="https://learn.liferay.com/test-url" type="maintenance" />);
+            
+            const button = screen.getByRole('button');
+            expect(button).toBeInTheDocument();
+        });
+
+        it('renders a badge when interactive is false', () => {
+            const {container} = render(<FeatureIndicator interactive={false} type="maintenance" />);
+            
+            const badge = container.querySelector('.badge');
+            expect(badge).toBeInTheDocument();
+        });
+    });
+});

--- a/modules/test/playwright/tests/product-navigation-control-menu-web/main/controlMenu.spec.ts
+++ b/modules/test/playwright/tests/product-navigation-control-menu-web/main/controlMenu.spec.ts
@@ -17,13 +17,15 @@ import {
 	performLogout,
 	userData,
 } from '../../../utils/performLogin';
+import { journalPagesTest } from '../../journal-web/main/fixtures/journalPagesTest';
 
 const test = mergeTests(
 	dataApiHelpersTest,
 	isolatedSiteTest,
 	loginTest(),
 	pagesAdminPagesTest,
-	siteSettingsPagesTest
+	siteSettingsPagesTest,
+	journalPagesTest
 );
 
 test(
@@ -172,3 +174,35 @@ test(
 		});
 	}
 );
+
+test('Check if the maintenance mode indicator is displaying correctly', async ({journalPage, page}) => {
+	const infoButton = page.getByRole('button', {
+            name: 'Open Maintenance Mode Definition'
+        });
+
+	await test.step('should show only the info icon without "Maintenance" text', async () => {
+
+		await journalPage.goto();
+
+        await expect(infoButton).toBeVisible();
+        await expect(infoButton).toHaveClass(/rounded-pill/); 
+        await expect(infoButton).toHaveClass(/btn-xs/);
+
+        const buttonText = await infoButton.innerText();
+        expect(buttonText.trim()).toBe('');
+
+        const icon = infoButton.locator('svg.lexicon-icon-info-circle-open');
+        await expect(icon).toBeVisible();
+
+        const iconContainer = infoButton.locator('span.inline-item');
+        await expect(iconContainer).not.toHaveClass(/inline-item-after/);
+    });
+
+    await test.step('should show popover/dialog when clicked', async () => {
+        await infoButton.click();
+
+        const popover = page.getByRole('dialog');
+        await expect(popover).toBeVisible();
+        await expect(popover).toContainText('This feature is in maintenance mode. Learn more about maintenance mode.');
+    });
+});

--- a/modules/test/playwright/tests/product-navigation-control-menu-web/main/controlMenu.spec.ts
+++ b/modules/test/playwright/tests/product-navigation-control-menu-web/main/controlMenu.spec.ts
@@ -17,7 +17,7 @@ import {
 	performLogout,
 	userData,
 } from '../../../utils/performLogin';
-import { journalPagesTest } from '../../journal-web/main/fixtures/journalPagesTest';
+import {journalPagesTest} from '../../journal-web/main/fixtures/journalPagesTest';
 
 const test = mergeTests(
 	dataApiHelpersTest,
@@ -175,34 +175,38 @@ test(
 	}
 );
 
-test('Check if the maintenance mode indicator is displaying correctly', async ({journalPage, page}) => {
+test('Check if the maintenance mode indicator is displaying correctly', async ({
+	journalPage,
+	page,
+}) => {
 	const infoButton = page.getByRole('button', {
-            name: 'Open Maintenance Mode Definition'
-        });
+		name: 'Open Maintenance Mode Definition',
+	});
 
 	await test.step('should show only the info icon without "Maintenance" text', async () => {
-
 		await journalPage.goto();
 
-        await expect(infoButton).toBeVisible();
-        await expect(infoButton).toHaveClass(/rounded-pill/); 
-        await expect(infoButton).toHaveClass(/btn-xs/);
+		await expect(infoButton).toBeVisible();
+		await expect(infoButton).toHaveClass(/rounded-pill/);
+		await expect(infoButton).toHaveClass(/btn-xs/);
 
-        const buttonText = await infoButton.innerText();
-        expect(buttonText.trim()).toBe('');
+		const buttonText = await infoButton.innerText();
+		expect(buttonText.trim()).toBe('');
 
-        const icon = infoButton.locator('svg.lexicon-icon-info-circle-open');
-        await expect(icon).toBeVisible();
+		const icon = infoButton.locator('svg.lexicon-icon-info-circle-open');
+		await expect(icon).toBeVisible();
 
-        const iconContainer = infoButton.locator('span.inline-item');
-        await expect(iconContainer).not.toHaveClass(/inline-item-after/);
-    });
+		const iconContainer = infoButton.locator('span.inline-item');
+		await expect(iconContainer).not.toHaveClass(/inline-item-after/);
+	});
 
-    await test.step('should show popover/dialog when clicked', async () => {
-        await infoButton.click();
+	await test.step('should show popover/dialog when clicked', async () => {
+		await infoButton.click();
 
-        const popover = page.getByRole('dialog');
-        await expect(popover).toBeVisible();
-        await expect(popover).toContainText('This feature is in maintenance mode. Learn more about maintenance mode.');
-    });
+		const popover = page.getByRole('dialog');
+		await expect(popover).toBeVisible();
+		await expect(popover).toContainText(
+			'This feature is in maintenance mode. Learn more about maintenance mode.'
+		);
+	});
 });


### PR DESCRIPTION
**Ticket:** https://liferay.atlassian.net/browse/LPD-85965

This PR replaces the persistent "Maintenance" label with a low-impact informational icon and tooltip for features in maintenance mode.
The goal is to provide transparency about the feature's lifecycle without causing unnecessary alarm or confusion among users, who often misinterpreted the "Maintenance" badge as a sign of imminent deprecation or system instability.

### Changes

Global Componente `FeatureIndicator.tsx`:

- Updated the maintenance type logic to conditionally hide the text label.
- Adjusted the ClayButton (interactive) and ClayBadge (non-interactive) to render only the `info-circle-open` symbol when the type is maintenance.
- Refined spacing and styles to ensure the icon remains centered and visually balanced without the accompanying text.

---
[newinfobutton.webm](https://github.com/user-attachments/assets/5ed9afbf-21e6-4a18-8081-6c7ce2b1ba23)

### Attention Points

1. The `BaseInfoMessageProductNavigationControlMenuEntry` class is having its `dark` property set to true, which on my machine made the button and icon appear a little pale, given that the application's new styles are light.