### PR TITLE
LPD-81847 Show focus shadow on ClayDualListBox selects

### DIFF
--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_reorder.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_reorder.scss
@@ -42,12 +42,17 @@ $clay-reorder-underlay: map-deep-merge(
 $clay-reorder-underlay-focus: () !default;
 $clay-reorder-underlay-focus: map-deep-merge(
 	(
-		background-color:
-			var(--clay-reorder-underlay-focus-background-color, $input-focus-bg),
-		border-color:
-			var(
+		background-color: var(
+				--clay-reorder-underlay-focus-background-color,
+				$input-focus-bg
+			),
+		border-color: var(
 				--clay-reorder-underlay-focus-border-color,
 				$input-focus-border-color
+			),
+		box-shadow: var(
+				--clay-reorder-underlay-focus-box-shadow,
+				$input-focus-box-shadow
 			),
 	),
 	$clay-reorder-underlay-focus

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_reorder.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_reorder.scss
@@ -42,15 +42,15 @@ $clay-reorder-underlay: map-deep-merge(
 $clay-reorder-underlay-focus: () !default;
 $clay-reorder-underlay-focus: map-deep-merge(
 	(
-		background-color: var(
-				--clay-reorder-underlay-focus-background-color,
-				$input-focus-bg
-			),
-		border-color: var(
+		background-color:
+			var(--clay-reorder-underlay-focus-background-color, $input-focus-bg),
+		border-color:
+			var(
 				--clay-reorder-underlay-focus-border-color,
 				$input-focus-border-color
 			),
-		box-shadow: var(
+		box-shadow:
+			var(
 				--clay-reorder-underlay-focus-box-shadow,
 				$input-focus-box-shadow
 			),

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas/variables/_reorder.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas/variables/_reorder.scss
@@ -1,7 +1,7 @@
 $clay-reorder-underlay-focus: () !default;
 $clay-reorder-underlay-focus: map-deep-merge(
 	(
-		box-shadow: null,
+		box-shadow: $input-focus-box-shadow,
 	),
 	$clay-reorder-underlay-focus
 );

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/variables/_reorder.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/variables/_reorder.scss
@@ -44,6 +44,7 @@ $cadmin-clay-reorder-underlay-focus: map-deep-merge(
 	(
 		background-color: $cadmin-input-focus-bg,
 		border-color: $cadmin-input-focus-border-color,
+		box-shadow: $cadmin-input-focus-box-shadow,
 	),
 	$cadmin-clay-reorder-underlay-focus
 );


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-81847

**What is being fixed:** When a user keyboard-focuses a select inside `ClayDualListBox`, no focus shadow appears. The expected behavior is the standard Clay focus glow (white inner ring + colored outer ring) — the same indicator every other Clay form control shows on focus. The current rendering only changes the underlay's border color, leaving the focus state visibly weaker and inconsistent with the rest of the design system.

**How it is being fixed:** `ClayDualListBox` renders two `ClaySelectBox` children, each producing `<div class="clay-reorder"><select class="form-control form-control-inset"/><div class="clay-reorder-underlay form-control"/></div>`. The select's own focus shadow is intentionally suppressed; the visible focus indicator is delegated to the underlay sibling via `.clay-reorder .form-control-inset:focus + .clay-reorder-underlay`. That focus map was missing the `box-shadow` declaration in cadmin and explicitly set it to `null` in atlas. The fix wires the map in each theme to the existing focus-shadow token — `$cadmin-input-focus-box-shadow` and `$input-focus-box-shadow` respectively — the same one `.form-control:focus` already uses, so no new color values are introduced and the focus indicator now matches every other form control.

**Scope (broader approach):** The fix is applied at the `.clay-reorder` layer rather than narrowed to `.clay-dual-listbox` because the missing focus shadow is a property of the underlay-focus map itself, not specific to the dual-list-box composition. As a result, both components that render `.clay-reorder` markup gain the focus indicator:

- `ClayDualListBox` (the component reported in the ticket — composes two `ClaySelectBox`).
- `ClaySelectBox` (used standalone elsewhere — also benefits, since "form control without a focus indicator" was the same bug there).

**Before**:
<img width="1235" height="416" alt="image" src="https://github.com/user-attachments/assets/e98d9f23-e995-4c07-8ff5-47e320377f71" />

**After**:
<img width="928" height="605" alt="image" src="https://github.com/user-attachments/assets/1ce04171-f01d-42f5-9492-826dc762ffa4" />
