### PR TITLE
LPD-78369 Scale label font-size and line-height inside form-group-sm

### DIFF
--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_forms.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_forms.scss
@@ -745,7 +745,11 @@ $form-group-sm-margin-bottom: 16px !default;
 
 $form-group-sm-margin-bottom-mobile: null !default;
 
-$form-group-sm-input-label-margin-bottom: 3px !default;
+$form-group-sm-input-label-font-size: 12px !default;
+
+$form-group-sm-input-label-line-height: 1.5 !default;
+
+$form-group-sm-input-label-margin-bottom: 2px !default;
 
 $form-group-sm-item-label-spacer: 25px !default;
 

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas/variables/_forms.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas/variables/_forms.scss
@@ -110,7 +110,9 @@ $input-padding-y-sm: 0.25rem !default;
 $form-group-margin-bottom: 1.5rem !default; // 24px
 $form-group-margin-bottom-mobile: 1rem !default; // 16px
 
-$form-group-sm-input-label-margin-bottom: 0.1875rem !default; // 3px
+$form-group-sm-input-label-font-size: 0.75rem !default; // 12px
+$form-group-sm-input-label-line-height: 1.5 !default; // 150%
+$form-group-sm-input-label-margin-bottom: 0.125rem !default; // 2px
 $form-group-sm-item-label-spacer: 1.5625rem !default; // 25px
 
 // Input Label (<label>)

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/components/_forms.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/components/_forms.scss
@@ -698,6 +698,8 @@ textarea.form-control-sm,
 	}
 
 	label {
+		font-size: $cadmin-form-group-sm-input-label-font-size;
+		line-height: $cadmin-form-group-sm-input-label-line-height;
 		margin-bottom: $cadmin-form-group-sm-input-label-margin-bottom;
 	}
 

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/variables/_forms.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/variables/_forms.scss
@@ -616,7 +616,9 @@ $cadmin-form-group-sm-margin-bottom: 16px !default; // 16px
 
 $cadmin-form-group-sm-margin-bottom-mobile: null !default;
 
-$cadmin-form-group-sm-input-label-margin-bottom: 3px !default; // 3px
+$cadmin-form-group-sm-input-label-font-size: 12px !default; // 12px
+$cadmin-form-group-sm-input-label-line-height: 1.5 !default; // 150%
+$cadmin-form-group-sm-input-label-margin-bottom: 2px !default; // 2px
 
 $cadmin-form-group-sm-item-label-spacer: 25px !default; // 25px
 

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/components/_forms.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/components/_forms.scss
@@ -810,6 +810,8 @@ textarea.form-control-sm,
 	}
 
 	label {
+		font-size: $form-group-sm-input-label-font-size;
+		line-height: $form-group-sm-input-label-line-height;
 		margin-bottom: $form-group-sm-input-label-margin-bottom;
 	}
 

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/variables/_forms.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/variables/_forms.scss
@@ -676,6 +676,8 @@ $form-group-margin-bottom-mobile: null !default;
 
 $form-group-sm-margin-bottom: 1rem !default; // 16px
 
