### PR TITLE
LPD-81198 Item Selector: Drag & drop upload is available, but there’s no clear “Upload files” action 

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/CreationMenu.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/CreationMenu.tsx
@@ -216,11 +216,7 @@ function CreationButton({
 			})}
 			title={firstItem.label}
 		>
-			{isMobile ? (
-				<ClayIcon symbol="plus" />
-			) : (
-				Liferay.Language.get('new')
-			)}
+			{isMobile ? <ClayIcon symbol="plus" /> : firstItem.label}
 
 			{newTabIcon}
 		</LinkOrButton>

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/ItemSelectorModal.tsx
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/ItemSelectorModal.tsx
@@ -264,16 +264,33 @@ function ItemSelectorModal<T extends Record<string, any>>({
 						{...fdsProps}
 						apiURL={apiURL}
 						creationMenu={
-							createItemURL
+							FilesUploaderComponent || createItemURL
 								? {
 										primaryItems: [
-											{
-												href: createItemURL,
-												label: Liferay.Language.get(
-													'add-new-item'
-												),
-												target: ACTION_ITEM_TARGETS.BLANK,
-											},
+											...(FilesUploaderComponent
+												? [
+														{
+															label: Liferay.Language.get(
+																'upload-files'
+															),
+															onClick: () =>
+																setViewType(
+																	'upload'
+																),
+														},
+													]
+												: []),
+											...(createItemURL
+												? [
+														{
+															href: createItemURL,
+															label: Liferay.Language.get(
+																'add-new-item'
+															),
+															target: ACTION_ITEM_TARGETS.BLANK,
+														},
+													]
+												: []),
 										],
 									}
 								: undefined

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/openCMSFileSelectorModal.ts
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/openCMSFileSelectorModal.ts
@@ -192,6 +192,7 @@ export default function openCMSFileSelectorModal({
 					: undefined,
 				filters: getCMSItemSelectorFilters(groupId),
 				groupedFilters: getCMSItemSelectorGroupedFilters(),
+				hideManagementBarInEmptyState: true,
 				...fdsProps,
 				id: `CMSItemSelectorFDS_${getRandomId()}`,
 			},

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/openCMSFileSelectorModal.ts
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/openCMSFileSelectorModal.ts
@@ -181,6 +181,15 @@ export default function openCMSFileSelectorModal({
 			allowedExtensions,
 			fdsProps: {
 				...FDS_PROPS,
+				emptyState: allowDragAndDrop
+					? {
+							description: Liferay.Language.get(
+								'drag-and-drop-to-upload'
+							),
+							image: '/states/cms_empty_state_files.svg',
+							title: Liferay.Language.get('no-files-yet'),
+						}
+					: undefined,
 				filters: getCMSItemSelectorFilters(groupId),
 				groupedFilters: getCMSItemSelectorGroupedFilters(),
 				...fdsProps,

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/test/ItemSelectorModal.test.tsx
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/test/ItemSelectorModal.test.tsx
@@ -182,7 +182,7 @@ describe('ItemSelectorModal component', () => {
 
 		const modal = await findByRole('dialog');
 
-		const newItemLink = await within(modal).findByText('new');
+		const newItemLink = await within(modal).findByText('add-new-item');
 
 		expect(newItemLink).toBeInTheDocument();
 

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/test/ItemSelectorModal.test.tsx
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/test/ItemSelectorModal.test.tsx
@@ -11,7 +11,14 @@ import userEvent from '@testing-library/user-event';
 import {fetch, loadClientExtensions, sub} from 'frontend-js-web';
 import React from 'react';
 
-import {ItemSelectorModal} from '../src/main/resources/META-INF/resources';
+import {
+	FilesUploaderComponent,
+	ItemSelectorModal,
+} from '../src/main/resources/META-INF/resources';
+
+const MockFilesUploaderComponent: FilesUploaderComponent = () => (
+	<div data-testid="mockFilesUploader" />
+);
 
 type TestItem = {
 	itemId: number;
@@ -63,11 +70,13 @@ const mockedSub = sub as jest.Mock;
 const ItemSelectorModalWrapper = ({
 	createItemURL,
 	defaultOpen,
+	filesUploaderComponent,
 	onItemsChange,
 	selectedItems,
 }: {
 	createItemURL?: string;
 	defaultOpen: boolean;
+	filesUploaderComponent?: FilesUploaderComponent;
 	onItemsChange: (items: TestItem[]) => void;
 	selectedItems: TestItem[];
 }) => {
@@ -99,6 +108,7 @@ const ItemSelectorModalWrapper = ({
 						} as IView,
 					],
 				}}
+				filesUploaderComponent={filesUploaderComponent}
 				itemTypeLabel="Space"
 				items={selectedItems}
 				locator={{
@@ -524,5 +534,30 @@ describe('ItemSelectorModal component', () => {
 			Liferay.Language.get('x-selected'),
 			mockFirstItem.name
 		);
+	});
+
+	it('renders Upload Files button if drag and drop is allowed', async () => {
+		const user = userEvent.setup();
+
+		const {findByRole, findByTestId} = render(
+			<ItemSelectorModalWrapper
+				defaultOpen={true}
+				filesUploaderComponent={MockFilesUploaderComponent}
+				onItemsChange={jest.fn}
+				selectedItems={[]}
+			/>
+		);
+
+		const modal = await findByRole('dialog');
+
+		const uploadFilesButton = await within(modal).findByRole('button', {
+			name: 'upload-files',
+		});
+
+		expect(uploadFilesButton).toBeInTheDocument();
+
+		user.click(uploadFilesButton);
+
+		expect(await findByTestId('mockFilesUploader')).toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
Link to issue: https://liferay.atlassian.net/browse/LPD-81198
Parent task: https://liferay.atlassian.net/browse/LPD-79505

# What I am trying to solve
Makes the Upload action visible in the CMS File Item Selector by surfacing it as a creation button (previously only reachable via drag-and-drop), and polishes the empty state shown when drag-and-drop uploads are allowed.

**frontend-js-item-selector-web/.../ItemSelectorModal.tsx**
  - Adds an Upload entry to the FDS creationMenu when a filesUploaderComponent is provided. Clicking it flips the modal's internal view to 'upload', reusing the existing uploader flow.
  - Keeps the existing createItemURL entry alongside it so both can coexist.

  **frontend-js-item-selector-web/.../openCMSFileSelectorModal.ts**
  - When allowDragAndDrop is true, configures a dedicated empty state (title "no-files-yet", description "drag-and-drop-to-upload", custom illustration /states/cms_empty_state_files.svg).
  - Sets hideManagementBarInEmptyState: true so the toolbar doesn't show when there's nothing to search or filter.

  **frontend-data-set-web/.../management_bar/controls/CreationMenu.tsx**
  - Fixes a hardcoded "new" label on the single-item CreationButton so it now renders firstItem.label. This lets the Upload action show "Upload" in the management bar instead of a generic "New."

  **frontend-js-item-selector-web/test/ItemSelectorModal.test.tsx**
  - Updates the assertion for the creation button to match the new per-item label (add-new-item) instead of the former hardcoded new.

<img width="862" height="808" alt="Screenshot 2026-04-21 at 13 43 30" src="https://github.com/user-attachments/assets/3c108de3-76cd-460c-bb4d-ffb91dce85d3" />

<img width="873" height="822" alt="Screenshot 2026-04-21 at 13 42 56" src="https://github.com/user-attachments/assets/757e0f1e-0b52-4575-842c-df8f0e8e82bf" />
