### PR TITLE
LPD-81255 Unify openCMSItemSelectorModal and HeadlessItemSelector 

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/plugins/HeadlessItemSelector.ts
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/plugins/HeadlessItemSelector.ts
@@ -35,22 +35,6 @@ const ALLOWED_VIDEO_FILE_EXTENSIONS = [
 
 const CMS_CREATE_ITEM_URL = `${location.origin}/web/cms/files?com.liferay.site.cms.site.initializer-filesSection_fdsConfig=(view:gallery)`;
 
-interface IImageSelectedItem {
-	embedded?: {
-		file?: {
-			link?: {
-				href?: string;
-			};
-		};
-	};
-}
-
-interface IVideoSelectedItem {
-	embedded?: {
-		videoURL?: string;
-	};
-}
-
 class HeadlessItemSelector extends Plugin {
 	init() {
 		const editor = this.editor;
@@ -74,20 +58,19 @@ class HeadlessItemSelector extends Plugin {
 
 			buttonView.on('execute', () => {
 				openCMSFileSelectorModal({
-					allowDragAndDrop: false,
 					allowedExtensions: ALLOWED_IMAGE_FILE_EXTENSIONS.join(','),
 					createItemURL: CMS_CREATE_ITEM_URL,
 					groupId: Liferay.ThemeDisplay.getSiteGroupId(),
 					itemTypeLabel: Liferay.Language.get('image'),
 					onSelect: (items) => {
-						const item = items[0] as IImageSelectedItem;
+						const href = items[0]?.embedded?.file?.link?.href;
 
-						if (!item?.embedded?.file?.link?.href) {
+						if (!href) {
 							return;
 						}
 
 						const viewFragment = editor.data.processor.toView(
-							`<img src="${item.embedded.file.link.href}">`
+							`<img src="${href}">`
 						);
 
 						const modelFragment = editor.data.toModel(viewFragment);
@@ -113,20 +96,19 @@ class HeadlessItemSelector extends Plugin {
 
 			buttonView.on('execute', () => {
 				openCMSFileSelectorModal({
-					allowDragAndDrop: false,
 					allowedExtensions: ALLOWED_VIDEO_FILE_EXTENSIONS.join(','),
 					createItemURL: CMS_CREATE_ITEM_URL,
 					groupId: Liferay.ThemeDisplay.getSiteGroupId(),
 					itemTypeLabel: Liferay.Language.get('video'),
 					onSelect: (items) => {
-						const item = items[0] as IVideoSelectedItem;
+						const videoURL = items[0]?.embedded?.videoURL;
 
-						if (!item?.embedded?.videoURL) {
+						if (!videoURL) {
 							return;
 						}
 
 						const viewFragment = editor.data.processor.toView(
-							`<oembed url="${item.embedded.videoURL}"></oembed>`
+							`<oembed url="${videoURL}"></oembed>`
 						);
 
 						const modelFragment = editor.data.toModel(viewFragment);

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/plugins/HeadlessItemSelector.ts
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/plugins/HeadlessItemSelector.ts
@@ -96,8 +96,10 @@ class HeadlessItemSelector extends Plugin {
 
 			buttonView.on('execute', () => {
 				openCMSFileSelectorModal({
-					allowedExtensions: ALLOWED_VIDEO_FILE_EXTENSIONS.join(','),
 					createItemURL: CMS_CREATE_ITEM_URL,
+					filters: [
+						`((objectDefinitionExternalReferenceCode eq 'L_CMS_EXTERNAL_VIDEO') or (extension in ('${ALLOWED_VIDEO_FILE_EXTENSIONS.join("','")}')))`,
+					],
 					groupId: Liferay.ThemeDisplay.getSiteGroupId(),
 					itemTypeLabel: Liferay.Language.get('video'),
 					onSelect: (items) => {

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/plugins/HeadlessItemSelector.ts
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/plugins/HeadlessItemSelector.ts
@@ -5,18 +5,7 @@
 
 import {Command, Plugin} from '@ckeditor/ckeditor5-core/dist/index.js';
 import {ButtonView} from '@ckeditor/ckeditor5-ui/dist/index.js';
-import ClayIcon from '@clayui/icon';
-import {
-	EConfigInURLBehavior,
-	IFrontendDataSetProps,
-} from '@liferay/frontend-data-set-web';
-import {
-	getCMSItemSelectorFilters,
-	getCMSItemSelectorGroupedFilters,
-	openItemSelectorModal,
-} from '@liferay/frontend-js-item-selector-web';
-import {mimeTypeUtils} from 'frontend-js-web';
-import React from 'react';
+import {openCMSFileSelectorModal} from '@liferay/frontend-js-item-selector-web';
 
 import getIcon from '../utils/getIcon';
 
@@ -32,92 +21,19 @@ const ALLOWED_IMAGE_FILE_EXTENSIONS = [
 	'webp',
 ];
 
-const CMS_FILE_ITEM_SELECTOR_CONFIG = {
-	createItemURL: `${location.origin}/web/cms/files?com.liferay.site.cms.site.initializer-filesSection_fdsConfig=(view:gallery)`,
-	items: [],
-	locator: {
-		id: 'embedded.id',
-		label: 'embedded.title',
-		value: 'embedded.id',
-	},
-	multiSelect: false,
-};
+const ALLOWED_VIDEO_FILE_EXTENSIONS = [
+	'avi',
+	'm4v',
+	'mkv',
+	'mov',
+	'mp4',
+	'ogg',
+	'ogv',
+	'webm',
+	'wmv',
+];
 
-const CMS_FILE_SEARCH_API_URL = `${location.origin}/o/search/v1.0/search?${[
-	'emptySearch=true',
-	'nestedFields=embedded,file.thumbnailURL',
-].join('&')}`;
-
-const FDS_PROPS: Omit<IFrontendDataSetProps, 'filters' | 'id'> = {
-	configInURLBehavior: EConfigInURLBehavior.OFF,
-	pagination: {
-		deltas: [{label: 20}, {label: 40}, {label: 60}],
-		initialDelta: 20,
-	},
-	views: [
-		{
-			contentRenderer: 'cards',
-			label: Liferay.Language.get('cards'),
-			name: 'cards',
-			schema: {
-				description: 'description',
-				symbol: '',
-				title: 'title',
-			},
-
-			setItemComponentProps: ({
-				item,
-				props,
-			}: {
-				item: {
-					embedded:
-						| {coverImage: {link: {href: string}}}
-						| {file: {mimeType: string; thumbnailURL: string}};
-				};
-				props: object;
-			}) => {
-				const stickerConfig = {
-					stickerProps: {
-						className: 'file-icon-color-5',
-						displayType: 'unstyled',
-					},
-				};
-
-				if ('file' in item.embedded) {
-					const mimeType = item.embedded?.file?.mimeType || '';
-
-					return {
-						...props,
-						imgProps: {src: item.embedded.file.thumbnailURL},
-						stickerProps: {
-							className:
-								mimeTypeUtils.getClassNameFromMimeType(
-									mimeType
-								),
-							content: React.createElement(ClayIcon, {
-								symbol: mimeTypeUtils.getIconFromMimeType(
-									mimeType
-								),
-							}),
-							displayType: 'unstyled',
-						},
-					};
-				}
-
-				return {
-					...props,
-					...stickerConfig,
-				};
-			},
-
-			thumbnail: 'cards2',
-		},
-	],
-};
-
-function getRandomId(): string {
-	return Math.random().toString(36).substring(2, 9);
-}
+const CMS_CREATE_ITEM_URL = `${location.origin}/web/cms/files?com.liferay.site.cms.site.initializer-filesSection_fdsConfig=(view:gallery)`;
 
 interface IImageSelectedItem {
 	embedded?: {
@@ -157,20 +73,14 @@ class HeadlessItemSelector extends Plugin {
 			buttonView.bind('isEnabled').to(command, 'isEnabled');
 
 			buttonView.on('execute', () => {
-				openItemSelectorModal({
-					...CMS_FILE_ITEM_SELECTOR_CONFIG,
-					apiURL: `${CMS_FILE_SEARCH_API_URL}&filter=(cmsKind eq 'object') and (cmsSection eq 'files') and (status in (0, 2, 3) and (extension in ('${ALLOWED_IMAGE_FILE_EXTENSIONS.join("','")}')))`,
-					fdsProps: {
-						...FDS_PROPS,
-						filters: getCMSItemSelectorFilters(
-							Liferay.ThemeDisplay.getSiteGroupId()
-						),
-						groupedFilters: getCMSItemSelectorGroupedFilters(),
-						id: `ImageHeadlessItemSelectorFDS_${getRandomId()}`,
-					},
+				openCMSFileSelectorModal({
+					allowDragAndDrop: false,
+					allowedExtensions: ALLOWED_IMAGE_FILE_EXTENSIONS.join(','),
+					createItemURL: CMS_CREATE_ITEM_URL,
+					groupId: Liferay.ThemeDisplay.getSiteGroupId(),
 					itemTypeLabel: Liferay.Language.get('image'),
-					onItemsChange: (items: Array<IImageSelectedItem>) => {
-						const item = items[0];
+					onSelect: (items) => {
+						const item = items[0] as IImageSelectedItem;
 
 						if (!item?.embedded?.file?.link?.href) {
 							return;
@@ -202,20 +112,14 @@ class HeadlessItemSelector extends Plugin {
 			buttonView.bind('isEnabled').to(command, 'isEnabled');
 
 			buttonView.on('execute', () => {
-				openItemSelectorModal({
-					...CMS_FILE_ITEM_SELECTOR_CONFIG,
-					apiURL: `${CMS_FILE_SEARCH_API_URL}&filter=(cmsKind eq 'object') and (cmsSection eq 'files') and (status in (0, 2, 3))`,
-					fdsProps: {
-						...FDS_PROPS,
-						filters: getCMSItemSelectorFilters(
-							Liferay.ThemeDisplay.getSiteGroupId()
-						),
-						groupedFilters: getCMSItemSelectorGroupedFilters(),
-						id: `VideoHeadlessItemSelectorFDS_${getRandomId()}`,
-					},
+				openCMSFileSelectorModal({
+					allowDragAndDrop: false,
+					allowedExtensions: ALLOWED_VIDEO_FILE_EXTENSIONS.join(','),
+					createItemURL: CMS_CREATE_ITEM_URL,
+					groupId: Liferay.ThemeDisplay.getSiteGroupId(),
 					itemTypeLabel: Liferay.Language.get('video'),
-					onItemsChange: (items: Array<IVideoSelectedItem>) => {
-						const item = items[0];
+					onSelect: (items) => {
+						const item = items[0] as IVideoSelectedItem;
 
 						if (!item?.embedded?.videoURL) {
 							return;

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/package.json
@@ -7,6 +7,7 @@
 		"@clayui/core": "^3.159.0",
 		"@clayui/data-provider": "^3.159.0",
 		"@clayui/form": "^3.159.0",
+		"@clayui/icon": "^3.159.0",
 		"@clayui/layout": "^3.159.0",
 		"@clayui/link": "^3.159.0",
 		"@clayui/modal": "^3.159.0",

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/DetachedCMSFilesItemSelectorModal.tsx
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/DetachedCMSFilesItemSelectorModal.tsx
@@ -80,7 +80,9 @@ const NewItemsNotificationComponent = ({
 			variant="stripe"
 		>
 			{Liferay.Util.sub(
-				Liferay.Language.get('x-new-items-are-not-visible-in-this-view'),
+				Liferay.Language.get(
+					'x-new-items-are-not-visible-in-this-view'
+				),
 				[newItemsCount]
 			)}
 
@@ -160,7 +162,11 @@ const DetachedCMSFilesItemSelectorModal = <T extends Record<string, any>>(
 
 	return (
 		<NotificationContext.Provider
-			value={{newItemsCount, setShowInlineNotification, showInlineNotification}}
+			value={{
+				newItemsCount,
+				setShowInlineNotification,
+				showInlineNotification,
+			}}
 		>
 			{open && (
 				<ItemSelectorModal

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/DetachedCMSFilesItemSelectorModal.tsx
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/DetachedCMSFilesItemSelectorModal.tsx
@@ -12,7 +12,14 @@ import {
 } from '@liferay/frontend-data-set-web';
 import {useBrowserTabVisibility} from '@liferay/frontend-js-react-web';
 import {fetch} from 'frontend-js-web';
-import React, {useEffect, useRef, useState} from 'react';
+import React, {
+	createContext,
+	useContext,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from 'react';
 
 import ItemSelectorModal from './ItemSelectorModal';
 import {TDetachedItemSelectorModal} from './types';
@@ -39,6 +46,80 @@ async function checkNewCMSFiles(
 
 	return (await response.json()) as {totalCount: number};
 }
+
+type NotificationContextValue = {
+	newItemsCount: number;
+	setShowInlineNotification: (show: boolean) => void;
+	showInlineNotification: boolean;
+};
+
+const NotificationContext = createContext<NotificationContextValue>({
+	newItemsCount: 0,
+	setShowInlineNotification: () => {},
+	showInlineNotification: false,
+});
+
+const NewItemsNotificationComponent = ({
+	context,
+}: {
+	context: IInlineNotificationComponent['context'];
+}) => {
+	const {newItemsCount, setShowInlineNotification, showInlineNotification} =
+		useContext(NotificationContext);
+
+	if (!showInlineNotification) {
+		return null;
+	}
+
+	return (
+		<ClayAlert
+			className="detached-cms-files-alert mx-n3 pl-5 pr-1"
+			displayType="info"
+			onClose={() => setShowInlineNotification(false)}
+			title={Liferay.Language.get('info')}
+			variant="stripe"
+		>
+			{Liferay.Util.sub(
+				Liferay.Language.get('x-new-items-are-not-visible-in-this-view'),
+				[newItemsCount]
+			)}
+
+			<ClayButton.Group className="pl-3" spaced>
+				<ClayButton
+					displayType="info"
+					onClick={() => {
+						const updatedSorts: TSort[] = (context?.sorts || [])
+							.filter((sort) => sort.key !== 'dateCreated')
+							.map((sort) => ({...sort, active: false}));
+
+						updatedSorts.push({
+							active: true,
+							direction: 'desc',
+							key: 'dateCreated',
+							label: Liferay.Language.get('by-creation-date'),
+						});
+
+						context?.onClearResultsBar();
+						context?.forceSortsUpdate(updatedSorts);
+
+						setShowInlineNotification(false);
+					}}
+					size="sm"
+				>
+					{Liferay.Language.get('reload')}
+				</ClayButton>
+
+				<ClayButton
+					alert
+					onClick={() => setShowInlineNotification(false)}
+					size="sm"
+				>
+					{Liferay.Language.get('dismiss')}
+				</ClayButton>
+			</ClayButton.Group>
+		</ClayAlert>
+	);
+};
 
 const DetachedCMSFilesItemSelectorModal = <T extends Record<string, any>>(
 	props: TDetachedItemSelectorModal<T>
@@ -69,87 +150,28 @@ const DetachedCMSFilesItemSelectorModal = <T extends Record<string, any>>(
 		}
 	}, [isBrowserTabVisible, open, props.apiURL]);
 
-	const NewItemsNotificationComponent = ({
-		context,
-	}: {
-		context: IInlineNotificationComponent['context'];
-	}) => {
-		if (!showInlineNotification) {
-			return null;
-		}
-
-		return (
-			<ClayAlert
-				className="detached-cms-files-alert mx-n3 pl-5 pr-1"
-				displayType="info"
-				onClose={() => setShowInlineNotification(false)}
-				title={Liferay.Language.get('info')}
-				variant="stripe"
-			>
-				{Liferay.Util.sub(
-					Liferay.Language.get(
-						'x-new-items-are-not-visible-in-this-view'
-					),
-					[newItemsCount]
-				)}
-
-				<ClayButton.Group className="pl-3" spaced>
-					<ClayButton
-						displayType="info"
-						onClick={() => {
-							const updatedSorts: TSort[] = (context?.sorts || [])
-								.filter((sort) => sort.key !== 'dateCreated')
-								.map((sort) => {
-									sort.active = false;
-
-									return sort;
-								});
-
-							updatedSorts.push({
-								active: true,
-								direction: 'desc',
-								key: 'dateCreated',
-								label: Liferay.Language.get('by-creation-date'),
-							});
-
-							context && context.onClearResultsBar();
-							context && context.forceSortsUpdate(updatedSorts);
-
-							setShowInlineNotification(false);
-						}}
-						size="sm"
-					>
-						{Liferay.Language.get('reload')}
-					</ClayButton>
-
-					<ClayButton
-						alert
-						onClick={() => setShowInlineNotification(false)}
-						size="sm"
-					>
-						{Liferay.Language.get('dismiss')}
-					</ClayButton>
-				</ClayButton.Group>
-			</ClayAlert>
-		);
-	};
+	const fdsProps = useMemo(
+		() => ({
+			...props.fdsProps,
+			inlineNotificationComponent: NewItemsNotificationComponent,
+		}),
+		[props.fdsProps]
+	);
 
 	return (
-		<>
+		<NotificationContext.Provider
+			value={{newItemsCount, setShowInlineNotification, showInlineNotification}}
+		>
 			{open && (
 				<ItemSelectorModal
 					{...props}
-					fdsProps={{
-						...props.fdsProps,
-						inlineNotificationComponent:
-							NewItemsNotificationComponent,
-					}}
+					fdsProps={fdsProps}
 					observer={observer}
 					onOpenChange={onOpenChange}
 					open={open}
 				/>
 			)}
-		</>
+		</NotificationContext.Provider>
 	);
 };
 

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/DetachedCMSFilesItemSelectorModal.tsx
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/DetachedCMSFilesItemSelectorModal.tsx
@@ -30,12 +30,14 @@ async function checkNewCMSFiles(
 	cmsRootFilesURL: string,
 	lastRequestTime: string
 ) {
-	const url = new URL(cmsRootFilesURL);
+	const url = new URL(cmsRootFilesURL, window.location.origin);
 	const existingFilter = url.searchParams.get('filter') ?? '';
 
 	url.searchParams.set(
 		'filter',
-		`${existingFilter} and dateCreated gt ${lastRequestTime}`
+		existingFilter
+			? `(${existingFilter}) and dateCreated gt ${lastRequestTime}`
+			: `dateCreated gt ${lastRequestTime}`
 	);
 
 	const response = await fetch(url.toString());

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/DetachedCMSFilesItemSelectorModal.tsx
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/DetachedCMSFilesItemSelectorModal.tsx
@@ -23,9 +23,15 @@ async function checkNewCMSFiles(
 	cmsRootFilesURL: string,
 	lastRequestTime: string
 ) {
-	const response = await fetch(
-		`${cmsRootFilesURL} and dateCreated gt ${lastRequestTime}`
+	const url = new URL(cmsRootFilesURL);
+	const existingFilter = url.searchParams.get('filter') ?? '';
+
+	url.searchParams.set(
+		'filter',
+		`${existingFilter} and dateCreated gt ${lastRequestTime}`
 	);
+
+	const response = await fetch(url.toString());
 
 	if (!response.ok) {
 		return {totalCount: 0};

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/getCMSItemSelectorFilters.ts
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/getCMSItemSelectorFilters.ts
@@ -25,9 +25,9 @@ export function getCMSItemSelectorFilters(
 		},
 		{
 			apiURL: "/o/object-admin/v1.0/object-definitions?filter=objectFolderExternalReferenceCode eq 'L_CMS_FILE_TYPES'",
-			entityFieldType: EEntityFieldType.INTEGER,
-			id: 'objectDefinitionId',
-			itemKey: 'id',
+			entityFieldType: EEntityFieldType.STRING,
+			id: 'objectDefinitionExternalReferenceCode',
+			itemKey: 'externalReferenceCode',
 			itemLabel: 'label.LANG',
 			label: Liferay.Language.get('type'),
 			multiple: true,
@@ -140,7 +140,7 @@ export function getCMSItemSelectorGroupedFilters(): IGroupedFilterConfig[] {
 		{
 			filters: [
 				'groupIds',
-				'objectDefinitionId',
+				'objectDefinitionExternalReferenceCode',
 				'taxonomyCategoryIds',
 				'keywords',
 				'creatorId',

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/openCMSFileSelectorModal.ts
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/openCMSFileSelectorModal.ts
@@ -112,6 +112,7 @@ const FDS_PROPS: Omit<
 				const fallbackStickerProps = {
 					stickerProps: {
 						className: 'file-icon-color-5',
+						displayType: 'unstyled',
 					},
 				};
 
@@ -131,6 +132,7 @@ const FDS_PROPS: Omit<
 									mimeType
 								),
 							}),
+							displayType: 'unstyled',
 						},
 					};
 				}

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/openCMSFileSelectorModal.ts
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/openCMSFileSelectorModal.ts
@@ -20,12 +20,16 @@ import {
 interface CMSFile {
 	description: string;
 	embedded: {
-		file: {
+		file?: {
+			link?: {
+				href?: string;
+			};
 			mimeType: string;
 			thumbnailURL: string;
 		};
 		id: number;
 		title: string;
+		videoURL?: string;
 	};
 	title: string;
 }
@@ -102,7 +106,7 @@ const FDS_PROPS: Omit<
 				item,
 				props,
 			}: {
-				item: {embedded: {file: {mimeType: string; thumbnailURL: string}}};
+				item: Pick<CMSFile, 'embedded'>;
 				props: object;
 			}) => {
 				const fallbackStickerProps = {
@@ -170,7 +174,7 @@ export default function openCMSFileSelectorModal({
 	maxFileSize,
 	onSelect,
 }: {
-	allowDragAndDrop: boolean;
+	allowDragAndDrop?: boolean;
 	allowedExtensions?: string;
 	config?: Partial<CMSFileItemSelectorModalConfig>;
 	createItemURL?: string;
@@ -185,7 +189,7 @@ export default function openCMSFileSelectorModal({
 		...config,
 	};
 
-	if (allowedExtensions && allowedExtensions.length) {
+	if (allowedExtensions) {
 		const extensions = normalizeExtensions(allowedExtensions);
 
 		finalConfig.apiURL = urlBuilder({

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/openCMSFileSelectorModal.ts
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/openCMSFileSelectorModal.ts
@@ -137,6 +137,19 @@ const FDS_PROPS: Omit<
 					};
 				}
 
+				if (item.embedded.videoURL) {
+					return {
+						...props,
+						stickerProps: {
+							className: 'file-icon-color-3',
+							content: React.createElement(ClayIcon, {
+								symbol: 'document-multimedia',
+							}),
+							displayType: 'unstyled',
+						},
+					};
+				}
+
 				return {
 					...props,
 					...fallbackStickerProps,
@@ -173,6 +186,7 @@ export default function openCMSFileSelectorModal({
 	config,
 	createItemURL,
 	fdsProps,
+	filters,
 	groupId,
 	itemTypeLabel,
 	maxFileSize,
@@ -183,6 +197,7 @@ export default function openCMSFileSelectorModal({
 	config?: Partial<CMSFileItemSelectorModalConfig>;
 	createItemURL?: string;
 	fdsProps?: Partial<CMSFileItemSelectorModalProps['fdsProps']>;
+	filters?: string[];
 	groupId: number;
 	itemTypeLabel?: string;
 	maxFileSize?: number;
@@ -193,7 +208,10 @@ export default function openCMSFileSelectorModal({
 		...config,
 	};
 
-	if (allowedExtensions) {
+	if (filters?.length) {
+		finalConfig.apiURL = urlBuilder({filters});
+	}
+	else if (allowedExtensions) {
 		const extensions = normalizeExtensions(allowedExtensions);
 
 		finalConfig.apiURL = urlBuilder({

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/openCMSFileSelectorModal.ts
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/openCMSFileSelectorModal.ts
@@ -115,7 +115,7 @@ const FDS_PROPS: Omit<
 					},
 				};
 
-				if ('file' in item.embedded) {
+				if (item.embedded.file) {
 					const mimeType = item.embedded.file.mimeType || '';
 
 					return {
@@ -123,7 +123,9 @@ const FDS_PROPS: Omit<
 						imgProps: {src: item.embedded.file.thumbnailURL},
 						stickerProps: {
 							className:
-								mimeTypeUtils.getClassNameFromMimeType(mimeType),
+								mimeTypeUtils.getClassNameFromMimeType(
+									mimeType
+								),
 							content: React.createElement(ClayIcon, {
 								symbol: mimeTypeUtils.getIconFromMimeType(
 									mimeType

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/openCMSFileSelectorModal.ts
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/openCMSFileSelectorModal.ts
@@ -3,7 +3,11 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import ClayIcon from '@clayui/icon';
+import {EConfigInURLBehavior} from '@liferay/frontend-data-set-web';
 import {render} from '@liferay/frontend-js-react-web';
+import {mimeTypeUtils} from 'frontend-js-web';
+import React from 'react';
 
 import CMSFileUploaderComponent from '../item_selector_file_uploader/CMSFileUploaderComponent';
 import DetachedCMSFilesItemSelectorModal from './DetachedCMSFilesItemSelectorModal';
@@ -17,6 +21,7 @@ interface CMSFile {
 	description: string;
 	embedded: {
 		file: {
+			mimeType: string;
 			thumbnailURL: string;
 		};
 		id: number;
@@ -56,7 +61,7 @@ function urlBuilder({
 	finalURL.search = new URLSearchParams({
 		emptySearch: 'true',
 		filter,
-		nestedFields: 'description,embedded,file.thumbnailURL',
+		nestedFields: 'description,embedded,file.mimeType,file.thumbnailURL',
 	}).toString();
 
 	return finalURL.toString();
@@ -77,6 +82,7 @@ const FDS_PROPS: Omit<
 	CMSFileItemSelectorModalProps['fdsProps'],
 	'filters' | 'id' | 'items'
 > = {
+	configInURLBehavior: EConfigInURLBehavior.OFF,
 	pagination: {
 		deltas: [{label: 20}, {label: 40}, {label: 60}],
 		initialDelta: 20,
@@ -96,27 +102,36 @@ const FDS_PROPS: Omit<
 				item,
 				props,
 			}: {
-				item: {embedded: {file: {thumbnailURL: string}}};
+				item: {embedded: {file: {mimeType: string; thumbnailURL: string}}};
 				props: object;
 			}) => {
-				const stickerProps = {
+				const fallbackStickerProps = {
 					stickerProps: {
 						className: 'file-icon-color-5',
-						displayType: 'unstyled',
 					},
 				};
 
 				if ('file' in item.embedded) {
+					const mimeType = item.embedded.file.mimeType || '';
+
 					return {
 						...props,
 						imgProps: {src: item.embedded.file.thumbnailURL},
-						...stickerProps,
+						stickerProps: {
+							className:
+								mimeTypeUtils.getClassNameFromMimeType(mimeType),
+							content: React.createElement(ClayIcon, {
+								symbol: mimeTypeUtils.getIconFromMimeType(
+									mimeType
+								),
+							}),
+						},
 					};
 				}
 
 				return {
 					...props,
-					...stickerProps,
+					...fallbackStickerProps,
 				};
 			},
 
@@ -148,16 +163,20 @@ export default function openCMSFileSelectorModal({
 	allowDragAndDrop = false,
 	allowedExtensions,
 	config,
+	createItemURL,
 	fdsProps,
 	groupId,
+	itemTypeLabel,
 	maxFileSize,
 	onSelect,
 }: {
 	allowDragAndDrop: boolean;
 	allowedExtensions?: string;
 	config?: Partial<CMSFileItemSelectorModalConfig>;
+	createItemURL?: string;
 	fdsProps?: Partial<CMSFileItemSelectorModalProps['fdsProps']>;
 	groupId: number;
+	itemTypeLabel?: string;
 	maxFileSize?: number;
 	onSelect: (items: Array<CMSFile>) => void;
 }) {
@@ -179,6 +198,7 @@ export default function openCMSFileSelectorModal({
 		{
 			...finalConfig,
 			allowedExtensions,
+			createItemURL,
 			fdsProps: {
 				...FDS_PROPS,
 				filters: getCMSItemSelectorFilters(groupId),
@@ -190,7 +210,7 @@ export default function openCMSFileSelectorModal({
 				? CMSFileUploaderComponent
 				: undefined,
 			groupId,
-			itemTypeLabel: Liferay.Language.get('files'),
+			itemTypeLabel: itemTypeLabel ?? Liferay.Language.get('files'),
 			maxFileSize,
 			onItemsChange: onSelect,
 		},

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/BaseObjectDefinitionSelectionFDSFilter.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/BaseObjectDefinitionSelectionFDSFilter.java
@@ -26,12 +26,12 @@ public abstract class BaseObjectDefinitionSelectionFDSFilter
 
 	@Override
 	public String getEntityFieldType() {
-		return FDSEntityFieldTypes.INTEGER;
+		return FDSEntityFieldTypes.STRING;
 	}
 
 	@Override
 	public String getId() {
-		return "objectDefinitionId";
+		return "objectDefinitionExternalReferenceCode";
 	}
 
 	@Override
@@ -61,7 +61,7 @@ public abstract class BaseObjectDefinitionSelectionFDSFilter
 			selectionFDSFilterItems.add(
 				new SelectionFDSFilterItem(
 					objectDefinition.getLabel(locale),
-					objectDefinition.getObjectDefinitionId()));
+					objectDefinition.getExternalReferenceCode()));
 		}
 
 		return selectionFDSFilterItems;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/CMSGroupedFDSFilters.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/CMSGroupedFDSFilters.java
@@ -50,8 +50,9 @@ public class CMSGroupedFDSFilters implements GroupedFDSFilters {
 			JSONUtil.put(
 				LanguageUtil.get(resourceBundle, "filter-by"),
 				JSONUtil.putAll(
-					"scopeGroupId", "objectDefinitionId", "taxonomyCategoryIds",
-					"keywords", "extension", "creatorId", "status")),
+					"scopeGroupId", "objectDefinitionExternalReferenceCode",
+					"taxonomyCategoryIds", "keywords", "extension", "creatorId",
+					"status")),
 			JSONUtil.put(
 				LanguageUtil.get(resourceBundle, "filter-by-date"),
 				JSONUtil.putAll(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-81255
https://liferay.atlassian.net/browse/LPD-79393

**What is being fixed:** The CKEditor headless image and video selectors (`HeadlessItemSelector`) had their own duplicated FDS configuration, a full copy of the API URL builder, pagination settings, cards view, sticker logic, and filter wiring, essentially re-implementing everything that `openCMSFileSelectorModal` already provides. Because of that duplication, the headless selectors were missing features that the CMS file selector had: inline notification for new files, consistent space/site filters, proper `configInURLBehavior` to prevent modal state from leaking into the page URL, and mime-type-based sticker icons. Additionally, the video selector had no extension filter, so it showed all file types instead of only videos. There was also a bug in `DetachedCMSFilesItemSelectorModal` where the new-files notification showed the total file count instead of the count of newly created files, caused by appending the date filter as a raw string to the URL instead of properly setting the query parameter. Also the Type dropdown filter in both the CMS files gallery and the item selector modal was sending `objectDefinitionId`.

**How it is being fixed:** The duplicated configuration in `HeadlessItemSelector` is removed entirely and both the image and video selectors are migrated to call `openCMSFileSelectorModal`, which is extended with `createItemURL`, `itemTypeLabel`, and `filters` parameters. The video selector now uses a combined OData filter that matches External Videos via `objectDefinitionExternalReferenceCode eq 'L_CMS_EXTERNAL_VIDEO'` and uploaded video files via their extension, so both types appear in the selector. The `openCMSFileSelectorModal` function gains mime-type-aware sticker rendering using `mimeTypeUtils`, `configInURLBehavior: OFF` to keep FDS state out of the URL, and a request for `file.mimeType` in `nestedFields`. External Video cards in the selector now show the correct sticker color (`file-icon-color-3`) and icon (`document-multimedia`), matching the CMS admin gallery. The URL filter bug in `DetachedCMSFilesItemSelectorModal` is fixed by using the `URL` API to properly set the `filter` query parameter instead of concatenating strings. The `NewItemsNotificationComponent` is moved to module scope and reads notification state through a React context, which gives FDS a stable prop reference and stops it from re-fetching on every render. The Type filter in both the CMS files gallery (`BaseObjectDefinitionSelectionFDSFilter`) and the item selector modal (`getCMSItemSelectorFilters`) is changed from `objectDefinitionId` (integer) to `objectDefinitionExternalReferenceCode` (string), which is stable across all environments.

[testunify.webm](https://github.com/user-attachments/assets/2f103fff-0f3e-4cae-a460-139480767dee)