### PR TITLE
LPD-86155 Add #main-content to terms of use

### DIFF
--- a/modules/apps/layout/layout-utility-page/layout-utility-page-terms-of-use/src/main/resources/META-INF/resources/terms_of_use.jsp
+++ b/modules/apps/layout/layout-utility-page/layout-utility-page-terms-of-use/src/main/resources/META-INF/resources/terms_of_use.jsp
@@ -21,7 +21,7 @@
 	TermsOfUseContentProvider termsOfUseContentProvider = (TermsOfUseContentProvider)request.getAttribute(TermsOfUseContentProvider.class.getName());
 	%>
 
-	<div class="mt-4 sheet sheet-lg">
+	<div class="mt-4 sheet sheet-lg" id="main-content" role="main" tabindex="-1">
 		<div class="sheet-header">
 			<div class="autofit-padded-no-gutters-x autofit-row">
 				<div class="autofit-col autofit-col-expand">


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPD-86155

It fixes the "Broken skip link" accessibility error in the terms of use page. It works by adding the expected ID to the terms of use page. It was evaluated using WAVE.

<img width="2440" height="915" alt="image" src="https://github.com/user-attachments/assets/e4c209ff-de6f-4670-8973-0d5b037d4744" />
