### PR TITLE
LPD-86410 Fix global menu crashing when Liferay.Portlet.refresh is called

### DIFF
--- a/modules/apps/application-list/application-list-taglib/src/main/java/com/liferay/application/list/taglib/internal/display/context/SideNavigationDisplayContext.java
+++ b/modules/apps/application-list/application-list-taglib/src/main/java/com/liferay/application/list/taglib/internal/display/context/SideNavigationDisplayContext.java
@@ -37,10 +37,19 @@ import java.util.Map;
 public class SideNavigationDisplayContext {
 
 	public SideNavigationDisplayContext(HttpServletRequest httpServletRequest) {
+		this(
+			httpServletRequest,
+			(PanelAppRegistry)httpServletRequest.getAttribute(
+				ApplicationListWebKeys.PANEL_APP_REGISTRY));
+	}
+
+	public SideNavigationDisplayContext(
+		HttpServletRequest httpServletRequest,
+		PanelAppRegistry panelAppRegistry) {
+
 		_httpServletRequest = httpServletRequest;
 
-		_panelAppRegistry = (PanelAppRegistry)httpServletRequest.getAttribute(
-			ApplicationListWebKeys.PANEL_APP_REGISTRY);
+		_panelAppRegistry = panelAppRegistry;
 
 		_panelCategoryHelper = new PanelCategoryHelper(_panelAppRegistry);
 
@@ -79,7 +88,9 @@ public class SideNavigationDisplayContext {
 		).put(
 			"label", _panelCategory.getLabel(_themeDisplay.getLocale())
 		).put(
-			"portletId", _portletId
+			"portletId", StringPool.BLANK
+		).put(
+			"selectedPortletId", _portletId
 		).put(
 			"siteAdministrationItemSelectedEventName", itemSelectedEventName
 		).put(

--- a/modules/apps/application-list/application-list-taglib/src/main/java/com/liferay/application/list/taglib/navigation/SideNavigationControlMenuEntry.java
+++ b/modules/apps/application-list/application-list-taglib/src/main/java/com/liferay/application/list/taglib/navigation/SideNavigationControlMenuEntry.java
@@ -6,7 +6,6 @@
 package com.liferay.application.list.taglib.navigation;
 
 import com.liferay.application.list.PanelAppRegistry;
-import com.liferay.application.list.constants.ApplicationListWebKeys;
 import com.liferay.application.list.display.context.logic.PanelCategoryHelper;
 import com.liferay.application.list.taglib.internal.display.context.SideNavigationDisplayContext;
 import com.liferay.frontend.taglib.clay.servlet.taglib.IconTag;
@@ -62,7 +61,8 @@ public class SideNavigationControlMenuEntry
 		throws IOException {
 
 		SideNavigationDisplayContext sideNavigationDisplayContext =
-			new SideNavigationDisplayContext(httpServletRequest);
+			new SideNavigationDisplayContext(
+				httpServletRequest, _panelAppRegistry);
 
 		try {
 			PrintWriter printWriter = httpServletResponse.getWriter();
@@ -103,7 +103,8 @@ public class SideNavigationControlMenuEntry
 
 			_reactRenderer.renderReact(
 				new ComponentDescriptor(
-					"{SideNavigationToggler} from application-list-taglib"),
+					"{SideNavigationToggler} from application-list-taglib",
+					null, null, true),
 				HashMapBuilder.<String, Object>put(
 					"visible", sideNavigationDisplayContext.isVisible()
 				).build(),
@@ -127,12 +128,8 @@ public class SideNavigationControlMenuEntry
 		if (FeatureFlagManagerUtil.isEnabled(
 				themeDisplay.getCompanyId(), "LPD-36105")) {
 
-			PanelAppRegistry panelAppRegistry =
-				(PanelAppRegistry)httpServletRequest.getAttribute(
-					ApplicationListWebKeys.PANEL_APP_REGISTRY);
-
 			PanelCategoryHelper panelCategoryHelper = new PanelCategoryHelper(
-				panelAppRegistry);
+				_panelAppRegistry);
 
 			return panelCategoryHelper.containsPortlet(
 				themeDisplay.getPpid(), "applications_menu");
@@ -140,6 +137,9 @@ public class SideNavigationControlMenuEntry
 
 		return false;
 	}
+
+	@Reference
+	private PanelAppRegistry _panelAppRegistry;
 
 	@Reference
 	private ReactRenderer _reactRenderer;

--- a/modules/apps/application-list/application-list-taglib/src/main/resources/META-INF/resources/js/SideNavigation.tsx
+++ b/modules/apps/application-list/application-list-taglib/src/main/resources/META-INF/resources/js/SideNavigation.tsx
@@ -24,7 +24,7 @@ interface Props {
 	expandedKeysSessionKey: string;
 	items: Array<SideNavigationItem>;
 	label: string;
-	portletId: string;
+	selectedPortletId: string;
 	siteAdministrationItemSelectedEventName: string;
 	siteAdministrationItemSelectorUrl: string;
 	visible: boolean;
@@ -38,7 +38,7 @@ function SideNavigation({
 	expandedKeysSessionKey,
 	items: externalItems,
 	label,
-	portletId,
+	selectedPortletId,
 	siteAdministrationItemSelectedEventName,
 	siteAdministrationItemSelectorUrl,
 	visible: initialVisible,
@@ -176,7 +176,7 @@ function SideNavigation({
 
 				{numberOfResults ? (
 					<ClayVerticalNav
-						active={portletId}
+						active={selectedPortletId}
 						defaultExpandedKeys={initialExpandedKeys}
 						displayType="primary"
 						expandedKeys={expandedKeys ?? userExpandedKeys}

--- a/modules/apps/application-list/application-list-taglib/test/SideNavigation.test.tsx
+++ b/modules/apps/application-list/application-list-taglib/test/SideNavigation.test.tsx
@@ -59,7 +59,7 @@ const renderComponent = ({expandedKeys = ['content', 'workflow']} = {}) =>
 			expandedKeysSessionKey="expandedKeysSessionKey"
 			items={ITEMS}
 			label="Applications"
-			portletId="assets"
+			selectedPortletId="assets"
 			siteAdministrationItemSelectedEventName="siteAdministrationItemSelectedEventName"
 			siteAdministrationItemSelectorUrl="siteAdministrationItemSelectorUrl"
 			visible

--- a/modules/test/playwright/tests/application-list-taglib/main/sideNavigation.spec.ts
+++ b/modules/test/playwright/tests/application-list-taglib/main/sideNavigation.spec.ts
@@ -7,16 +7,20 @@ import {expect, mergeTests} from '@playwright/test';
 
 import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
 import {globalMenuPagesTest} from '../../../fixtures/globalMenuPagesTest';
+import {isolatedSiteTest} from '../../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../../fixtures/loginTest';
 import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
 import {closeProductMenu, openProductMenu} from '../../../utils/productMenu';
 import {waitForPageToBeLoaded} from '../../../utils/waitForPageToBeLoaded';
+import {contentDashboardPagesTest} from '../../content-dashboard-web/main/fixtures/contentDashboardPagesTest';
 
 const test = mergeTests(
+	contentDashboardPagesTest,
 	featureFlagsTest({
 		'LPD-36105': {enabled: true},
 	}),
 	globalMenuPagesTest,
+	isolatedSiteTest,
 	loginTest()
 );
 
@@ -206,6 +210,63 @@ test(
 			await page.reload();
 
 			await expect(menu).toBeVisible();
+		});
+	}
+);
+
+test(
+	'Side navigation remains visible after Liferay.Portlet.refresh call',
+	{tag: '@LPD-86410'},
+	async ({contentDashboardPage, page, site}) => {
+		async function expectSideNavigationToBeRendered() {
+			const sideNavigation = page.getByLabel('Applications Menu', {
+				exact: true,
+			});
+			const toggler = page.getByTestId('sideNavigationToggler');
+
+			await expect(sideNavigation).toBeVisible();
+			await expect(toggler).toBeVisible();
+
+			await toggler.click();
+
+			await expect(sideNavigation).toBeHidden();
+
+			await toggler.click();
+
+			await expect(sideNavigation).toBeVisible();
+		}
+
+		await test.step('Go to Applications > Content Dashboard', async () => {
+			await contentDashboardPage.goto(site.friendlyUrlPath);
+
+			await waitForPageToBeLoaded(page);
+
+			await expectSideNavigationToBeRendered();
+		});
+
+		const modalTitle = page.getByRole('heading', {
+			exact: true,
+			name: 'Configuration',
+		});
+
+		await test.step('Click on the settings (cog) icon to open the modal', async () => {
+			await page
+				.locator('button', {
+					has: page.locator('svg.lexicon-icon-cog'),
+				})
+				.click();
+
+			await expect(modalTitle).toBeVisible();
+		});
+
+		await test.step('Close the modal and verify side navigation visibility', async () => {
+			await page
+				.getByRole('button', {exact: true, name: 'Close'})
+				.click();
+
+			await expect(modalTitle).toBeHidden();
+
+			await expectSideNavigationToBeRendered();
 		});
 	}
 );


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPD-86410

This update fixes the global menu crashing when `Liferay.Portlet.refresh` is called. There are two fixes here:
1. Setting `portletId` to empty string is intended. The reason is to avoid the react rendered to destroy this component when navigating while not tying it to the current active portlet.
2. Still figuring out the control menu issue

# IMPORTANT!

~This bug isn't fully fixed yet. The `SideNavigationToggler` is still crashing, and I think it's an issue within control menu. Still investigating.~

~The toggler is visible now, but the react isn't kicking in yet. Will probably replace it by a vanilla JS component.~

Fixed, finally, thank god!