+$form-group-sm-input-label-font-size: 0.75rem !default; // 12px
+$form-group-sm-input-label-line-height: 1.5 !default; // 150%
 $form-group-sm-input-label-margin-bottom: 0.25rem !default; // 4px
 
 $form-group-sm-item-label-spacer: 1.75rem !default; // 28px

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/form_elements.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/form_elements.jsp
@@ -166,3 +166,51 @@ for (int i = 0; i < 8; i++) {
 	selectedMultiselectItems="<%= multiselectDisplayContext.getSelectedMultiselectItems() %>"
 	sourceMultiselectItems="<%= multiselectDisplayContext.getSourceMultiselectItems() %>"
 />
+
+<h3>FORM GROUP</h3>
+
+<blockquote>
+	<p>Form group variants: default and small. Labels and controls should scale proportionally with the variant.</p>
+</blockquote>
+
+<div class="form-group" id="formGroupDefault">
+	<label class="control-label" for="inputDefault">Default Input</label>
+
+	<input class="form-control" id="inputDefault" type="text" />
+</div>
+
+<div class="form-group form-group-sm" id="formGroupSm">
+	<label class="control-label" for="inputSm">Small Input</label>
+
+	<input class="form-control form-control-sm" id="inputSm" type="text" />
+</div>
+
+<div class="form-group" id="formGroupDefaultTextarea">
+	<label class="control-label" for="textareaDefault">Default Textarea</label>
+
+	<textarea class="form-control" id="textareaDefault"></textarea>
+</div>
+
+<div class="form-group form-group-sm" id="formGroupSmTextarea">
+	<label class="control-label" for="textareaSm">Small Textarea</label>
+
+	<textarea class="form-control form-control-sm" id="textareaSm"></textarea>
+</div>
+
+<div class="form-group" id="formGroupDefaultSelect">
+	<label class="control-label" for="selectDefault">Default Select</label>
+
+	<select class="form-control" id="selectDefault">
+		<option>Option 1</option>
+		<option>Option 2</option>
+	</select>
+</div>
+
+<div class="form-group form-group-sm" id="formGroupSmSelect">
+	<label class="control-label" for="selectSm">Small Select</label>
+
+	<select class="form-control form-control-sm" id="selectSm">
+		<option>Option 1</option>
+		<option>Option 2</option>
+	</select>
+</div>

--- a/modules/test/playwright/tests/frontend-taglib-clay/main/formGroup.spec.ts
+++ b/modules/test/playwright/tests/frontend-taglib-clay/main/formGroup.spec.ts
@@ -3,12 +3,25 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {expect} from '@playwright/test';
+import {Locator, expect} from '@playwright/test';
 
 import {claySamplePageTest} from './fixtures/claySamplePageTest';
 import {TabName} from './pages/ClaySamplePage';
 
 const test = claySamplePageTest;
+
+async function assertDefaultLabelStyles(label: Locator) {
+	await expect(label).toHaveCSS('font-size', '14px');
+	await expect(label).toHaveCSS('font-weight', '600');
+	await expect(label).toHaveCSS('line-height', '21px');
+	await expect(label).toHaveCSS('margin-bottom', '4px');
+}
+
+async function assertSmLabelStyles(label: Locator) {
+	await expect(label).toHaveCSS('font-size', '12px');
+	await expect(label).toHaveCSS('line-height', '18px');
+	await expect(label).toHaveCSS('margin-bottom', '2px');
+}
 
 test.beforeEach(async ({claySamplePage}) => {
 	await claySamplePage.selectTab(TabName.FORM_ELEMENTS);
@@ -16,15 +29,9 @@ test.beforeEach(async ({claySamplePage}) => {
 
 test('Default variant', async ({page}) => {
 	await test.step('label should have correct font-size, line-height, font-weight and margin-bottom', async () => {
-		const label = page.locator('label[for="inputDefault"]');
-
-		await expect(label).toHaveCSS('font-size', '14px');
-
-		await expect(label).toHaveCSS('line-height', '21px');
-
-		await expect(label).toHaveCSS('font-weight', '600');
-
-		await expect(label).toHaveCSS('margin-bottom', '4px');
+		await assertDefaultLabelStyles(
+			page.locator('label[for="inputDefault"]')
+		);
 	});
 
 	await test.step('margin-bottom should be 24px', async () => {
@@ -35,29 +42,21 @@ test('Default variant', async ({page}) => {
 	});
 
 	await test.step('textarea label should have the same styles as input label', async () => {
-		const label = page.locator('label[for="textareaDefault"]');
-
-		await expect(label).toHaveCSS('font-size', '14px');
-		await expect(label).toHaveCSS('margin-bottom', '4px');
+		await assertDefaultLabelStyles(
+			page.locator('label[for="textareaDefault"]')
+		);
 	});
 
 	await test.step('select label should have the same styles as input label', async () => {
-		const label = page.locator('label[for="selectDefault"]');
-
-		await expect(label).toHaveCSS('font-size', '14px');
-		await expect(label).toHaveCSS('margin-bottom', '4px');
+		await assertDefaultLabelStyles(
+			page.locator('label[for="selectDefault"]')
+		);
 	});
 });
 
 test('Small variant', async ({page}) => {
 	await test.step('label should have scaled font-size, line-height and margin-bottom', async () => {
-		const label = page.locator('label[for="inputSm"]');
-
-		await expect(label).toHaveCSS('font-size', '12px');
-
-		await expect(label).toHaveCSS('line-height', '18px');
-
-		await expect(label).toHaveCSS('margin-bottom', '2px');
+		await assertSmLabelStyles(page.locator('label[for="inputSm"]'));
 	});
 
 	await test.step('margin-bottom should be 16px', async () => {
@@ -68,18 +67,10 @@ test('Small variant', async ({page}) => {
 	});
 
 	await test.step('textarea label should have the same scaled styles as input label', async () => {
-		const label = page.locator('label[for="textareaSm"]');
-
-		await expect(label).toHaveCSS('font-size', '12px');
-		await expect(label).toHaveCSS('line-height', '18px');
-		await expect(label).toHaveCSS('margin-bottom', '2px');
+		await assertSmLabelStyles(page.locator('label[for="textareaSm"]'));
 	});
 
 	await test.step('select label should have the same scaled styles as input label', async () => {
-		const label = page.locator('label[for="selectSm"]');
-
-		await expect(label).toHaveCSS('font-size', '12px');
-		await expect(label).toHaveCSS('line-height', '18px');
-		await expect(label).toHaveCSS('margin-bottom', '2px');
+		await assertSmLabelStyles(page.locator('label[for="selectSm"]'));
 	});
 });

--- a/modules/test/playwright/tests/frontend-taglib-clay/main/formGroup.spec.ts
+++ b/modules/test/playwright/tests/frontend-taglib-clay/main/formGroup.spec.ts
@@ -1,0 +1,85 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect} from '@playwright/test';
+
+import {claySamplePageTest} from './fixtures/claySamplePageTest';
+import {TabName} from './pages/ClaySamplePage';
+
+const test = claySamplePageTest;
+
+test.beforeEach(async ({claySamplePage}) => {
+	await claySamplePage.selectTab(TabName.FORM_ELEMENTS);
+});
+
+test('Default variant', async ({page}) => {
+	await test.step('label should have correct font-size, line-height, font-weight and margin-bottom', async () => {
+		const label = page.locator('label[for="inputDefault"]');
+
+		await expect(label).toHaveCSS('font-size', '14px');
+
+		await expect(label).toHaveCSS('line-height', '21px');
+
+		await expect(label).toHaveCSS('font-weight', '600');
+
+		await expect(label).toHaveCSS('margin-bottom', '4px');
+	});
+
+	await test.step('margin-bottom should be 24px', async () => {
+		await expect(page.locator('#formGroupDefault')).toHaveCSS(
+			'margin-bottom',
+			'24px'
+		);
+	});
+
+	await test.step('textarea label should have the same styles as input label', async () => {
+		const label = page.locator('label[for="textareaDefault"]');
+
+		await expect(label).toHaveCSS('font-size', '14px');
+		await expect(label).toHaveCSS('margin-bottom', '4px');
+	});
+
+	await test.step('select label should have the same styles as input label', async () => {
+		const label = page.locator('label[for="selectDefault"]');
+
+		await expect(label).toHaveCSS('font-size', '14px');
+		await expect(label).toHaveCSS('margin-bottom', '4px');
+	});
+});
+
+test('Small variant', async ({page}) => {
+	await test.step('label should have scaled font-size, line-height and margin-bottom', async () => {
+		const label = page.locator('label[for="inputSm"]');
+
+		await expect(label).toHaveCSS('font-size', '12px');
+
+		await expect(label).toHaveCSS('line-height', '18px');
+
+		await expect(label).toHaveCSS('margin-bottom', '2px');
+	});
+
+	await test.step('margin-bottom should be 16px', async () => {
+		await expect(page.locator('#formGroupSm')).toHaveCSS(
+			'margin-bottom',
+			'16px'
+		);
+	});
+
+	await test.step('textarea label should have the same scaled styles as input label', async () => {
+		const label = page.locator('label[for="textareaSm"]');
+
+		await expect(label).toHaveCSS('font-size', '12px');
+		await expect(label).toHaveCSS('line-height', '18px');
+		await expect(label).toHaveCSS('margin-bottom', '2px');
+	});
+
+	await test.step('select label should have the same scaled styles as input label', async () => {
+		const label = page.locator('label[for="selectSm"]');
+
+		await expect(label).toHaveCSS('font-size', '12px');
+		await expect(label).toHaveCSS('line-height', '18px');
+		await expect(label).toHaveCSS('margin-bottom', '2px');
+	});
+});


### PR DESCRIPTION
**Ticket:** https://liferay.atlassian.net/browse/LPD-78369

## What is being fixed

When a form field uses the small variant (`.form-group-sm`), its `<label>` stayed at the regular 14px font-size and 4px spacing, creating a visually unbalanced form.

## How it is being fixed

- Added `$form-group-sm-input-label-font-size` (12px) and `$form-group-sm-input-label-line-height` (1.5) variables to the base, Atlas, and Cadmin SCSS variable files
- Updated `$form-group-sm-input-label-margin-bottom` from 3px → 2px in Atlas and Cadmin
- Applied the new variables to `.form-group-sm label` in both `components/_forms.scss` and `cadmin/components/_forms.scss`

<img width="1681" height="862" alt="image" src="https://github.com/user-attachments/assets/2c560428-1709-4615-8424-f38aafc59a0a" />
