### PR TITLE
LPD-86326 Update portal title to reflect updated Design Library

### DIFF
--- a/modules/apps/design-library/design-library-web/src/main/java/com/liferay/design/library/web/internal/display/context/DesignLibrarySettingsDisplayContext.java
+++ b/modules/apps/design-library/design-library-web/src/main/java/com/liferay/design/library/web/internal/display/context/DesignLibrarySettingsDisplayContext.java
@@ -48,6 +48,8 @@ public class DesignLibrarySettingsDisplayContext {
 			"externalReferenceCode", group.getExternalReferenceCode()
 		).put(
 			"groupId", group.getGroupId()
+		).put(
+			"portletId", _getThemeDisplay().getPpid()
 		).build();
 	}
 
@@ -59,14 +61,16 @@ public class DesignLibrarySettingsDisplayContext {
 		portletDisplay.setURLBack(_getBackURL());
 
 		Group group = _getGroup();
-		ThemeDisplay themeDisplay =
-			(ThemeDisplay)_httpServletRequest.getAttribute(
-				WebKeys.THEME_DISPLAY);
 
 		renderResponse.setTitle(
 			LanguageUtil.format(
 				_httpServletRequest, "x-settings",
-				group.getName(themeDisplay.getLocale()), false));
+				group.getName(_getThemeDisplay().getLocale()), false));
+	}
+
+	private ThemeDisplay _getThemeDisplay() {
+		return (ThemeDisplay)_httpServletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
 	}
 
 	private String _getBackURL() {

--- a/modules/apps/design-library/design-library-web/src/main/java/com/liferay/design/library/web/internal/display/context/DesignLibrarySettingsDisplayContext.java
+++ b/modules/apps/design-library/design-library-web/src/main/java/com/liferay/design/library/web/internal/display/context/DesignLibrarySettingsDisplayContext.java
@@ -68,11 +68,6 @@ public class DesignLibrarySettingsDisplayContext {
 				group.getName(_getThemeDisplay().getLocale()), false));
 	}
 
-	private ThemeDisplay _getThemeDisplay() {
-		return (ThemeDisplay)_httpServletRequest.getAttribute(
-			WebKeys.THEME_DISPLAY);
-	}
-
 	private String _getBackURL() {
 		return PortletURLBuilder.createRenderURL(
 			_liferayPortletResponse
@@ -95,6 +90,11 @@ public class DesignLibrarySettingsDisplayContext {
 		_group = depotEntry.getGroup();
 
 		return _group;
+	}
+
+	private ThemeDisplay _getThemeDisplay() {
+		return (ThemeDisplay)_httpServletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
 	}
 
 	private final long _designLibraryEntryId;

--- a/modules/apps/design-library/design-library-web/src/main/resources/META-INF/resources/js/components/design-libraries/DesignLibrarySettings.tsx
+++ b/modules/apps/design-library/design-library-web/src/main/resources/META-INF/resources/js/components/design-libraries/DesignLibrarySettings.tsx
@@ -20,12 +20,14 @@ interface DesignLibrarySettingsProps {
 	backURL: string;
 	externalReferenceCode: string;
 	groupId: string;
+	portletId: string;
 }
 
 export default function DesignLibrarySettings({
 	backURL,
 	externalReferenceCode,
 	groupId,
+	portletId
 }: DesignLibrarySettingsProps) {
 	const id = useId();
 
@@ -75,9 +77,12 @@ export default function DesignLibrarySettings({
 
 				const updatedDesignLibrary = data as DesignLibrary;
 
-				if (setDesignLibrary) {
-					setDesignLibrary(updatedDesignLibrary);
+				setDesignLibrary(updatedDesignLibrary);
+
+				if (name !== designLibrary?.name) {
+					Liferay.Portlet.refresh(`#p_p_id_${portletId}_`);
 				}
+
 			}
 			catch (error: any) {
 				const errorMessage =

--- a/modules/apps/design-library/design-library-web/src/main/resources/META-INF/resources/js/components/design-libraries/DesignLibrarySettings.tsx
+++ b/modules/apps/design-library/design-library-web/src/main/resources/META-INF/resources/js/components/design-libraries/DesignLibrarySettings.tsx
@@ -27,7 +27,7 @@ export default function DesignLibrarySettings({
 	backURL,
 	externalReferenceCode,
 	groupId,
-	portletId
+	portletId,
 }: DesignLibrarySettingsProps) {
 	const id = useId();
 
@@ -82,7 +82,6 @@ export default function DesignLibrarySettings({
 				if (name !== designLibrary?.name) {
 					Liferay.Portlet.refresh(`#p_p_id_${portletId}_`);
 				}
-
 			}
 			catch (error: any) {
 				const errorMessage =

--- a/modules/test/playwright/tests/design-library-web/main/designLibrary.spec.ts
+++ b/modules/test/playwright/tests/design-library-web/main/designLibrary.spec.ts
@@ -374,6 +374,12 @@ test(
 
 			await settingsMenuItem.click();
 
+			const headerTitle = page.getByTestId('headerTitle');
+
+			await expect(headerTitle).toBeVisible();
+
+			await expect(headerTitle).toHaveText(`${designLibraryName} Settings`);
+
 			await expect(page.getByRole('textbox', {name: 'Name'})).toHaveValue(
 				designLibraryName
 			);
@@ -394,7 +400,10 @@ test(
 
 			await page.getByRole('button', {name: 'Save'}).click();
 
-			await page.waitForLoadState();
+			await waitForAlert(
+				page,
+				`Success:${editedDesignLibraryName} was saved successfully.`
+			);
 
 			await expect(page.getByRole('textbox', {name: 'Name'})).toHaveValue(
 				editedDesignLibraryName

--- a/modules/test/playwright/tests/design-library-web/main/designLibrary.spec.ts
+++ b/modules/test/playwright/tests/design-library-web/main/designLibrary.spec.ts
@@ -378,7 +378,9 @@ test(
 
 			await expect(headerTitle).toBeVisible();
 
-			await expect(headerTitle).toHaveText(`${designLibraryName} Settings`);
+			await expect(headerTitle).toHaveText(
+				`${designLibraryName} Settings`
+			);
 
 			await expect(page.getByRole('textbox', {name: 'Name'})).toHaveValue(
 				designLibraryName


### PR DESCRIPTION
**Ticket:** https://liferay.atlassian.net/browse/LPD-86326

This PR is a follow-up that updates the portlet header title in the design library settings to reflect updates. Because the header is detached from the rest of the design and changes to it are made directly on the backend during rendering, it is currently not reflecting the changes.

### How was it resolved?

Since the idea is to avoid any page reloading, the initial solution involves simply refreshing the portlet, so it updates directly with the new information. However, we might not be able to proceed with this idea, as refreshing the portlet is causing React components on the screen to be unmounted that are not directly related to the portlet design library. If this cannot be resolved, the best options would be to remove the header for this page and add one made entirely in the frontend, as in the CMS (in which case we would lose the user button and the menu as in the CMS), or perform a page reload to update the information.

**NOTE**: Even if we follow an alternative approach to the refresh, it's important to keep an eye on this behavior, because since the new global menu is in beta and will be released at some point, any refresh performance could break the application, as the global menu's side navigation is a React component.