### PR TITLE
LPD-74518 Scroll the selected option into view when opening Picker

### DIFF
--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/picker/Picker.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/picker/Picker.tsx
@@ -417,26 +417,27 @@ export function Picker<T extends Record<string, any> | string | number>({
 			return;
 		}
 
-		const key =
-			selectedKey || selectedKey === 0
-				? selectedKey
-				: activeDescendant;
+		const key = selectedKey ?? activeDescendant;
 
-		if (!key && key !== 0) {
-			return;
-		}
-
-		const item = document.getElementById(String(key));
-
-		if (!item || !listRef.current.contains(item)) {
+		if (key === undefined) {
 			return;
 		}
 
 		const list = listRef.current;
+
+		const item = list.querySelector<HTMLElement>(
+			`[id="${CSS.escape(String(key))}"]`
+		);
+
+		if (!item) {
+			return;
+		}
+
 		const itemRect = item.getBoundingClientRect();
 		const listRect = list.getBoundingClientRect();
-		const itemOffsetInList =
-			itemRect.top - listRect.top + list.scrollTop;
+
+		const itemOffsetInList = itemRect.top - listRect.top + list.scrollTop;
+
 		const centeredTop =
 			itemOffsetInList - (list.clientHeight - itemRect.height) / 2;
 

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/picker/Picker.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/picker/Picker.tsx
@@ -433,9 +433,12 @@ export function Picker<T extends Record<string, any> | string | number>({
 		}
 
 		const list = listRef.current;
-		const offsetTop = item.offsetTop - list.offsetTop;
+		const itemRect = item.getBoundingClientRect();
+		const listRect = list.getBoundingClientRect();
+		const itemOffsetInList =
+			itemRect.top - listRect.top + list.scrollTop;
 		const centeredTop =
-			offsetTop - (list.clientHeight - item.offsetHeight) / 2;
+			itemOffsetInList - (list.clientHeight - itemRect.height) / 2;
 
 		list.scrollTop = Math.max(
 			0,

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/picker/Picker.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/picker/Picker.tsx
@@ -412,6 +412,37 @@ export function Picker<T extends Record<string, any> | string | number>({
 			listRef.current?.removeEventListener('scroll', onScroll, true);
 	}, [active]);
 
+	useEffect(() => {
+		if (!active || !listRef.current) {
+			return;
+		}
+
+		const key =
+			selectedKey || selectedKey === 0
+				? selectedKey
+				: activeDescendant;
+
+		if (!key && key !== 0) {
+			return;
+		}
+
+		const item = document.getElementById(String(key));
+
+		if (!item || !listRef.current.contains(item)) {
+			return;
+		}
+
+		const list = listRef.current;
+		const offsetTop = item.offsetTop - list.offsetTop;
+		const centeredTop =
+			offsetTop - (list.clientHeight - item.offsetHeight) / 2;
+
+		list.scrollTop = Math.max(
+			0,
+			Math.min(centeredTop, list.scrollHeight - list.clientHeight)
+		);
+	}, [active]);
+
 	const onMoveFocus = useCallback(
 		(
 			key: 'PageUp' | 'PageDown',

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/picker/__tests__/IncrementalInteractions.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/picker/__tests__/IncrementalInteractions.tsx
@@ -195,7 +195,9 @@ describe('Picker incremental interactions', () => {
 		const LIST_CLIENT_HEIGHT = 200;
 
 		const originalScrollTo = HTMLElement.prototype.scrollTo;
+
 		HTMLElement.prototype.scrollTo = jest.fn() as any;
+
 		const getBoundingClientRectSpy = jest
 			.spyOn(Element.prototype, 'getBoundingClientRect')
 			.mockImplementation(function (this: HTMLElement) {
@@ -207,11 +209,11 @@ describe('Picker incremental interactions', () => {
 						height: ITEM_HEIGHT,
 						left: 0,
 						right: 0,
+						toJSON: () => ({}),
 						top,
 						width: 0,
 						x: 0,
 						y: top,
-						toJSON: () => ({}),
 					};
 				}
 
@@ -221,11 +223,11 @@ describe('Picker incremental interactions', () => {
 						height: LIST_CLIENT_HEIGHT,
 						left: 0,
 						right: 0,
+						toJSON: () => ({}),
 						top: 0,
 						width: 0,
 						x: 0,
 						y: 0,
-						toJSON: () => ({}),
 					};
 				}
 
@@ -234,13 +236,14 @@ describe('Picker incremental interactions', () => {
 					height: 0,
 					left: 0,
 					right: 0,
+					toJSON: () => ({}),
 					top: 0,
 					width: 0,
 					x: 0,
 					y: 0,
-					toJSON: () => ({}),
 				};
 			});
+
 		const clientHeightSpy = jest
 			.spyOn(HTMLElement.prototype, 'clientHeight', 'get')
 			.mockImplementation(function (this: HTMLElement) {
@@ -248,6 +251,7 @@ describe('Picker incremental interactions', () => {
 					? LIST_CLIENT_HEIGHT
 					: 0;
 			});
+
 		const scrollHeightSpy = jest
 			.spyOn(HTMLElement.prototype, 'scrollHeight', 'get')
 			.mockImplementation(function (this: HTMLElement) {
@@ -266,6 +270,7 @@ describe('Picker incremental interactions', () => {
 			userEvent.click(getByRole('combobox'));
 
 			const selectedIndex = items.indexOf('Item 40');
+
 			const expected = Math.max(
 				0,
 				Math.min(
@@ -279,8 +284,11 @@ describe('Picker incremental interactions', () => {
 		}
 		finally {
 			getBoundingClientRectSpy.mockRestore();
+
 			clientHeightSpy.mockRestore();
+
 			scrollHeightSpy.mockRestore();
+
 			HTMLElement.prototype.scrollTo = originalScrollTo;
 		}
 	});

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/picker/__tests__/IncrementalInteractions.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/picker/__tests__/IncrementalInteractions.tsx
@@ -188,6 +188,75 @@ describe('Picker incremental interactions', () => {
 		expect(combobox.getAttribute('aria-activedescendant')).toBe('Banana');
 	});
 
+	it('scrolls the selected option into view when expanding the menu', () => {
+		const items = Array.from({length: 50}, (_, i) => `Item ${i + 1}`);
+
+		const ITEM_HEIGHT = 20;
+		const LIST_CLIENT_HEIGHT = 200;
+
+		const originalScrollTo = HTMLElement.prototype.scrollTo;
+		HTMLElement.prototype.scrollTo = jest.fn() as any;
+		const offsetTopSpy = jest
+			.spyOn(HTMLElement.prototype, 'offsetTop', 'get')
+			.mockImplementation(function (this: HTMLElement) {
+				if (this.getAttribute('role') === 'option') {
+					return items.indexOf(this.id) * ITEM_HEIGHT;
+				}
+
+				return 0;
+			});
+		const offsetHeightSpy = jest
+			.spyOn(HTMLElement.prototype, 'offsetHeight', 'get')
+			.mockImplementation(function (this: HTMLElement) {
+				return this.getAttribute('role') === 'option'
+					? ITEM_HEIGHT
+					: 0;
+			});
+		const clientHeightSpy = jest
+			.spyOn(HTMLElement.prototype, 'clientHeight', 'get')
+			.mockImplementation(function (this: HTMLElement) {
+				return this.getAttribute('role') === 'listbox'
+					? LIST_CLIENT_HEIGHT
+					: 0;
+			});
+		const scrollHeightSpy = jest
+			.spyOn(HTMLElement.prototype, 'scrollHeight', 'get')
+			.mockImplementation(function (this: HTMLElement) {
+				return this.getAttribute('role') === 'listbox'
+					? items.length * ITEM_HEIGHT
+					: 0;
+			});
+
+		try {
+			const {getByRole} = render(
+				<Picker items={items} selectedKey="Item 40">
+					{(item) => <Option key={item}>{item}</Option>}
+				</Picker>
+			);
+
+			userEvent.click(getByRole('combobox'));
+
+			const selectedIndex = items.indexOf('Item 40');
+			const expected = Math.max(
+				0,
+				Math.min(
+					selectedIndex * ITEM_HEIGHT -
+						(LIST_CLIENT_HEIGHT - ITEM_HEIGHT) / 2,
+					items.length * ITEM_HEIGHT - LIST_CLIENT_HEIGHT
+				)
+			);
+
+			expect(getByRole('listbox').scrollTop).toBe(expected);
+		}
+		finally {
+			offsetTopSpy.mockRestore();
+			offsetHeightSpy.mockRestore();
+			clientHeightSpy.mockRestore();
+			scrollHeightSpy.mockRestore();
+			HTMLElement.prototype.scrollTo = originalScrollTo;
+		}
+	});
+
 	describe('expanded menu', () => {
 		it.concurrent.each([
 			['enter', '[Enter]'],

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/picker/__tests__/IncrementalInteractions.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/picker/__tests__/IncrementalInteractions.tsx
@@ -196,21 +196,50 @@ describe('Picker incremental interactions', () => {
 
 		const originalScrollTo = HTMLElement.prototype.scrollTo;
 		HTMLElement.prototype.scrollTo = jest.fn() as any;
-		const offsetTopSpy = jest
-			.spyOn(HTMLElement.prototype, 'offsetTop', 'get')
+		const getBoundingClientRectSpy = jest
+			.spyOn(Element.prototype, 'getBoundingClientRect')
 			.mockImplementation(function (this: HTMLElement) {
 				if (this.getAttribute('role') === 'option') {
-					return items.indexOf(this.id) * ITEM_HEIGHT;
+					const top = items.indexOf(this.id) * ITEM_HEIGHT;
+
+					return {
+						bottom: top + ITEM_HEIGHT,
+						height: ITEM_HEIGHT,
+						left: 0,
+						right: 0,
+						top,
+						width: 0,
+						x: 0,
+						y: top,
+						toJSON: () => ({}),
+					};
 				}
 
-				return 0;
-			});
-		const offsetHeightSpy = jest
-			.spyOn(HTMLElement.prototype, 'offsetHeight', 'get')
-			.mockImplementation(function (this: HTMLElement) {
-				return this.getAttribute('role') === 'option'
-					? ITEM_HEIGHT
-					: 0;
+				if (this.getAttribute('role') === 'listbox') {
+					return {
+						bottom: LIST_CLIENT_HEIGHT,
+						height: LIST_CLIENT_HEIGHT,
+						left: 0,
+						right: 0,
+						top: 0,
+						width: 0,
+						x: 0,
+						y: 0,
+						toJSON: () => ({}),
+					};
+				}
+
+				return {
+					bottom: 0,
+					height: 0,
+					left: 0,
+					right: 0,
+					top: 0,
+					width: 0,
+					x: 0,
+					y: 0,
+					toJSON: () => ({}),
+				};
 			});
 		const clientHeightSpy = jest
 			.spyOn(HTMLElement.prototype, 'clientHeight', 'get')
@@ -249,8 +278,7 @@ describe('Picker incremental interactions', () => {
 			expect(getByRole('listbox').scrollTop).toBe(expected);
 		}
 		finally {
-			offsetTopSpy.mockRestore();
-			offsetHeightSpy.mockRestore();
+			getBoundingClientRectSpy.mockRestore();
 			clientHeightSpy.mockRestore();
 			scrollHeightSpy.mockRestore();
 			HTMLElement.prototype.scrollTo = originalScrollTo;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-74518

**What is being fixed:** When a `ClayDatePicker` is configured with a wide year range (the DDM Date/Time field uses a 125-year range, the Web Content Schedule Publication picker about 76), opening the year selector showed the dropdown scrolled to the top, with the selected current year rendered far below the visible area. The user had to scroll manually to see what was already selected. The same bug affects every Liferay-internal `Picker` whose `selectedKey` is not near the top of `items`.

**How it is being fixed:** Added a `useEffect` to the Liferay copy of `Picker` (`clay-core/src/picker/Picker.tsx`) that runs when the menu becomes active, looks up the selected option (falling back to the keyboard-focused option), and assigns `listRef.current.scrollTop` to a clamped, centered offset. Direct `scrollTop` is used rather than `scrollIntoView` so ancestor scroll containers — the `Overlay` portal and the page itself — are not affected. A new test in `IncrementalInteractions.tsx` mocks the listbox geometry, opens a 50-item Picker with a deep `selectedKey`, and verifies the resulting scroll offset matches the centering formula.

[picker-year.webm](https://github.com/user-attachments/assets/53d4f13c-f249-4caf-8d31-19f157695fab)
