### PR TITLE
LPD-86166 Password Policies: disable submit button until form inputs are loaded

### DIFF
--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/edit_configuration.jsp
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/edit_configuration.jsp
@@ -199,10 +199,10 @@ renderResponse.setTitle(categoryDisplayName);
 							<aui:button-row>
 								<c:choose>
 									<c:when test="<%= configurationModel.hasScopeConfiguration(configurationScopeDisplayContext.getScope()) %>">
-										<aui:button data-qa-id="submitConfiguration" name="update" type="submit" value="update" />
+										<aui:button cssClass="configuration-submit-button" data-qa-id="submitConfiguration" disabled="<%= true %>" name="update" type="submit" value="update" />
 									</c:when>
 									<c:otherwise>
-										<aui:button data-qa-id="submitConfiguration" name="save" type="submit" value="save" />
+										<aui:button cssClass="configuration-submit-button" data-qa-id="submitConfiguration" disabled="<%= true %>" name="save" type="submit" value="save" />
 									</c:otherwise>
 								</c:choose>
 
@@ -222,3 +222,34 @@ renderResponse.setTitle(categoryDisplayName);
 		</clay:col>
 	</clay:row>
 </clay:container-fluid>
+
+<c:if test="<%= !configurationModel.isReadOnly() %>">
+	<aui:script>
+		var form = document.forms['<portlet:namespace />fm'];
+
+		if (form) {
+			var handleInputs = function () {
+				var inputs = form.querySelectorAll(
+					'input:not([type="hidden"]), select, textarea'
+				);
+
+				if (inputs.length) {
+					observer.disconnect();
+
+					form.querySelectorAll('.configuration-submit-button').forEach(
+						function (button) {
+							button.removeAttribute('disabled');
+							button.classList.remove('disabled');
+						}
+					);
+				}
+			};
+
+			var observer = new MutationObserver(handleInputs);
+
+			observer.observe(form, {childList: true, subtree: true});
+
+			handleInputs();
+		}
+	</aui:script>
+</c:if>

--- a/modules/test/playwright/tests/configuration-admin-web/main/configurationAdminUI.spec.ts
+++ b/modules/test/playwright/tests/configuration-admin-web/main/configurationAdminUI.spec.ts
@@ -41,3 +41,56 @@ test(
 		});
 	}
 );
+
+test(
+	'Configuration submit button stays disabled when form has no inputs',
+	{tag: ['@LPD-86166']},
+	async ({page, systemSettingsPage}) => {
+		await page.addInitScript(() => {
+			const OriginalMutationObserver = window.MutationObserver;
+
+			window.MutationObserver = function (callback) {
+				return new OriginalMutationObserver(function (
+					mutations,
+					observer
+				) {
+					document.querySelectorAll('form').forEach((form) => {
+						if (
+							form.querySelector('.configuration-submit-button')
+						) {
+							form.querySelectorAll(
+								'input:not([type="hidden"]), select, textarea'
+							).forEach((input) => input.remove());
+						}
+					});
+
+					callback.call(this, mutations, observer);
+				});
+			} as unknown as typeof MutationObserver;
+		});
+
+		await systemSettingsPage.goToSystemSetting(
+			'Users',
+			'Password Policies'
+		);
+
+		await expect(
+			page.locator('.configuration-submit-button')
+		).toBeDisabled();
+	}
+);
+
+test(
+	'Configuration submit button is enabled once form inputs are loaded',
+	{tag: ['@LPD-86166']},
+	async ({page, systemSettingsPage}) => {
+		await systemSettingsPage.goToSystemSetting(
+			'Users',
+			'Password Policies'
+		);
+
+		await expect(
+			page.locator('.configuration-submit-button')
+		).toBeEnabled();
+	}
+);


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPD-86166

Improvements from https://github.com/liferay-platform-experience/liferay-portal/pull/1877

### How it is solved

Used a Mutation Observer in the form to check that input are loaded. (Clause assisted)

Other possible solutions discarded: 

- the event `Liferay.componentReady('<portlet:namespace />ddmForm')` was not fired here
- Looking for the form `id=^ddmForm` was not working also, because it was enabled the button while inputs where not loaded yet. 

### Tests: 
```
npm run playwright -- test -g 'LPD-86166'  --reporter list

> @liferay/playwright@1.0.0 playwright
> playwright test -g LPD-86166 --reporter list


Running 2 tests using 1 worker

  ✓  1 [configuration-admin-web.main] › tests/configuration-admin-web/main/configurationAdminUI.spec.ts:45:1 › Configuration submit button stays disabled when form has no inputs @LPD-86166 (10.3s)
  ✓  2 [configuration-admin-web.main] › tests/configuration-admin-web/main/configurationAdminUI.spec.ts:83:1 › Configuration submit button is enabled once form inputs are loaded @LPD-86166 (8.6s)

  2 passed (23.7s)
```