### PR TITLE
LPD-86166 Disabling update and save buttons from Configuration interface until the form is loaded

### DIFF
--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/edit_configuration.jsp
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/edit_configuration.jsp
@@ -199,10 +199,10 @@ renderResponse.setTitle(categoryDisplayName);
 							<aui:button-row>
 								<c:choose>
 									<c:when test="<%= configurationModel.hasScopeConfiguration(configurationScopeDisplayContext.getScope()) %>">
-										<aui:button data-qa-id="submitConfiguration" name="update" type="submit" value="update" />
+										<aui:button data-qa-id="submitConfiguration" disabled="<%= true %>" name="update" type="submit" value="update" />
 									</c:when>
 									<c:otherwise>
-										<aui:button data-qa-id="submitConfiguration" name="save" type="submit" value="save" />
+										<aui:button data-qa-id="submitConfiguration" disabled="<%= true %>" name="save" type="submit" value="save" />
 									</c:otherwise>
 								</c:choose>
 
@@ -222,3 +222,36 @@ renderResponse.setTitle(categoryDisplayName);
 		</clay:col>
 	</clay:row>
 </clay:container-fluid>
+
+<aui:script use="aui-base">
+	AUI().ready(function () {
+		var formId = '<portlet:namespace />fm';
+		var saveBtnId = '#<portlet:namespace />save';
+		var updateBtnId = '#<portlet:namespace />update';
+
+		var pollingId = setInterval(function () {
+			var form = document.getElementById(formId);
+
+			if (form) {
+				var visibleInputs = form.querySelectorAll(
+					'input:not([type="hidden"]), select, textarea'
+				);
+
+				if (visibleInputs.length > 0) {
+					var saveBtn = A.one(saveBtnId);
+					var updateBtn = A.one(updateBtnId);
+
+					if (saveBtn) {
+						Liferay.Util.toggleDisabled(saveBtn, false);
+					}
+
+					if (updateBtn) {
+						Liferay.Util.toggleDisabled(updateBtn, false);
+					}
+
+					clearInterval(pollingId);
+				}
+			}
+		}, 200);
+	});
+</aui:script>


### PR DESCRIPTION
**Ticket:** https://liferay.atlassian.net/browse/LPD-86166

This PR solves the issue that allows users to click on the "Save" and "Update" buttons from the Configuration interface when they have a slow internet connection and the form data has not been loaded yet.

### How was it resolved?
I defaulted the status of the "Save" and "Update" buttons to "disabled" and added some JS code that checks periodically if the HTML form does contains not hidden elements. In case the form only contains hidden elements or no elements at all, we need to wait some time before checking again to see if we can enable the button. When there are non hidden elements in the form, it means it has been loaded, so we can enable again the button.