### PR TITLE
LPD-87140 Fix maintenance icon appearing pale by defaulting isDark to false

### DIFF
--- a/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/product/navigation/control/menu/MaintenanceInfoMessageProductNavigationControlMenuEntry.java
+++ b/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/product/navigation/control/menu/MaintenanceInfoMessageProductNavigationControlMenuEntry.java
@@ -37,9 +37,4 @@ public class MaintenanceInfoMessageProductNavigationControlMenuEntry
 			MAINTENANCE;
 	}
 
-	@Override
-	protected boolean isDark() {
-		return false;
-	}
-
 }

--- a/modules/apps/product-navigation/product-navigation-control-menu-api/src/main/java/com/liferay/product/navigation/control/menu/BaseInfoMessageProductNavigationControlMenuEntry.java
+++ b/modules/apps/product-navigation/product-navigation-control-menu-api/src/main/java/com/liferay/product/navigation/control/menu/BaseInfoMessageProductNavigationControlMenuEntry.java
@@ -91,7 +91,7 @@ public abstract class BaseInfoMessageProductNavigationControlMenuEntry
 	protected abstract String getType();
 
 	protected boolean isDark() {
-		return true;
+		return false;
 	}
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87140

**What is being fixed:** The maintenance mode icon in the control menu bar appears pale/washed-out. `BaseInfoMessageProductNavigationControlMenuEntry` had `isDark()` hardcoded to `true`, which was designed for dark-themed UI contexts. With the control menu updated to light styles, this flag causes the `FeatureIndicator` badge to render with incorrect styling.

**How it is being fixed:** The default return value of `isDark()` in the base class is changed from `true` to `false`, fixing all inheriting modules (blogs, bookmarks, document-library, dynamic-data-mapping, journal, knowledge-base, message-boards, sharing, wiki) in a single change. The Depot module's now-redundant override of `isDark()` returning `false` is also removed.

**Before**
<img width="286" height="61" alt="image" src="https://github.com/user-attachments/assets/9991d038-c062-48a5-ae0c-644adaff73d5" />

**After**
<img width="291" height="68" alt="image" src="https://github.com/user-attachments/assets/36b69270-be17-4010-973b-998c2461f870" />
