### PR TITLE
LPD-87565 Fix Sites picker search for the Guest site's displayed name

### DIFF
--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SiteResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SiteResourceImpl.java
@@ -70,10 +70,8 @@ import jakarta.ws.rs.core.Response;
 import java.io.File;
 import java.io.Serializable;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
@@ -329,46 +327,6 @@ public class SiteResourceImpl extends BaseSiteResourceImpl {
 				"site", true
 			).build();
 
-		List<Group> groups = _groupService.search(
-			contextCompany.getCompanyId(), classNameIds, search, null, params,
-			true, pagination.getStartPosition(), pagination.getEndPosition(),
-			new GroupNameComparator());
-		int searchCount = _groupService.searchCount(
-			contextCompany.getCompanyId(), classNameIds, search, params);
-
-		if (Validator.isNotNull(search)) {
-			Group guestGroup = _groupLocalService.fetchGroup(
-				contextCompany.getCompanyId(), GroupConstants.GUEST);
-
-			if (guestGroup != null) {
-				boolean alreadyIncluded = groups.contains(guestGroup);
-				boolean shouldBeIncluded = _descriptiveNameContains(
-					guestGroup, search,
-					contextAcceptLanguage.getPreferredLocale());
-
-				if (alreadyIncluded && !shouldBeIncluded) {
-					groups = new ArrayList<>(groups);
-
-					groups.remove(guestGroup);
-
-					searchCount--;
-				}
-				else if (!alreadyIncluded && shouldBeIncluded) {
-					if (pagination.getStartPosition() == 0) {
-						List<Group> mergedGroups = new ArrayList<>(
-							groups.size() + 1);
-
-						mergedGroups.add(guestGroup);
-						mergedGroups.addAll(groups);
-
-						groups = mergedGroups;
-					}
-
-					searchCount++;
-				}
-			}
-		}
-
 		return Page.of(
 			HashMapBuilder.put(
 				"create",
@@ -385,7 +343,15 @@ public class SiteResourceImpl extends BaseSiteResourceImpl {
 					ActionKeys.DELETE, "deleteSiteBatch", Group.class.getName(),
 					null)
 			).build(),
-			transform(groups, this::_toSite), pagination, searchCount);
+			transform(
+				_groupService.search(
+					contextCompany.getCompanyId(), classNameIds, search, null,
+					params, true, pagination.getStartPosition(),
+					pagination.getEndPosition(), new GroupNameComparator()),
+				this::_toSite),
+			pagination,
+			_groupService.searchCount(
+				contextCompany.getCompanyId(), classNameIds, search, params));
 	}
 
 	@Override
@@ -557,16 +523,6 @@ public class SiteResourceImpl extends BaseSiteResourceImpl {
 		}
 
 		return group;
