### PR TITLE
LPD-87245 Add space filter to missing CMS components referencing asset libraries of type Space

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/categorization/tags/ViewTags.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/categorization/tags/ViewTags.tsx
@@ -65,7 +65,7 @@ export default function ViewTags({
 
 	const filters = [
 		{
-			apiURL: '/o/headless-asset-library/v1.0/asset-libraries',
+			apiURL: "/o/headless-asset-library/v1.0/asset-libraries?filter=type eq 'Space'",
 			entityFieldType: 'string',
 			id: 'groupIds',
 			itemKey: 'id',

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/dashboard/components/SpacesDropdown.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/dashboard/components/SpacesDropdown.tsx
@@ -32,6 +32,7 @@ const SpacesDropdown: React.FC<React.HTMLAttributes<HTMLElement>> = ({
 
 	const fetchSpaces = async (keywords: string = '') => {
 		const queryParams = buildQueryString({
+			filter: "type eq 'Space'",
 			keywords,
 		});
 		const endpoint = `${PATH}${queryParams}`;

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/categorization/tags/ViewTags.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/categorization/tags/ViewTags.test.tsx
@@ -1,0 +1,54 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import '@testing-library/jest-dom';
+import {render} from '@testing-library/react';
+import React from 'react';
+
+import ViewTags from '../../../../../src/main/resources/META-INF/resources/js/main_view/categorization/tags/ViewTags';
+
+const mockFrontendDataSet = jest.fn((_props: any) => null);
+
+jest.mock('@liferay/frontend-data-set-web', () => ({
+	...(jest.requireActual('@liferay/frontend-data-set-web') as any),
+	FrontendDataSet: (props: any) => mockFrontendDataSet(props),
+}));
+
+(global as any).Liferay = {
+	Language: {
+		get: (key: string) => key,
+	},
+	ThemeDisplay: {
+		getPathThemeImages: () => '/path/to/images',
+	},
+};
+
+describe('[CMS Categorization] Components: ViewTags', () => {
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('passes a Space-typed asset library filter to FrontendDataSet', () => {
+		render(
+			<ViewTags
+				actionItems={[] as any}
+				cmsGroupId={1}
+				dataSetId="tags"
+				invalidTagCharacters=""
+				tagUsagesURL=""
+				tagsURL=""
+				vocabulariesURL=""
+			/>
+		);
+
+		const [{filters}] = mockFrontendDataSet.mock.calls[0] as any;
+
+		const spaceFilter = filters.find(
+			(filter: any) => filter.id === 'groupIds'
+		);
+
+		expect(spaceFilter?.apiURL).toContain("filter=type eq 'Space'");
+	});
+});

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/dashboard/SpacesDropdown.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/dashboard/SpacesDropdown.test.tsx
@@ -37,6 +37,29 @@ describe('[CMS Dashboard] Components: SpacesDropdown', () => {
 		jest.restoreAllMocks();
 	});
 
+	it('fetches spaces filtered by type Space', async () => {
+		const apiHelperGetSpy = jest.spyOn(ApiHelper, 'get').mockResolvedValue({
+			data: {items: []},
+			error: null,
+		});
+
+		render(<WrappedComponent />);
+
+		fireEvent.click(
+			screen.getByRole('button', {
+				name: 'all-spaces',
+			})
+		);
+
+		await waitForElementToBeRemoved(() => screen.getByTestId('loading'));
+
+		expect(apiHelperGetSpy).toHaveBeenCalledWith(
+			expect.stringContaining(
+				`filter=${encodeURIComponent("type eq 'Space'")}`
+			)
+		);
+	});
+
 	it('renders correctly', async () => {
 		jest.spyOn(ApiHelper, 'get').mockResolvedValue({
 			data: {items: []},


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPD-87245

## Summary

Previous commits added `filter=type eq 'Space'` to several CMS components' asset library queries to exclude non-Space asset libraries from dropdowns and lists. Two components were missed in that effort: `ViewTags` (categorization module) and `SpacesDropdown` (dashboard). This PR applies the same Space-type filter to both components and adds unit tests to verify the filter is correctly applied.

## Changes

**ViewTags.tsx** — Updated the asset-libraries API URL to include the Space filter parameter in the `groupIds` filter configuration, ensuring only Space-type asset libraries are fetched for the tag categorization interface.

**SpacesDropdown.tsx** — Added the Space-type filter to the query parameters in the `fetchSpaces` method, restricting results to Space-type asset libraries when populating the dropdown.

**ViewTags.test.tsx** (new) — Verifies the `groupIds` filter's apiURL contains `filter=type eq 'Space'`.

**SpacesDropdown.test.tsx** — Asserts that the API call includes the Space-type filter in its query parameters.

## How to test it

1. Run module unit tests: `yarn test` in `modules/apps/site/site-cms-site-initializer`.
2. Deploy and visit Categorization > Tags; confirm only Space-type asset libraries appear.
3. Visit Dashboard and click the spaces dropdown; verify only Space-type libraries listed.