### PR TITLE
LPD-87297 Fix color picker Editor hex input not adding the # prefix

### DIFF
--- a/modules/apps/layout/layout-js-components-web/src/main/resources/META-INF/resources/js/components/color_picker/ColorPickerField.tsx
+++ b/modules/apps/layout/layout-js-components-web/src/main/resources/META-INF/resources/js/components/color_picker/ColorPickerField.tsx
@@ -14,6 +14,7 @@ import {sub} from 'frontend-js-web';
 import React, {useEffect, useMemo, useRef, useState} from 'react';
 
 import {Color, ColorCategoryMap} from '../../types/ColorPicker';
+import getValidHexColor from '../../utils/getValidHexColor';
 import ColorPalette from './ColorPalette';
 import TokenButton from './TokenButton';
 
@@ -218,7 +219,11 @@ export default function ColorPickerField({
 											color.toHexString().toUpperCase()
 										);
 									}}
-									onHexBlur={externalOnColorChangeEditor}
+									onHexBlur={(value) =>
+										externalOnColorChangeEditor(
+											getValidHexColor(value)
+										)
+									}
 									onHexChange={(hex: string) =>
 										dispatch({hex})
 									}

--- a/modules/apps/layout/layout-js-components-web/test/components/color_picker/ColorPicker.test.tsx
+++ b/modules/apps/layout/layout-js-components-web/test/components/color_picker/ColorPicker.test.tsx
@@ -415,6 +415,115 @@ describe('ColorPicker', () => {
 		});
 	});
 
+	describe('When typing in the Editor hex input popup', () => {
+		it('calls onValueSelect with # prefix when a hex value is typed', async () => {
+			const onValueSelect = jest.fn();
+			const {getByLabelText} = renderColorPicker({
+				onValueSelect,
+				value: '#ffb46e',
+			});
+
+			await userEvent.click(getByLabelText('select-color'));
+
+			const hexInput = screen.getByTestId('customHexInput');
+
+			fireEvent.change(hexInput, {target: {value: 'FF0000'}});
+			fireEvent.blur(hexInput);
+
+			await waitFor(() => {
+				expect(onValueSelect).toHaveBeenCalledWith(
+					INPUT_NAME,
+					'#FF0000'
+				);
+			});
+		});
+
+		it('calls onValueSelect with # prefix when a color name is typed', async () => {
+			const onValueSelect = jest.fn();
+			const {getByLabelText} = renderColorPicker({
+				onValueSelect,
+				value: '#ffb46e',
+			});
+
+			await userEvent.click(getByLabelText('select-color'));
+
+			const hexInput = screen.getByTestId('customHexInput');
+
+			fireEvent.change(hexInput, {target: {value: 'red'}});
+			fireEvent.blur(hexInput);
+
+			await waitFor(() => {
+				expect(onValueSelect).toHaveBeenCalledWith(
+					INPUT_NAME,
+					'#FF0000'
+				);
+			});
+		});
+
+		it('calls onValueSelect without double # prefix when value already has #', async () => {
+			const onValueSelect = jest.fn();
+			const {getByLabelText} = renderColorPicker({
+				onValueSelect,
+				value: '#ffb46e',
+			});
+
+			await userEvent.click(getByLabelText('select-color'));
+
+			const hexInput = screen.getByTestId('customHexInput');
+
+			fireEvent.change(hexInput, {target: {value: '#FF0000'}});
+			fireEvent.blur(hexInput);
+
+			await waitFor(() => {
+				expect(onValueSelect).toHaveBeenCalledWith(
+					INPUT_NAME,
+					'#FF0000'
+				);
+			});
+		});
+
+		it('calls onValueSelect with # prefix when an 8-digit hex value is typed', async () => {
+			const onValueSelect = jest.fn();
+			const {getByLabelText} = renderColorPicker({
+				onValueSelect,
+				value: '#ffb46e',
+			});
+
+			await userEvent.click(getByLabelText('select-color'));
+
+			const hexInput = screen.getByTestId('customHexInput');
+
+			fireEvent.change(hexInput, {target: {value: 'FF000080'}});
+			fireEvent.blur(hexInput);
+
+			await waitFor(() => {
+				expect(onValueSelect).toHaveBeenCalledWith(
+					INPUT_NAME,
+					'#FF000080'
+				);
+			});
+		});
+
+		it('does not call onValueSelect with invalid hex value', async () => {
+			const onValueSelect = jest.fn();
+			const {getByLabelText} = renderColorPicker({
+				onValueSelect,
+				value: '#ffb46e',
+			});
+
+			await userEvent.click(getByLabelText('select-color'));
+
+			const hexInput = screen.getByTestId('customHexInput');
+
+			fireEvent.change(hexInput, {target: {value: 'ZZZZZZ'}});
+			fireEvent.blur(hexInput);
+
+			await waitFor(() => {
+				expect(onValueSelect).not.toHaveBeenCalledWith();
+			});
+		});
+	});
+
 	describe('When the value is a CSS color', () => {
 		it('ensures that when a CSS color color longer than 9 characters is typed, the color remains unchanged', async () => {
 			const {baseElement} = renderColorPicker({


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPD-87297

## Summary

The color picker's Editor popup (custom color tab) was not saving the correct value when the user typed a hex color directly into the hex input and blurred. The `onHexBlur` callback was forwarding the raw value from Clay (which omits the `#` prefix) straight to the change handler, resulting in an unprefixed string being persisted.

## Changes

- `ColorPickerField.tsx`: Replaced direct pass-through on `onHexBlur` with `getValidHexColor(value)`, which strips any existing `#`, validates the hex, and returns a properly prefixed value.
- `ColorPicker.test.tsx`: Added tests for the Editor hex input covering:
  - Plain hex value (`FF0000` → `#FF0000`)
  - CSS color name (`red` → `#FF0000`)
  - Already-prefixed hex (`#FF0000` → `#FF0000`, no double prefix)
  - 8-digit hex with alpha (`FF000080` → `#FF000080`)
  - Invalid hex (not propagated with `#ZZZZZZ`)

## How to test it

1. Open a page in the editor with a styled fragment that has a color field.
2. Click the color swatch to open the color picker.
3. Switch to the custom color tab (Editor popup).
4. Clear the hex input and type a hex value without `#` (e.g., `FF0000`). Tab out or click away.
5. Confirm the color is applied correctly (red) and the saved value is `#FF0000`.
6. Repeat typing a CSS color name (e.g., `red`) — confirm it resolves to `#FF0000`.
7. Repeat with an 8-digit hex (e.g., `FF000080`) — confirm it saves with `#` prefix.