-	}
-
-	private boolean _descriptiveNameContains(
-			Group group, String search, Locale locale)
-		throws Exception {
-
-		String descriptiveName = StringUtil.toLowerCase(
-			group.getDescriptiveName(locale), locale);
-
-		return descriptiveName.contains(StringUtil.toLowerCase(search, locale));
 	}
 
 	private Map<Locale, String> _getDescriptionMap(Site site) {

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SiteResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SiteResourceImpl.java
@@ -343,7 +343,8 @@ public class SiteResourceImpl extends BaseSiteResourceImpl {
 			if (guestGroup != null) {
 				boolean alreadyIncluded = groups.contains(guestGroup);
 				boolean shouldBeIncluded = _descriptiveNameContains(
-					guestGroup, search);
+					guestGroup, search,
+					contextAcceptLanguage.getPreferredLocale());
 
 				if (alreadyIncluded && !shouldBeIncluded) {
 					groups = new ArrayList<>(groups);
@@ -558,13 +559,14 @@ public class SiteResourceImpl extends BaseSiteResourceImpl {
 		return group;
 	}
 
-	private boolean _descriptiveNameContains(Group group, String search)
+	private boolean _descriptiveNameContains(
+			Group group, String search, Locale locale)
 		throws Exception {
 
 		String descriptiveName = StringUtil.toLowerCase(
-			group.getDescriptiveName(LocaleUtil.getDefault()));
+			group.getDescriptiveName(locale), locale);
 
-		return descriptiveName.contains(StringUtil.toLowerCase(search));
+		return descriptiveName.contains(StringUtil.toLowerCase(search, locale));
 	}
 
 	private Map<Locale, String> _getDescriptionMap(Site site) {

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SiteResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SiteResourceImpl.java
@@ -70,8 +70,10 @@ import jakarta.ws.rs.core.Response;
 import java.io.File;
 import java.io.Serializable;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
@@ -327,6 +329,45 @@ public class SiteResourceImpl extends BaseSiteResourceImpl {
 				"site", true
 			).build();
 
+		List<Group> groups = _groupService.search(
+			contextCompany.getCompanyId(), classNameIds, search, null, params,
+			true, pagination.getStartPosition(), pagination.getEndPosition(),
+			new GroupNameComparator());
+		int searchCount = _groupService.searchCount(
+			contextCompany.getCompanyId(), classNameIds, search, params);
+
+		if (Validator.isNotNull(search)) {
+			Group guestGroup = _groupLocalService.fetchGroup(
+				contextCompany.getCompanyId(), GroupConstants.GUEST);
+
+			if (guestGroup != null) {
+				boolean alreadyIncluded = groups.contains(guestGroup);
+				boolean shouldBeIncluded = _descriptiveNameContains(
+					guestGroup, search);
+
+				if (alreadyIncluded && !shouldBeIncluded) {
+					groups = new ArrayList<>(groups);
+
+					groups.remove(guestGroup);
+
+					searchCount--;
+				}
+				else if (!alreadyIncluded && shouldBeIncluded) {
+					if (pagination.getStartPosition() == 0) {
+						List<Group> mergedGroups = new ArrayList<>(
+							groups.size() + 1);
+
+						mergedGroups.add(guestGroup);
+						mergedGroups.addAll(groups);
+
+						groups = mergedGroups;
+					}
+
+					searchCount++;
+				}
+			}
+		}
+
 		return Page.of(
 			HashMapBuilder.put(
 				"create",
@@ -343,15 +384,7 @@ public class SiteResourceImpl extends BaseSiteResourceImpl {
 					ActionKeys.DELETE, "deleteSiteBatch", Group.class.getName(),
 					null)
 			).build(),
-			transform(
-				_groupService.search(
-					contextCompany.getCompanyId(), classNameIds, search, null,
-					params, true, pagination.getStartPosition(),
-					pagination.getEndPosition(), new GroupNameComparator()),
-				this::_toSite),
-			pagination,
-			_groupService.searchCount(
-				contextCompany.getCompanyId(), classNameIds, search, params));
+			transform(groups, this::_toSite), pagination, searchCount);
 	}
 
 	@Override
@@ -523,6 +556,15 @@ public class SiteResourceImpl extends BaseSiteResourceImpl {
 		}
 
 		return group;
+	}
+
+	private boolean _descriptiveNameContains(Group group, String search)
+		throws Exception {
+
+		String descriptiveName = StringUtil.toLowerCase(
+			group.getDescriptiveName(LocaleUtil.getDefault()));
+
+		return descriptiveName.contains(StringUtil.toLowerCase(search));
 	}
 
 	private Map<Locale, String> _getDescriptionMap(Site site) {

--- a/modules/test/playwright/tests/design-library-web/main/designLibrary.spec.ts
+++ b/modules/test/playwright/tests/design-library-web/main/designLibrary.spec.ts
@@ -256,7 +256,7 @@ test(
 	{tag: '@LPD-79453'},
 	async ({apiHelpers, designLibrariesPage, page}) => {
 		const designLibraryName = getRandomString();
-		const siteName = 'Liferay DXP';
+		const siteName = 'Liferay DXP Site';
 
 		const connectedSitesDialog = page.getByRole('dialog');
 

--- a/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
@@ -4676,7 +4676,28 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 			return CustomSQLUtil.keywords(name);
 		}
 
-		if (StringUtil.wildcardMatches(
+		Group guestGroup = fetchGroup(companyId, GroupConstants.GUEST);
+
+		String lowerCaseGuestDescriptiveName = StringPool.BLANK;
+
+		if (guestGroup != null) {
+			try {
+				String guestDescriptiveName = guestGroup.getDescriptiveName(
+					LocaleUtil.getMostRelevantLocale());
+
+				lowerCaseGuestDescriptiveName = StringUtil.toLowerCase(
+					guestDescriptiveName);
+			}
+			catch (PortalException portalException) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(portalException);
+				}
+			}
+		}
+
+		if (lowerCaseGuestDescriptiveName.contains(
+				StringUtil.toLowerCase(name)) ||
+			StringUtil.wildcardMatches(
 				company.getName(), name, CharPool.UNDERLINE, CharPool.PERCENT,
 				CharPool.BACK_SLASH, false)) {
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87565

**What is being fixed:** The `GET /o/headless-admin-site/v1.0/sites?search=...` endpoint cannot find the Guest site by the name users actually see in the UI. The default site is displayed as `Liferay DXP Site`, but typing `Liferay DXP`, `DXP`, or `Site` in any picker that consumes this endpoint (Design Library Connected Sites, CMS Connected Sites / Space picker) returns nothing. Conversely, typing `Guest`, a string the user never sees, surfaces the site under a name that does not appear anywhere in the UI. This breaks the Playwright test `design-library-web/main/designLibrary.spec.ts > Can connect and disconnect a site from a design library` and any user-facing flow that relies on typing the displayed name.

**How it is being fixed:** The fix moves into the service layer. `GroupLocalServiceImpl.getSearchNames` already appended a Guest fallback (`%guest%`) to the search LIKE patterns when the keyword matched the company name. That worked while the default company was `Liferay DXP` — typing substrings of the displayed name triggered the fallback. LPD-77422 / LPD-77443 then renamed the default company to `Liferay` and special-cased `GroupImpl.getDescriptiveName` to read the language-bundle key `liferay-dxp-site` (`Liferay DXP Site` in en, `Sitio de Liferay DXP` in es, etc.). The display side moved; the search side did not, so `DXP` and `Site` stopped firing the existing fallback.

[site-picker.webm](https://github.com/user-attachments/assets/92c418d4-ce64-4f1a-ab26-e6c2b3384a52)