### PR TITLE
LPD-77874 Anchor breadcrumb collapse toggle to first row of items

### DIFF
--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_breadcrumbs.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_breadcrumbs.scss
@@ -147,6 +147,7 @@ $breadcrumb-link: map-deep-merge(
 		border-radius: 1px,
 		color: var(--breadcrumb-link-color, $breadcrumb-link-color),
 		display: block,
+		line-height: 1.5rem,
 		text-decoration:
 			var(
 				--breadcrumb-link-text-decoration,
@@ -177,6 +178,8 @@ $breadcrumb-toggle: () !default;
 $breadcrumb-toggle: map-merge(
 	(
 		color: $breadcrumb-link-color,
+		flex-shrink: 0,
+		margin-top: $breadcrumb-padding-y,
 	),
 	$breadcrumb-toggle
 );
@@ -184,7 +187,6 @@ $breadcrumb-toggle: map-merge(
 $breadcrumb-bar: () !default;
 $breadcrumb-bar: map-deep-merge(
 	(
-		align-items: center,
 		display: flex,
 	),
 	$breadcrumb-bar

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/variables/_breadcrumbs.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/variables/_breadcrumbs.scss
@@ -72,9 +72,8 @@ $cadmin-breadcrumb-item: map-deep-merge(
 				content: '',
 				height: $cadmin-breadcrumb-divider-svg-icon-height,
 				left: 0px,
-				margin-top: calc(
-						#{$cadmin-breadcrumb-divider-svg-icon-height} / -2
-					),
+				margin-top:
+					calc(#{$cadmin-breadcrumb-divider-svg-icon-height} / -2),
 				padding: 0px,
 				position: absolute,
 				top: 50%,

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/variables/_breadcrumbs.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/variables/_breadcrumbs.scss
@@ -135,6 +135,7 @@ $cadmin-breadcrumb-link: map-deep-merge(
 		border-radius: 1px,
 		color: $cadmin-breadcrumb-link-color,
 		display: block,
+		line-height: 1.5rem,
 		text-decoration: $cadmin-breadcrumb-link-text-decoration,
 		text-transform: $cadmin-breadcrumb-text-transform,
 		transition: box-shadow 0.15s ease-in-out,
@@ -160,6 +161,7 @@ $cadmin-breadcrumb-toggle: () !default;
 $cadmin-breadcrumb-toggle: map-merge(
 	(
 		color: $cadmin-breadcrumb-link-color,
+		flex-shrink: 0,
 		margin-top: $cadmin-breadcrumb-padding-y,
 	),
 	$cadmin-breadcrumb-toggle
@@ -168,7 +170,6 @@ $cadmin-breadcrumb-toggle: map-merge(
 $cadmin-breadcrumb-bar: () !default;
 $cadmin-breadcrumb-bar: map-deep-merge(
 	(
-		align-items: flex-start,
 		display: flex,
 	),
 	$cadmin-breadcrumb-bar

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/variables/_breadcrumbs.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/variables/_breadcrumbs.scss
@@ -72,8 +72,9 @@ $cadmin-breadcrumb-item: map-deep-merge(
 				content: '',
 				height: $cadmin-breadcrumb-divider-svg-icon-height,
 				left: 0px,
-				margin-top:
-					calc(#{$cadmin-breadcrumb-divider-svg-icon-height} / -2),
+				margin-top: calc(
+						#{$cadmin-breadcrumb-divider-svg-icon-height} / -2
+					),
 				padding: 0px,
 				position: absolute,
 				top: 50%,
@@ -159,6 +160,7 @@ $cadmin-breadcrumb-toggle: () !default;
 $cadmin-breadcrumb-toggle: map-merge(
 	(
 		color: $cadmin-breadcrumb-link-color,
+		margin-top: $cadmin-breadcrumb-padding-y,
 	),
 	$cadmin-breadcrumb-toggle
 );
@@ -166,7 +168,7 @@ $cadmin-breadcrumb-toggle: map-merge(
 $cadmin-breadcrumb-bar: () !default;
 $cadmin-breadcrumb-bar: map-deep-merge(
 	(
-		align-items: center,
+		align-items: flex-start,
 		display: flex,
 	),
 	$cadmin-breadcrumb-bar

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/variables/_breadcrumbs.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/variables/_breadcrumbs.scss
@@ -132,6 +132,7 @@ $breadcrumb-link: map-deep-merge(
 	(
 		color: $breadcrumb-link-color,
 		display: block,
+		line-height: 1.5rem,
 		text-decoration: $breadcrumb-link-text-decoration,
 		text-transform: $breadcrumb-text-transform,
 
@@ -154,6 +155,7 @@ $breadcrumb-toggle: () !default;
 $breadcrumb-toggle: map-merge(
 	(
 		color: $breadcrumb-link-color,
+		flex-shrink: 0,
 		margin-top: $breadcrumb-padding-y,
 	),
 	$breadcrumb-toggle
@@ -162,7 +164,6 @@ $breadcrumb-toggle: map-merge(
 $breadcrumb-bar: () !default;
 $breadcrumb-bar: map-deep-merge(
 	(
-		align-items: flex-start,
 		display: flex,
 	),
 	$breadcrumb-bar

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/variables/_breadcrumbs.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/variables/_breadcrumbs.scss
@@ -154,6 +154,7 @@ $breadcrumb-toggle: () !default;
 $breadcrumb-toggle: map-merge(
 	(
 		color: $breadcrumb-link-color,
+		margin-top: $breadcrumb-padding-y,
 	),
 	$breadcrumb-toggle
 );
@@ -161,7 +162,7 @@ $breadcrumb-toggle: map-merge(
 $breadcrumb-bar: () !default;
 $breadcrumb-bar: map-deep-merge(
 	(
-		align-items: center,
+		align-items: flex-start,
 		display: flex,
 	),
 	$breadcrumb-bar


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-77874

**What is being fixed:** When the breadcrumb has enough items to wrap onto multiple rows, the collapse/expand toggle drifts to the vertical center of the bar instead of staying aligned with the first row of items, so the icon looks visually detached from the trail.

**How it is being fixed:** `.breadcrumb-bar` is a flex container with `align-items: center`, so when the `<ol class="breadcrumb">` child wraps onto multiple rows the bar grows taller and the toggle re-centers vertically. Switching the bar to `align-items: flex-start` keeps the toggle pinned to the top, and adding `margin-top: $breadcrumb-padding-y` on the toggle accounts for the breadcrumb's own vertical padding so the icon ends up on the same line as the first row of items. The cadmin theme is fixed the same way through its mirrored tokens.