### PR TITLE
LPD-86448 Remove apiHelpers.headlessSite calls for Platform Experience

### DIFF
--- a/modules/test/playwright/tests/accessibility-menu-web/main/accessibilityMenuSmoke.spec.ts
+++ b/modules/test/playwright/tests/accessibility-menu-web/main/accessibilityMenuSmoke.spec.ts
@@ -156,7 +156,7 @@ test.describe('Accessibility Menu Configuration Override and Inheritance', () =>
 			[firstSite, secondSite] = await Promise.all(
 				[FIRST_SITE_NAME, SECOND_SITE_NAME].map(
 					async (name) =>
-						await apiHelpers.headlessSite.createSite({name})
+						await apiHelpers.headlessAdminSite.postSite({name})
 				)
 			);
 		});
@@ -183,7 +183,9 @@ test.describe('Accessibility Menu Configuration Override and Inheritance', () =>
 
 			await Promise.all(
 				[firstSite, secondSite].map((site) =>
-					apiHelpers.headlessSite.deleteSite(site.id)
+					apiHelpers.headlessAdminSite.deleteSite(
+						site.externalReferenceCode
+					)
 				)
 			);
 

--- a/modules/test/playwright/tests/product-navigation-applications-menu/main/applicationsMenu.spec.ts
+++ b/modules/test/playwright/tests/product-navigation-applications-menu/main/applicationsMenu.spec.ts
@@ -35,7 +35,7 @@ test(
 			await test.step(`Assert "View All" link visibility after creating 6 more sites`, async () => {
 				for (let index = 1; index < 7; index++) {
 					sites.push(
-						await apiHelpers.headlessSite.createSite({
+						await apiHelpers.headlessAdminSite.postSite({
 							name: getRandomString(),
 						})
 					);
@@ -72,7 +72,9 @@ test(
 			await test.step('Cleanup sites', async () => {
 				await Promise.all(
 					sites.map((site) =>
-						apiHelpers.headlessSite.deleteSite(site.id)
+						apiHelpers.headlessAdminSite.deleteSite(
+							site.externalReferenceCode
+						)
 					)
 				);
 			});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-86448

### Summary
Standardized Playwright tests by replacing legacy `apiHelpers.headlessSite` with `apiHelpers.headlessAdminSite`.

If you encounter any failures or flakiness related to these changes, please let me know.