### PR TITLE
LPD-83670 Fix exception message in getGroupScopedFilterString

### DIFF
--- a/modules/apps/configuration-admin/configuration-admin-api/src/main/java/com/liferay/configuration/admin/util/ConfigurationFilterStringUtil.java
+++ b/modules/apps/configuration-admin/configuration-admin-api/src/main/java/com/liferay/configuration/admin/util/ConfigurationFilterStringUtil.java
@@ -57,7 +57,7 @@ public class ConfigurationFilterStringUtil {
 
 			throw new IllegalArgumentException(
 				"A valid company is expected when building a group scoped " +
-					"configuration filter");
+					"configuration filter string");
 		}
 
 		return StringBundler.concat(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-83670

**What is being fixed:** ConfigurationFilterStringUtilTest.testGetGroupScopedFilterString was failing because the IllegalArgumentException thrown by getGroupScopedFilterString ended in "configuration filter" while the test asserted it ended in "configuration filter string".

**How it is being fixed:** Append " string" to the exception message so it accurately describes what the method builds (a filter string, matching the method name) and matches the test's assertion.