### PR TITLE
LPD-82544 Upload Files in CMS Item Selector from Object Layout

### DIFF
--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/ItemSelectorModal.tsx
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/ItemSelectorModal.tsx
@@ -199,6 +199,35 @@ function ItemSelectorModal<T extends Record<string, any>>({
 		});
 	};
 
+	const defaultCreationMenu =
+		FilesUploaderComponent || createItemURL
+			? {
+					primaryItems: [
+						...(FilesUploaderComponent
+							? [
+									{
+										label: Liferay.Language.get(
+											'upload-files'
+										),
+										onClick: () => setViewType('upload'),
+									},
+								]
+							: []),
+						...(createItemURL
+							? [
+									{
+										href: createItemURL,
+										label: Liferay.Language.get(
+											'add-new-item'
+										),
+										target: ACTION_ITEM_TARGETS.BLANK,
+									},
+								]
+							: []),
+					],
+				}
+			: undefined;
+
 	const hasSelectedItems = !!selectedItems.length;
 
 	const fileDropSettings = useMemo<IFileDropSettings>(() => {
@@ -264,36 +293,7 @@ function ItemSelectorModal<T extends Record<string, any>>({
 						{...fdsProps}
 						apiURL={apiURL}
 						creationMenu={
-							FilesUploaderComponent || createItemURL
-								? {
-										primaryItems: [
-											...(FilesUploaderComponent
-												? [
-														{
-															label: Liferay.Language.get(
-																'upload-files'
-															),
-															onClick: () =>
-																setViewType(
-																	'upload'
-																),
-														},
-													]
-												: []),
-											...(createItemURL
-												? [
-														{
-															href: createItemURL,
-															label: Liferay.Language.get(
-																'add-new-item'
-															),
-															target: ACTION_ITEM_TARGETS.BLANK,
-														},
-													]
-												: []),
-										],
-									}
-								: undefined
+							fdsProps.creationMenu ?? defaultCreationMenu
 						}
 						emptyState={
 							fdsProps.emptyState ||

--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/package.json
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/package.json
@@ -1,6 +1,7 @@
 {
 	"dependencies": {
 		"@clayui/autocomplete": "^3.161.0",
+		"@clayui/badge": "^3.161.0",
 		"@clayui/button": "^3.161.0",
 		"@clayui/data-provider": "^3.161.0",
 		"@clayui/drop-down": "^3.161.0",
@@ -11,6 +12,7 @@
 		"@clayui/shared": "^3.161.0",
 		"@liferay/frontend-data-set-web": "*",
 		"@liferay/frontend-js-item-selector-web": "*",
+		"@liferay/frontend-js-react-web": "*",
 		"@liferay/object-js-components-web": "*",
 		"classnames": "2.3.1",
 		"data-engine-js-components-web": "*",

--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Attachment/Attachment.scss
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Attachment/Attachment.scss
@@ -49,6 +49,20 @@
 	@include attachment(flex, 1rem, 1rem, 0, 0, 5px, 0, 5px);
 }
 
+.lfr-objects__cms-drag-overlay {
+	align-items: center;
+	background: rgba(var(--primary-rgb, 11, 95, 255), 0.06);
+	border: 2px dashed var(--primary, #0b5fff);
+	bottom: 0;
+	display: flex;
+	justify-content: center;
+	left: 0;
+	position: absolute;
+	right: 0;
+	top: 0;
+	z-index: 10;
+}
+
 .col-ddm .col-md-4 {
 	.lfr-objects__attachment {
 		@include attachment(block, 1rem, 0.2rem, 1rem, 5px, 0, 0.3rem, 0.5rem);

--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Attachment/AttachmentBase.tsx
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Attachment/AttachmentBase.tsx
@@ -4,16 +4,17 @@
  */
 
 import ClayButton from '@clayui/button';
-import {useModal} from '@clayui/modal';
+import ClayModal, {useModal} from '@clayui/modal';
 import {
 	convertToFormData,
 	makeFetch,
 	useConfig,
 } from 'data-engine-js-components-web';
 import {openSelectionModal} from 'frontend-js-components-web';
-import {fetch} from 'frontend-js-web';
+import {fetch, getFileAsBase64} from 'frontend-js-web';
 import React, {ChangeEventHandler, useEffect, useRef, useState} from 'react';
 
+import CMSUploadModal, {Space} from './CMSFilesUploadModal';
 import FileContainer from './FileContainer';
 import CMSFilesItemSelectorModal, {
 	CMSFile,
@@ -61,10 +62,6 @@ type FolderRef =
 	| {objectEntryFolderExternalReferenceCode: string}
 	| {objectEntryFolderId: number};
 
-interface Space {
-	externalReferenceCode: string;
-}
-
 export interface AttachmentBaseProps<TValue> {
 	acceptedFileExtensions: string;
 	attachment: AttachmentFile | null;
@@ -82,23 +79,6 @@ export interface AttachmentBaseProps<TValue> {
 	url: string;
 	value: TValue;
 }
-
-const getBase64 = (file: File): Promise<string> =>
-	new Promise((resolve, reject) => {
-		const reader = new FileReader();
-
-		reader.onload = () => {
-			if (typeof reader.result === 'string') {
-				resolve(reader.result.split(',')[1]);
-			}
-			else {
-				reject(new Error('Invalid FileReader result'));
-			}
-		};
-
-		reader.onerror = reject;
-		reader.readAsDataURL(file);
-	});
 
 export default function AttachmentBase({
 	acceptedFileExtensions,
@@ -119,13 +99,23 @@ export default function AttachmentBase({
 	const inputRef = useRef<HTMLInputElement>(null);
 
 	const [cmsFiles, setCMSFiles] = useState<CMSFile[]>([]);
+	const [filesToUpload, setFilesToUpload] = useState<File[]>([]);
 	const [isLoading, setLoading] = useState(false);
+	const [preserveStateOnNextOpen, setPreserveStateOnNextOpen] =
+		useState(false);
+	const [refreshCounter, setRefreshCounter] = useState(0);
 	const [spaces, setSpaces] = useState<Space[]>([]);
 
 	const {
 		observer: spaceItemSelectorObserver,
-		onOpenChange: spaceItemSelectorOpenChange,
+		onOpenChange: onSpaceItemSelectorOpenChange,
 		open: spaceItemSelectorOpen,
+	} = useModal();
+
+	const {
+		observer: uploadModalObserver,
+		onOpenChange: onUploadModalOpenChange,
+		open: uploadModalOpen,
 	} = useModal();
 
 	const DEFAULT_FOLDER_ERC = 'L_FILES';
@@ -144,6 +134,28 @@ export default function AttachmentBase({
 
 	const hasLibraryStorage =
 		isUserComputerToCMSBasicDocument || isUserComputerToDocumentsAndMedia;
+
+	/**
+	 * This ref is used for the cleanup effect so that it only runs when the modal actually closes,
+	 * and prevents it from running on the initial render.
+	 */
+	const uploadModalWasOpenRef = useRef(false);
+
+	const handleCloseUploadModal = () => {
+		onUploadModalOpenChange(false);
+	};
+
+	const handleOpenUploadModal = (files?: File[]) => {
+		setFilesToUpload(files ?? []);
+		setPreserveStateOnNextOpen(true);
+
+		onUploadModalOpenChange(true);
+		onSpaceItemSelectorOpenChange(false);
+	};
+
+	const handleUploadSuccess = () => {
+		setRefreshCounter((prev) => prev + 1);
+	};
 
 	const handleCMSItemsChange = (items: CMSFile[]) => {
 		setCMSFiles(items);
@@ -206,6 +218,23 @@ export default function AttachmentBase({
 				setSpaces(data.items ?? []);
 			});
 	}, []);
+
+	useEffect(() => {
+		if (!attachment) {
+			setCMSFiles([]);
+		}
+	}, [attachment]);
+
+	useEffect(() => {
+		if (uploadModalOpen) {
+			uploadModalWasOpenRef.current = true;
+		}
+		else if (uploadModalWasOpenRef.current) {
+			uploadModalWasOpenRef.current = false;
+			setFilesToUpload([]);
+			onSpaceItemSelectorOpenChange(true);
+		}
+	}, [uploadModalOpen, onSpaceItemSelectorOpenChange]);
 
 	const findOrCreateFolder = async (
 		folderName: string,
@@ -322,7 +351,7 @@ export default function AttachmentBase({
 			);
 		}
 
-		const fileBase64 = await getBase64(file);
+		const fileBase64 = await getFileAsBase64(file);
 
 		const isVisible = !!storageDepotGroup;
 
@@ -475,7 +504,7 @@ export default function AttachmentBase({
 								}
 							}
 							else if (isCMSBasicDocument) {
-								spaceItemSelectorOpenChange(true);
+								onSpaceItemSelectorOpenChange(true);
 							}
 						}}
 					>
@@ -496,9 +525,26 @@ export default function AttachmentBase({
 					items={cmsFiles}
 					observer={spaceItemSelectorObserver}
 					onItemsChange={handleCMSItemsChange}
-					onOpenChange={spaceItemSelectorOpenChange}
+					onOpenChange={onSpaceItemSelectorOpenChange}
+					onOpenUploadModal={handleOpenUploadModal}
+					onPreserveStateConsumed={() =>
+						setPreserveStateOnNextOpen(false)
+					}
 					open={spaceItemSelectorOpen}
+					preserveStateOnOpen={preserveStateOnNextOpen}
+					refreshCounter={refreshCounter}
 				/>
+			)}
+
+			{uploadModalOpen && (
+				<ClayModal observer={uploadModalObserver} size="lg">
+					<CMSUploadModal
+						initialFiles={filesToUpload}
+						onModalClose={handleCloseUploadModal}
+						onUploadSuccess={handleUploadSuccess}
+						spaces={spaces}
+					/>
+				</ClayModal>
 			)}
 
 			<input

--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Attachment/CMSFilesUploadModal.tsx
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Attachment/CMSFilesUploadModal.tsx
@@ -1,0 +1,197 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {ClaySelect} from '@clayui/form';
+import ClayModal from '@clayui/modal';
+import {
+	FieldBase,
+	FileData,
+	MultipleFileUploader,
+	UploadRequestCallback,
+	openToast,
+} from 'frontend-js-components-web';
+import {fetch, getFileAsBase64, sub} from 'frontend-js-web';
+import React, {useMemo, useState} from 'react';
+
+export type Space = {
+	externalReferenceCode: string;
+	id?: string | number;
+	name?: string;
+};
+
+export default function CMSUploadModal({
+	initialFiles,
+	onModalClose,
+	onUploadSuccess,
+	spaces,
+}: {
+	initialFiles?: File[];
+	onModalClose: () => void;
+	onUploadSuccess: () => void;
+	spaces: Space[];
+}) {
+	const [spaceERC, setSpaceERC] = useState<string>('');
+	const [spaceError, setSpaceError] = useState(false);
+
+	const filesToUpload = useMemo<FileData[] | undefined>(
+		() =>
+			initialFiles?.map((file) => ({
+				file,
+				name: file.name,
+				size: file.size,
+			})),
+		[initialFiles]
+	);
+
+	const isValidSpace = (value: string) =>
+		spaces.some((space) => space.externalReferenceCode === value);
+
+	const formValidation = async () => {
+		const isValid = isValidSpace(spaceERC);
+
+		setSpaceError(!isValid);
+
+		return isValid;
+	};
+
+	const uploadRequest: UploadRequestCallback = async ({fileData}) => {
+		if (!isValidSpace(spaceERC)) {
+			setSpaceError(true);
+
+			throw new Error(Liferay.Language.get('space-is-required'));
+		}
+
+		const fileBase64 = await getFileAsBase64(fileData.file);
+
+		const response = await fetch(
+			`/o/cms/basic-documents/scopes/${spaceERC}`,
+			{
+				body: JSON.stringify({
+					file: {
+						fileBase64,
+						name: fileData.name,
+					},
+					objectEntryFolderExternalReferenceCode: 'L_FILES',
+					title: fileData.name,
+				}),
+				headers: {
+					'Accept': 'application/json',
+					'Content-Type': 'application/json',
+				},
+				method: 'POST',
+			}
+		);
+
+		if (!response.ok) {
+			throw new Error('Upload failed');
+		}
+
+		return response.json();
+	};
+
+	const selectedSpace = spaces.find(
+		(space) => space.externalReferenceCode === spaceERC
+	);
+
+	const onUploadComplete = ({
+		failedFiles,
+		successFiles,
+	}: {
+		failedFiles: string[];
+		successFiles: string[];
+	}) => {
+		if (successFiles.length && selectedSpace) {
+			onUploadSuccess();
+
+			const toastMessage =
+				successFiles.length === 1
+					? sub(
+							Liferay.Language.get(
+								'x-file-was-successfully-uploaded-to-x-space'
+							),
+							['1', selectedSpace.name]
+						)
+					: sub(
+							Liferay.Language.get(
+								'x-files-were-successfully-uploaded-to-x-space'
+							),
+							[String(successFiles.length), selectedSpace.name]
+						);
+
+			openToast({
+				message: toastMessage,
+				type: 'success',
+			});
+		}
+
+		if (!failedFiles.length) {
+			onModalClose();
+		}
+	};
+
+	return (
+		<>
+			<ClayModal.Header
+				closeButtonAriaLabel={Liferay.Language.get('close')}
+			>
+				{Liferay.Language.get('upload-files')}
+			</ClayModal.Header>
+
+			<MultipleFileUploader
+				filesToUpload={filesToUpload}
+				formValidation={formValidation}
+				onModalClose={onModalClose}
+				onUploadComplete={onUploadComplete}
+				scopeSelectorElement={
+					spaces.length ? (
+						<FieldBase
+							errorMessage={
+								spaceError
+									? Liferay.Language.get(
+											'this-field-is-required'
+										)
+									: undefined
+							}
+							helpMessage={Liferay.Language.get(
+								'select-the-space-to-upload-the-file'
+							)}
+							id="spaceSelect"
+							label={Liferay.Language.get('space')}
+							required
+						>
+							<ClaySelect
+								id="spaceSelect"
+								onChange={(event) => {
+									setSpaceError(false);
+									setSpaceERC(event.target.value);
+								}}
+								value={spaceERC}
+							>
+								<ClaySelect.Option
+									aria-label={Liferay.Language.get(
+										'select-a-space'
+									)}
+									label={Liferay.Language.get(
+										'select-a-space'
+									)}
+									value=""
+								/>
+
+								{spaces.map((space) => (
+									<ClaySelect.Option
+										key={space.externalReferenceCode}
+										label={space.name}
+										value={space.externalReferenceCode}
+									/>
+								))}
+							</ClaySelect>
+						</FieldBase>
+					) : undefined
+				}
+				uploadRequest={uploadRequest}
+			/>
+		</>
+	);
+}

--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Attachment/util/CMSFilesItemSelectorModal.tsx
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Attachment/util/CMSFilesItemSelectorModal.tsx
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import Badge from '@clayui/badge';
 import ClayButton from '@clayui/button';
 import {IView} from '@liferay/frontend-data-set-web';
 import {
@@ -11,13 +12,15 @@ import {
 	getCMSItemSelectorFilters,
 	getCMSItemSelectorGroupedFilters,
 } from '@liferay/frontend-js-item-selector-web';
-import React, {useState} from 'react';
+import {ReactPortal} from '@liferay/frontend-js-react-web';
+import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {v4 as uuidv4} from 'uuid';
 
 const BASE_SEARCH_PARAMS = {
 	currentURL: '/web/cms/files',
 	emptySearch: 'true',
-	nestedFields: 'description,embedded,file.thumbnailURL',
+	nestedFields:
+		'description,embedded,file.thumbnailURL,file.mimeType,file.name',
 };
 
 const OBJECT_ENTRY_FOLDER_CLASS_NAME =
@@ -25,10 +28,43 @@ const OBJECT_ENTRY_FOLDER_CLASS_NAME =
 
 const ROOT_URL = `${window.location.origin}${Liferay.ThemeDisplay.getPathContext()}/o/search/v1.0/search`;
 
-const CMS_ROOT_FILES_URL = `${ROOT_URL}?${new URLSearchParams({
-	...BASE_SEARCH_PARAMS,
-	filter: "cmsRoot eq true and cmsSection eq 'files' and status in (0)",
-}).toString()}`;
+const SPACES_API_URL = '/o/headless-asset-library/v1.0/asset-libraries';
+
+const SPACE_STYLE: Record<string, {backgroundColor: string; color: string}> = {
+	'outline-0': {backgroundColor: '#f1f2f5', color: '#272833'},
+	'outline-1': {backgroundColor: '#f2e5ff', color: '#aa33ff'},
+	'outline-2': {backgroundColor: '#fff8e5', color: '#b38900'},
+	'outline-3': {backgroundColor: '#f1fce9', color: '#458613'},
+	'outline-4': {backgroundColor: '#ffe5e5', color: '#e60000'},
+	'outline-5': {backgroundColor: '#fff0e5', color: '#cc4e00'},
+	'outline-6': {backgroundColor: '#eafbf8', color: '#1b7e6e'},
+	'outline-7': {backgroundColor: '#e5f6ff', color: '#0077b3'},
+	'outline-8': {backgroundColor: '#ffe5f4', color: '#e50082'},
+	'outline-9': {backgroundColor: '#fff', color: '#393a4a'},
+};
+
+function getSpaceAvatarSrc(letter: string, displayType: string) {
+	const {backgroundColor = '', color = ''} = SPACE_STYLE[displayType] ?? {};
+
+	const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 200"><rect width="300" height="200" fill="#ffffff"/><rect x="125" y="75" rx="6" ry="6" width="50" height="50" fill="${backgroundColor}" stroke="${color}" stroke-width="1"/><text x="150" y="100" dy=".35em" text-anchor="middle" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="26" font-weight="700" fill="${color}">${letter}</text></svg>`;
+
+	return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`;
+}
+
+const getSpaceId = (item: any) => {
+	return item.siteId || item.groupId || item.group?.id || item.id;
+};
+
+function getSpaceRootFilesURL(groupId: string) {
+	if (!groupId || groupId === 'undefined') {
+		return '';
+	}
+
+	return `${ROOT_URL}?${new URLSearchParams({
+		...BASE_SEARCH_PARAMS,
+		filter: `cmsRoot eq true and cmsSection eq 'files' and status in (0) and scopeGroupId eq ${groupId}`,
+	}).toString()}`;
+}
 
 function getCMSChildFolderURL(folderId: string) {
 	return `${ROOT_URL}?${new URLSearchParams({
@@ -55,203 +91,479 @@ export type CMSFile = {
 	title: string;
 };
 
+type Space = {
+	id: string;
+	name: string;
+};
+
 function CMSFilesItemSelectorModal({
 	fdsProps,
+	items,
+	onOpenUploadModal,
+	onPreserveStateConsumed,
+	open,
+	preserveStateOnOpen = false,
+	refreshCounter = 0,
 	...otherProps
 }: Omit<
 	IItemSelectorModalProps<CMSFile>,
 	'itemTypeLabel' | 'fdsProps' | 'apiURL'
 > & {
-	fdsProps?: IItemSelectorModalProps<CMSFile>['fdsProps'];
+	fdsProps?: IItemSelectorModalProps<any>['fdsProps'];
+	onOpenUploadModal?: (files?: File[]) => void;
+	onPreserveStateConsumed?: () => void;
+	preserveStateOnOpen?: boolean;
+	refreshCounter?: number;
 }) {
+	const wasOpenRef = useRef(open);
+
+	const [dragCoordinates, setDragCoordinates] = useState({x: 0, y: 0});
 	const [folderStructure, setFolderStructure] = useState<
 		{folderId: string; folderName: string}[]
 	>([]);
-	const [url, setURL] = useState(CMS_ROOT_FILES_URL);
+	const [isDraggingOver, setIsDraggingOver] = useState(false);
+	const [selectedSpace, setSelectedSpace] = useState<Space | null>(null);
+	const [url, setURL] = useState(SPACES_API_URL);
 
-	function onChildFolderClick({
-		folderId,
-		folderName,
-	}: {
-		folderId: string;
-		folderName: string;
-	}) {
-		setFolderStructure((prevStructure) => [
-			...prevStructure,
-			{folderId, folderName},
-		]);
+	const isSpaceMode = !selectedSpace;
 
-		setURL(getCMSChildFolderURL(folderId));
-	}
+	const modalId = useMemo(
+		() =>
+			`itemSelectorModal-cms-${isSpaceMode ? 'space' : 'files'}-${refreshCounter}-${uuidv4()}`,
+		[isSpaceMode, refreshCounter]
+	);
 
-	return (
-		<ItemSelectorModal
-			{...otherProps}
-			apiURL={url}
-			breadcrumbs={
-				folderStructure.length
-					? [
-							{
-								label: Liferay.Language.get('default'),
-								onClick: () => {
-									setFolderStructure([]);
-									setURL(CMS_ROOT_FILES_URL);
-								},
-							},
-							...folderStructure.map(
-								({folderId, folderName}, index) => ({
-									label: folderName,
-									onClick: () => {
-										setFolderStructure(
-											(prevFolderStructure) =>
-												prevFolderStructure.slice(
-													0,
-													index + 1
-												)
-										);
+	useEffect(() => {
+		const wasOpen = wasOpenRef.current;
 
-										setURL(getCMSChildFolderURL(folderId));
-									},
-								})
-							),
-						]
-					: undefined
+		wasOpenRef.current = open;
+
+		if (!open || wasOpen) {
+			return;
+		}
+
+		if (preserveStateOnOpen) {
+			onPreserveStateConsumed?.();
+
+			return;
+		}
+
+		if (!items.length) {
+			setSelectedSpace(null);
+			setFolderStructure([]);
+			setURL(SPACES_API_URL);
+		}
+	}, [open, items, preserveStateOnOpen, onPreserveStateConsumed]);
+
+	useEffect(() => {
+		if (!open || !selectedSpace) {
+			setIsDraggingOver(false);
+
+			return;
+		}
+
+		const handleDragEnter = (event: DragEvent) => {
+			if (!event.dataTransfer?.types.includes('Files')) {
+				return;
 			}
-			fdsProps={{
-				...fdsProps,
-				customRenderers: {
-					tableCell: [
-						{
-							component: ({itemData, value}) => {
-								const {embedded, entryClassName} = itemData;
 
-								return entryClassName ===
-									OBJECT_ENTRY_FOLDER_CLASS_NAME ? (
-									<ClayButton
-										className="c-p-0"
-										displayType="link"
-										onClick={() =>
-											onChildFolderClick({
-												folderId: String(embedded.id),
-												folderName: embedded.title,
-											})
-										}
-									>
-										{value}
-									</ClayButton>
-								) : (
-									value
-								);
-							},
-							name: 'cmsFilesTitleCellRenderer',
-							type: 'internal',
-						},
-					],
+			setIsDraggingOver(true);
+		};
+
+		const handleDragEnd = () => {
+			setIsDraggingOver(false);
+		};
+
+		const handleDragLeave = (event: DragEvent) => {
+			if (event.relatedTarget !== null) {
+				return;
+			}
+
+			setIsDraggingOver(false);
+		};
+
+		document.addEventListener('dragend', handleDragEnd, true);
+		document.addEventListener('dragenter', handleDragEnter, true);
+		document.addEventListener('dragleave', handleDragLeave, true);
+
+		return () => {
+			document.removeEventListener('dragend', handleDragEnd, true);
+			document.removeEventListener('dragenter', handleDragEnter, true);
+			document.removeEventListener('dragleave', handleDragLeave, true);
+		};
+	}, [open, selectedSpace]);
+
+	const onChildFolderClick = useCallback(
+		({folderId, folderName}: {folderId: string; folderName: string}) => {
+			setFolderStructure((prevStructure) => [
+				...prevStructure,
+				{folderId, folderName},
+			]);
+
+			setURL(getCMSChildFolderURL(folderId));
+		},
+		[]
+	);
+
+	const onResetToSpaces = useCallback(() => {
+		setSelectedSpace(null);
+		setFolderStructure([]);
+		setURL(SPACES_API_URL);
+	}, []);
+
+	const onSpaceClick = useCallback((space: Space) => {
+		setSelectedSpace(space);
+		setURL(getSpaceRootFilesURL(space.id));
+		setFolderStructure([]);
+	}, []);
+
+	const breadcrumbs = useMemo(() => {
+		if (!selectedSpace) {
+			return undefined;
+		}
+
+		const crumbs: Array<{
+			active?: boolean;
+			label: string;
+			onClick?: () => void;
+		}> = [
+			{
+				label: Liferay.Language.get('spaces'),
+				onClick: onResetToSpaces,
+			},
+		];
+
+		if (folderStructure.length) {
+			crumbs.push({
+				label: selectedSpace.name,
+				onClick: () => {
+					setURL(getSpaceRootFilesURL(selectedSpace.id));
+					setFolderStructure([]);
 				},
-				filters: getCMSItemSelectorFilters(
-					Liferay.ThemeDisplay.getSiteGroupId()
-				),
-				groupedFilters: getCMSItemSelectorGroupedFilters(),
-				id: `itemSelectorModal-cms-${uuidv4()}`,
-				views: [
-					{
-						contentRenderer: 'cards',
-						label: Liferay.Language.get('cards'),
-						name: 'cards',
-						schema: {
-							description: 'embedded.description',
-							image: 'embedded.file.thumbnailURL',
-							title: 'embedded.title',
+			});
+		}
+		else {
+			crumbs.push({
+				active: true,
+				label: selectedSpace.name,
+			});
+		}
+
+		folderStructure.forEach(({folderId, folderName}, index) => {
+			const isLast = index === folderStructure.length - 1;
+
+			crumbs.push({
+				active: isLast,
+				label: folderName,
+				onClick: isLast
+					? undefined
+					: () => {
+							setFolderStructure((prev) =>
+								prev.slice(0, index + 1)
+							);
+							setURL(getCMSChildFolderURL(folderId));
 						},
-						setItemComponentProps: ({
-							item,
-							props,
-						}: {
-							item: CMSFile;
-							props: Record<string, unknown>;
-						}) => {
-							if (
-								item.entryClassName ===
-								OBJECT_ENTRY_FOLDER_CLASS_NAME
-							) {
-								return {
-									...props,
-									onClick: () =>
-										onChildFolderClick({
-											folderId: String(item.embedded.id),
-											folderName: item.embedded.title,
-										}),
-									onSelectChange: null,
-									symbol: 'folder',
+			});
+		});
+
+		return crumbs;
+	}, [folderStructure, onResetToSpaces, selectedSpace]);
+
+	const currentViews = useMemo(
+		() =>
+			(!selectedSpace
+				? [
+						{
+							contentRenderer: 'cards',
+							label: Liferay.Language.get('cards'),
+							name: 'cards',
+							schema: {
+								description: 'description',
+								title: 'name',
+							},
+							setItemComponentProps: ({item, props}: any) => ({
+								...props,
+								imgProps: {
+									alt: item.name,
+									src: getSpaceAvatarSrc(
+										item.name?.charAt(0).toUpperCase(),
+										item.settings?.logoColor
+									),
+									style: {
+										backgroundColor: '#fff',
+										height: '100%',
+										maxHeight: 'none',
+										maxWidth: 'none',
+										width: '100%',
+									},
+								},
+								onClick: () => {
+									onSpaceClick({
+										id: getSpaceId(item),
+										name: item.name,
+									});
+								},
+								onSelectChange: null,
+							}),
+							thumbnail: 'cards2',
+						},
+					]
+				: [
+						{
+							contentRenderer: 'cards',
+							label: Liferay.Language.get('cards'),
+							name: 'cards',
+							schema: {
+								description: 'embedded.description',
+								image: 'embedded.file.thumbnailURL',
+								title: 'embedded.title',
+							},
+							setItemComponentProps: ({
+								item,
+								props,
+							}: {
+								item: any;
+								props: any;
+							}) => {
+								if (
+									item.entryClassName ===
+									OBJECT_ENTRY_FOLDER_CLASS_NAME
+								) {
+									return {
+										...props,
+										onClick: () => {
+											onChildFolderClick({
+												folderId: item.embedded.id,
+												folderName: item.embedded.title,
+											});
+										},
+										onSelectChange: null,
+										symbol: 'folder',
+									};
+								}
+
+								const stickerProps = {
+									className: 'file-icon-color-5',
+									displayType: 'unstyled',
 								};
-							}
 
-							const stickerProps = {
-								className: 'file-icon-color-5',
-								displayType: 'unstyled',
-							};
+								if (
+									!item.embedded?.file?.mimeType?.startsWith(
+										'image'
+									)
+								) {
+									return {
+										...props,
+										imgProps: null,
+										stickerProps,
+									};
+								}
 
-							if (
-								!item.embedded?.file?.mimeType?.startsWith(
-									'image'
-								)
-							) {
 								return {
 									...props,
-									imgProps: null,
 									stickerProps,
 								};
-							}
+							},
+							thumbnail: 'cards2',
+						},
+						{
+							contentRenderer: 'table',
+							label: Liferay.Language.get('table'),
+							name: 'table',
+							schema: {
+								fields: [
+									{
+										contentRenderer:
+											'cmsFilesTitleCellRenderer',
+										fieldName: 'embedded.title',
+										label: Liferay.Language.get('title'),
+										sortable: false,
+									},
+									{
+										fieldName: 'embedded.description',
+										label: Liferay.Language.get(
+											'description'
+										),
+										sortable: false,
+									},
+									{
+										fieldName: 'embedded.file.name',
+										label: Liferay.Language.get(
+											'file-name'
+										),
+										sortable: false,
+									},
+									{
+										fieldName: 'embedded.file.mimeType',
+										label: Liferay.Language.get('type'),
+										sortable: false,
+									},
+								],
+							},
+							thumbnail: 'table',
+						},
+					]) as IView[],
+		[onChildFolderClick, onSpaceClick, selectedSpace]
+	);
 
-							return {
-								...props,
-								stickerProps,
-							};
-						},
-						thumbnail: 'cards2',
+	const modalBodyElement = isDraggingOver
+		? document.querySelector('.modal-body')
+		: null;
+
+	return (
+		<>
+			<ItemSelectorModal
+				{...otherProps}
+				apiURL={url}
+				breadcrumbs={breadcrumbs}
+				fdsProps={{
+					pagination: {
+						deltas: [{label: 20}, {label: 40}, {label: 60}],
+						initialDelta: 20,
 					},
-					{
-						contentRenderer: 'table',
-						label: Liferay.Language.get('table'),
-						name: 'table',
-						schema: {
-							fields: [
-								{
-									contentRenderer:
-										'cmsFilesTitleCellRenderer',
-									fieldName: 'embedded.title',
-									label: Liferay.Language.get('title'),
-									sortable: false,
+					...fdsProps,
+					creationMenu: onOpenUploadModal
+						? {
+								primaryItems: [
+									{
+										label: Liferay.Language.get(
+											'upload-files'
+										),
+										onClick: () => onOpenUploadModal(),
+									},
+								],
+							}
+						: undefined,
+					customRenderers: {
+						tableCell: [
+							{
+								component: ({itemData, value}) => {
+									if (selectedSpace) {
+										const {embedded, entryClassName} =
+											itemData;
+
+										return entryClassName ===
+											OBJECT_ENTRY_FOLDER_CLASS_NAME ? (
+											<ClayButton
+												className="c-p-0"
+												displayType="link"
+												onClick={() => {
+													onChildFolderClick({
+														folderId: embedded.id,
+														folderName:
+															embedded.title,
+													});
+												}}
+											>
+												{value}
+											</ClayButton>
+										) : (
+											value
+										);
+									}
+
+									return (
+										<ClayButton
+											className="c-p-0"
+											displayType="link"
+											onClick={() => {
+												onSpaceClick({
+													id: getSpaceId(itemData),
+													name: itemData.name,
+												});
+											}}
+										>
+											{value}
+										</ClayButton>
+									);
 								},
-								{
-									fieldName: 'embedded.description',
-									label: Liferay.Language.get('description'),
-									sortable: false,
-								},
-								{
-									fieldName: 'embedded.file.name',
-									label: Liferay.Language.get('file-name'),
-									sortable: false,
-								},
-								{
-									fieldName: 'embedded.file.mimeType',
-									label: Liferay.Language.get('type'),
-									sortable: false,
-								},
-							],
-						},
-						thumbnail: 'table',
+								name: 'cmsFilesTitleCellRenderer',
+								type: 'internal',
+							},
+						],
 					},
-				] as IView[],
-			}}
-			itemTypeLabel={Liferay.Language.get('files')}
-			locator={{
-				id: 'embedded.id',
-				label: 'embedded.title',
-				value: 'embedded.id',
-			}}
-			multiSelect={false}
-		/>
+					emptyState: {
+						description: Liferay.Language.get(
+							'drag-and-drop-your-files-or'
+						),
+					},
+					...(selectedSpace
+						? {
+								filters: getCMSItemSelectorFilters(
+									Liferay.ThemeDisplay.getSiteGroupId()
+								),
+								groupedFilters:
+									getCMSItemSelectorGroupedFilters(),
+							}
+						: {}),
+					id: modalId,
+					views: currentViews,
+				}}
+				itemTypeLabel={Liferay.Language.get(
+					selectedSpace ? 'files' : 'space'
+				)}
+				items={items}
+				key={modalId}
+				locator={{
+					id: selectedSpace ? 'embedded.id' : 'id',
+					label: selectedSpace ? 'embedded.title' : 'name',
+					value: selectedSpace ? 'embedded.id' : 'id',
+				}}
+				multiSelect={false}
+				open={open}
+			/>
+
+			{isDraggingOver && modalBodyElement && (
+				<ReactPortal container={modalBodyElement} wrapper={false}>
+					<div
+						className="lfr-objects__cms-drag-overlay"
+						onDragEnd={() => setIsDraggingOver(false)}
+						onDragOver={(event) => {
+							event.preventDefault();
+							setDragCoordinates({
+								x: event.clientX,
+								y: event.clientY,
+							});
+						}}
+						onDrop={(event) => {
+							event.preventDefault();
+							setIsDraggingOver(false);
+
+							const files = event.dataTransfer?.files
+								? Array.from(event.dataTransfer.files)
+								: [];
+
+							if (files[0]) {
+								onOpenUploadModal?.(files);
+							}
+						}}
+					>
+						<div
+							className="fds-file-drag-layer"
+							id={`${modalId}-fds-file-drag-layer`}
+						>
+							<div
+								style={{
+									left: 0,
+									pointerEvents: 'none',
+									position: 'fixed',
+									top: 0,
+									transform: `translate(${dragCoordinates.x + 60}px, ${dragCoordinates.y + 80}px)`,
+									zIndex: 9999,
+								}}
+							>
+								<Badge
+									displayType="primary"
+									label={Liferay.Language.get(
+										'drop-files-here-to-upload'
+									)}
+								/>
+							</div>
+						</div>
+					</div>
+				</ReactPortal>
+			)}
+		</>
 	);
 }
 

--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Attachment/util/CMSFilesItemSelectorModal.tsx
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Attachment/util/CMSFilesItemSelectorModal.tsx
@@ -16,6 +16,8 @@ import {ReactPortal} from '@liferay/frontend-js-react-web';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {v4 as uuidv4} from 'uuid';
 
+import {getSpaceAvatarSrc} from './getSpaceAvatarSrc';
+
 const BASE_SEARCH_PARAMS = {
 	currentURL: '/web/cms/files',
 	emptySearch: 'true',
@@ -29,27 +31,6 @@ const OBJECT_ENTRY_FOLDER_CLASS_NAME =
 const ROOT_URL = `${window.location.origin}${Liferay.ThemeDisplay.getPathContext()}/o/search/v1.0/search`;
 
 const SPACES_API_URL = '/o/headless-asset-library/v1.0/asset-libraries';
-
-const SPACE_STYLE: Record<string, {backgroundColor: string; color: string}> = {
-	'outline-0': {backgroundColor: '#f1f2f5', color: '#272833'},
-	'outline-1': {backgroundColor: '#f2e5ff', color: '#aa33ff'},
-	'outline-2': {backgroundColor: '#fff8e5', color: '#b38900'},
-	'outline-3': {backgroundColor: '#f1fce9', color: '#458613'},
-	'outline-4': {backgroundColor: '#ffe5e5', color: '#e60000'},
-	'outline-5': {backgroundColor: '#fff0e5', color: '#cc4e00'},
-	'outline-6': {backgroundColor: '#eafbf8', color: '#1b7e6e'},
-	'outline-7': {backgroundColor: '#e5f6ff', color: '#0077b3'},
-	'outline-8': {backgroundColor: '#ffe5f4', color: '#e50082'},
-	'outline-9': {backgroundColor: '#fff', color: '#393a4a'},
-};
-
-function getSpaceAvatarSrc(letter: string, displayType: string) {
-	const {backgroundColor = '', color = ''} = SPACE_STYLE[displayType] ?? {};
-
-	const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 200"><rect width="300" height="200" fill="#ffffff"/><rect x="125" y="75" rx="6" ry="6" width="50" height="50" fill="${backgroundColor}" stroke="${color}" stroke-width="1"/><text x="150" y="100" dy=".35em" text-anchor="middle" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="26" font-weight="700" fill="${color}">${letter}</text></svg>`;
-
-	return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`;
-}
 
 const getSpaceId = (item: any) => {
 	return item.siteId || item.groupId || item.group?.id || item.id;
@@ -283,19 +264,15 @@ function CMSFilesItemSelectorModal({
 							},
 							setItemComponentProps: ({item, props}: any) => ({
 								...props,
+								flushHorizontal: true,
+								flushVertical: true,
 								imgProps: {
 									alt: item.name,
 									src: getSpaceAvatarSrc(
-										item.name?.charAt(0).toUpperCase(),
-										item.settings?.logoColor
+										item.name?.charAt(0).toUpperCase() ??
+											'',
+										item.settings?.logoColor || 'outline-0'
 									),
-									style: {
-										backgroundColor: '#fff',
-										height: '100%',
-										maxHeight: 'none',
-										maxWidth: 'none',
-										width: '100%',
-									},
 								},
 								onClick: () => {
 									onSpaceClick({

--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Attachment/util/getSpaceAvatarSrc.ts
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Attachment/util/getSpaceAvatarSrc.ts
@@ -1,0 +1,24 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+/**
+ * Utility function for generating a data-URI space avatar matching Clay's
+ * `sticker-outline-N` palette
+ */
+export function getSpaceAvatarSrc(letter: string, displayType: string) {
+	const probe = document.createElement('span');
+
+	probe.className = `sticker sticker-${displayType}`;
+
+	document.body.appendChild(probe);
+
+	const {backgroundColor, color} = getComputedStyle(probe);
+
+	probe.remove();
+
+	const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 200" preserveAspectRatio="xMidYMid slice"><rect width="300" height="200" fill="#ffffff"/><rect x="125" y="75" rx="6" ry="6" width="50" height="50" fill="${backgroundColor}" stroke="${color}" stroke-width="0.5"/><text x="150" y="100" dy=".35em" text-anchor="middle" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif" font-size="26" font-weight="700" fill="${color}">${letter}</text></svg>`;
+
+	return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`;
+}

--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/tests/Attachment/CMSFilesItemSelectorModal.spec.tsx
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/tests/Attachment/CMSFilesItemSelectorModal.spec.tsx
@@ -1,0 +1,362 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import '@testing-library/jest-dom';
+import {act, fireEvent, render, screen} from '@testing-library/react';
+import React from 'react';
+
+import CMSFilesItemSelectorModal, {
+	CMSFile,
+} from '../../js/Attachment/util/CMSFilesItemSelectorModal';
+
+const SPACES_API_URL = '/o/headless-asset-library/v1.0/asset-libraries';
+
+let lastItemSelectorProps: any = null;
+
+jest.mock('@liferay/frontend-js-item-selector-web', () => ({
+	ItemSelectorModal: (props: any) => {
+		lastItemSelectorProps = props;
+
+		if (!props.open) {
+			return null;
+		}
+
+		return (
+			<div data-testid="item-selector">
+				<span data-testid="api-url">{props.apiURL}</span>
+
+				{props.breadcrumbs && (
+					<nav data-testid="breadcrumbs">
+						{props.breadcrumbs.map((crumb: any, i: number) => (
+							<button
+								data-testid={`breadcrumb-${i}`}
+								key={i}
+								onClick={crumb.onClick}
+							>
+								{crumb.label}
+							</button>
+						))}
+					</nav>
+				)}
+
+				<button
+					data-testid="simulate-space-click"
+					onClick={() => {
+						const spaceItem = {
+							id: '42',
+							name: 'Space A',
+							siteId: '42',
+						};
+						const view = props.fdsProps?.views?.[0];
+						const itemProps = view?.setItemComponentProps?.({
+							item: spaceItem,
+							props: {},
+						});
+
+						itemProps?.onClick?.();
+					}}
+				>
+					Click Space
+				</button>
+			</div>
+		);
+	},
+	getCMSItemSelectorFilters: jest.fn().mockReturnValue([]),
+	getCMSItemSelectorGroupedFilters: jest.fn().mockReturnValue([]),
+}));
+
+jest.mock('@liferay/frontend-js-react-web', () => ({
+	ReactPortal: ({children}: {children: React.ReactNode}) => (
+		<div>{children}</div>
+	),
+}));
+
+jest.mock('uuid', () => ({v4: () => 'test-uuid'}));
+
+(globalThis as any).Liferay = {
+	Language: {
+		get: (key: string) => key,
+	},
+	ThemeDisplay: {
+		getPathContext: () => '',
+		getSiteGroupId: () => '12345',
+	},
+};
+
+const mockFile: CMSFile = {
+	embedded: {
+		file: {
+			fileURL: 'http://example.com/file.png',
+			id: 10,
+			mimeType: 'image/png',
+		},
+		id: 10,
+		title: 'file.png',
+	},
+	id: 10,
+	title: 'file.png',
+};
+
+const defaultProps = {
+	items: [] as CMSFile[],
+	observer: {},
+	onItemsChange: jest.fn(),
+	onOpenChange: jest.fn(),
+};
+
+afterEach(() => {
+	jest.clearAllMocks();
+	lastItemSelectorProps = null;
+});
+
+describe('CMSFilesItemSelectorModal — initial state', () => {
+	it('passes SPACES_API_URL when opening for the first time', () => {
+		render(<CMSFilesItemSelectorModal {...defaultProps} open={true} />);
+
+		expect(screen.getByTestId('api-url')).toHaveTextContent(SPACES_API_URL);
+	});
+
+	it('does not render modal content when closed', () => {
+		render(<CMSFilesItemSelectorModal {...defaultProps} open={false} />);
+
+		expect(screen.queryByTestId('item-selector')).not.toBeInTheDocument();
+	});
+
+	it('shows no breadcrumbs when in space list view', () => {
+		render(<CMSFilesItemSelectorModal {...defaultProps} open={true} />);
+
+		expect(screen.queryByTestId('breadcrumbs')).not.toBeInTheDocument();
+	});
+});
+
+describe('CMSFilesItemSelectorModal — space navigation', () => {
+	it('switches to space files URL after clicking a space card', () => {
+		render(<CMSFilesItemSelectorModal {...defaultProps} open={true} />);
+
+		fireEvent.click(screen.getByTestId('simulate-space-click'));
+
+		expect(screen.getByTestId('api-url').textContent).not.toBe(
+			SPACES_API_URL
+		);
+		expect(screen.getByTestId('api-url').textContent).toContain(
+			'scopeGroupId+eq+42'
+		);
+	});
+
+	it('shows breadcrumbs after navigating into a space', () => {
+		render(<CMSFilesItemSelectorModal {...defaultProps} open={true} />);
+
+		fireEvent.click(screen.getByTestId('simulate-space-click'));
+
+		expect(screen.getByTestId('breadcrumbs')).toBeInTheDocument();
+		expect(screen.getByTestId('breadcrumb-0')).toHaveTextContent('spaces');
+		expect(screen.getByTestId('breadcrumb-1')).toHaveTextContent('Space A');
+	});
+
+	it('returns to space list when the Spaces breadcrumb is clicked', () => {
+		render(<CMSFilesItemSelectorModal {...defaultProps} open={true} />);
+
+		fireEvent.click(screen.getByTestId('simulate-space-click'));
+
+		expect(screen.getByTestId('api-url').textContent).not.toBe(
+			SPACES_API_URL
+		);
+
+		fireEvent.click(screen.getByTestId('breadcrumb-0'));
+
+		expect(screen.getByTestId('api-url')).toHaveTextContent(SPACES_API_URL);
+		expect(screen.queryByTestId('breadcrumbs')).not.toBeInTheDocument();
+	});
+});
+
+describe('CMSFilesItemSelectorModal — open/close state management', () => {
+	it('resets to space list when reopened with no selected items', () => {
+		const {rerender} = render(
+			<CMSFilesItemSelectorModal
+				{...defaultProps}
+				items={[]}
+				open={true}
+			/>
+		);
+
+		fireEvent.click(screen.getByTestId('simulate-space-click'));
+
+		expect(screen.getByTestId('api-url').textContent).not.toBe(
+			SPACES_API_URL
+		);
+
+		rerender(
+			<CMSFilesItemSelectorModal
+				{...defaultProps}
+				items={[]}
+				open={false}
+			/>
+		);
+
+		act(() => {
+			rerender(
+				<CMSFilesItemSelectorModal
+					{...defaultProps}
+					items={[]}
+					open={true}
+				/>
+			);
+		});
+
+		expect(screen.getByTestId('api-url')).toHaveTextContent(SPACES_API_URL);
+	});
+
+	it('does not reset when reopened with selected items', () => {
+		const {rerender} = render(
+			<CMSFilesItemSelectorModal
+				{...defaultProps}
+				items={[]}
+				open={true}
+			/>
+		);
+
+		fireEvent.click(screen.getByTestId('simulate-space-click'));
+
+		const urlAfterNavigation =
+			screen.getByTestId('api-url').textContent ?? '';
+
+		rerender(
+			<CMSFilesItemSelectorModal
+				{...defaultProps}
+				items={[mockFile]}
+				open={false}
+			/>
+		);
+
+		act(() => {
+			rerender(
+				<CMSFilesItemSelectorModal
+					{...defaultProps}
+					items={[mockFile]}
+					open={true}
+				/>
+			);
+		});
+
+		expect(screen.getByTestId('api-url').textContent).toBe(
+			urlAfterNavigation
+		);
+	});
+
+	it('preserves navigation state when preserveStateOnOpen is true', () => {
+		const {rerender} = render(
+			<CMSFilesItemSelectorModal
+				{...defaultProps}
+				items={[]}
+				open={true}
+			/>
+		);
+
+		fireEvent.click(screen.getByTestId('simulate-space-click'));
+
+		const urlAfterNavigation =
+			screen.getByTestId('api-url').textContent ?? '';
+
+		rerender(
+			<CMSFilesItemSelectorModal
+				{...defaultProps}
+				items={[]}
+				open={false}
+			/>
+		);
+
+		act(() => {
+			rerender(
+				<CMSFilesItemSelectorModal
+					{...defaultProps}
+					items={[]}
+					open={true}
+					preserveStateOnOpen={true}
+				/>
+			);
+		});
+
+		expect(screen.getByTestId('api-url').textContent).toBe(
+			urlAfterNavigation
+		);
+	});
+
+	it('calls onPreserveStateConsumed after preserving state', () => {
+		const onPreserveStateConsumed = jest.fn();
+
+		const {rerender} = render(
+			<CMSFilesItemSelectorModal
+				{...defaultProps}
+				items={[]}
+				open={true}
+			/>
+		);
+
+		fireEvent.click(screen.getByTestId('simulate-space-click'));
+
+		rerender(
+			<CMSFilesItemSelectorModal
+				{...defaultProps}
+				items={[]}
+				open={false}
+			/>
+		);
+
+		act(() => {
+			rerender(
+				<CMSFilesItemSelectorModal
+					{...defaultProps}
+					items={[]}
+					onPreserveStateConsumed={onPreserveStateConsumed}
+					open={true}
+					preserveStateOnOpen={true}
+				/>
+			);
+		});
+
+		expect(onPreserveStateConsumed).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe('CMSFilesItemSelectorModal — upload integration', () => {
+	it('includes Upload Files in the creation menu when onOpenUploadModal is provided', () => {
+		const onOpenUploadModal = jest.fn();
+
+		render(
+			<CMSFilesItemSelectorModal
+				{...defaultProps}
+				onOpenUploadModal={onOpenUploadModal}
+				open={true}
+			/>
+		);
+
+		expect(
+			lastItemSelectorProps?.fdsProps?.creationMenu?.primaryItems?.[0]
+				?.label
+		).toBe('upload-files');
+	});
+
+	it('does not include a creation menu when onOpenUploadModal is not provided', () => {
+		render(<CMSFilesItemSelectorModal {...defaultProps} open={true} />);
+
+		expect(lastItemSelectorProps?.fdsProps?.creationMenu).toBeUndefined();
+	});
+
+	it('calls onOpenUploadModal when the Upload Files button is triggered', () => {
+		const onOpenUploadModal = jest.fn();
+
+		render(
+			<CMSFilesItemSelectorModal
+				{...defaultProps}
+				onOpenUploadModal={onOpenUploadModal}
+				open={true}
+			/>
+		);
+
+		lastItemSelectorProps?.fdsProps?.creationMenu?.primaryItems?.[0]?.onClick?.();
+
+		expect(onOpenUploadModal).toHaveBeenCalledTimes(1);
+	});
+});

--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/tests/Attachment/CMSFilesUploadModal.spec.tsx
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/tests/Attachment/CMSFilesUploadModal.spec.tsx
@@ -1,0 +1,348 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import '@testing-library/jest-dom';
+import {fireEvent, render, screen, waitFor} from '@testing-library/react';
+import React from 'react';
+
+import CMSUploadModal from '../../js/Attachment/CMSFilesUploadModal';
+
+jest.mock('@clayui/modal', () => ({
+	__esModule: true,
+	default: {
+		Header: ({children}: {children: React.ReactNode}) => (
+			<header data-testid="modal-header">{children}</header>
+		),
+	},
+}));
+
+jest.mock('frontend-js-components-web', () => ({
+	FieldBase: ({
+		children,
+		errorMessage,
+		label,
+		required,
+	}: {
+		children: React.ReactNode;
+		errorMessage?: string;
+		label: string;
+		required?: boolean;
+	}) => (
+		<div>
+			<label htmlFor="spaceSelect">
+				{label}
+
+				{required && <span>*</span>}
+			</label>
+
+			{errorMessage && <span role="alert">{errorMessage}</span>}
+
+			{children}
+		</div>
+	),
+	MultipleFileUploader: ({
+		formValidation,
+		onModalClose,
+		onUploadComplete,
+		scopeSelectorElement,
+	}: {
+		formValidation: () => Promise<boolean>;
+		onModalClose: () => void;
+		onUploadComplete: (result: {
+			failedFiles: string[];
+			successFiles: string[];
+		}) => void;
+		scopeSelectorElement?: React.ReactNode;
+	}) => (
+		<div data-testid="multi-uploader">
+			{scopeSelectorElement}
+
+			<button data-testid="btn-validate" onClick={formValidation}>
+				validate
+			</button>
+
+			<button
+				data-testid="btn-complete-success-single"
+				onClick={() =>
+					onUploadComplete({
+						failedFiles: [],
+						successFiles: ['file.txt'],
+					})
+				}
+			>
+				complete single
+			</button>
+
+			<button
+				data-testid="btn-complete-success-multiple"
+				onClick={() =>
+					onUploadComplete({
+						failedFiles: [],
+						successFiles: ['file1.txt', 'file2.txt'],
+					})
+				}
+			>
+				complete multiple
+			</button>
+
+			<button
+				data-testid="btn-complete-with-failures"
+				onClick={() =>
+					onUploadComplete({
+						failedFiles: ['file.txt'],
+						successFiles: [],
+					})
+				}
+			>
+				complete failure
+			</button>
+
+			<button data-testid="btn-close" onClick={onModalClose}>
+				close
+			</button>
+		</div>
+	),
+	openToast: jest.fn(),
+}));
+
+jest.mock('frontend-js-web', () => ({
+	fetch: jest.fn(),
+	getFileAsBase64: jest.fn(),
+	sub: jest.fn((key: string) => key),
+}));
+
+(globalThis as any).Liferay = {
+	Language: {
+		get: (key: string) => key,
+	},
+	ThemeDisplay: {
+		getPathContext: () => '',
+		getSiteGroupId: () => '12345',
+	},
+};
+
+const mockOpenToast: jest.Mock = jest.requireMock(
+	'frontend-js-components-web'
+).openToast;
+const mockFetch: jest.Mock = jest.requireMock('frontend-js-web').fetch;
+const mockGetFileAsBase64: jest.Mock =
+	jest.requireMock('frontend-js-web').getFileAsBase64;
+const mockSub: jest.Mock = jest.requireMock('frontend-js-web').sub;
+
+const ONE_SPACE = [
+	{externalReferenceCode: 'space-erc-1', id: 1, name: 'Space One'},
+];
+
+const MULTIPLE_SPACES = [
+	{externalReferenceCode: 'space-erc-1', id: 1, name: 'Space One'},
+	{externalReferenceCode: 'space-erc-2', id: 2, name: 'Space Two'},
+];
+
+const defaultProps = {
+	onModalClose: jest.fn(),
+	onUploadSuccess: jest.fn(),
+};
+
+beforeEach(() => {
+	mockFetch.mockResolvedValue({
+		json: jest.fn().mockResolvedValue({id: 1}),
+		ok: true,
+	});
+	mockGetFileAsBase64.mockResolvedValue('base64data==');
+});
+
+afterEach(() => {
+	jest.clearAllMocks();
+});
+
+describe('CMSFilesUploadModal — space selector rendering', () => {
+	it('does not render space selector when spaces array is empty', () => {
+		render(<CMSUploadModal {...defaultProps} spaces={[]} />);
+
+		expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+	});
+
+	it('renders an enabled selector with empty value when there is only one space', () => {
+		render(<CMSUploadModal {...defaultProps} spaces={ONE_SPACE} />);
+
+		const select = screen.getByRole('combobox');
+
+		expect(select).not.toBeDisabled();
+		expect(select).toHaveValue('');
+	});
+
+	it('shows a placeholder option for single space', () => {
+		render(<CMSUploadModal {...defaultProps} spaces={ONE_SPACE} />);
+
+		expect(
+			screen.getByRole('option', {name: 'select-a-space'})
+		).toBeInTheDocument();
+	});
+
+	it('renders enabled selector with placeholder when multiple spaces exist', () => {
+		render(<CMSUploadModal {...defaultProps} spaces={MULTIPLE_SPACES} />);
+
+		const select = screen.getByRole('combobox');
+
+		expect(select).not.toBeDisabled();
+		expect(select).toHaveValue('');
+		expect(
+			screen.getByRole('option', {name: 'select-a-space'})
+		).toBeInTheDocument();
+	});
+
+	it('renders an option for every space', () => {
+		render(<CMSUploadModal {...defaultProps} spaces={MULTIPLE_SPACES} />);
+
+		expect(
+			screen.getByRole('option', {name: 'Space One'})
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole('option', {name: 'Space Two'})
+		).toBeInTheDocument();
+	});
+});
+
+describe('CMSFilesUploadModal — form validation', () => {
+	it('fails validation and shows error even when only one space exists', async () => {
+		render(<CMSUploadModal {...defaultProps} spaces={ONE_SPACE} />);
+
+		fireEvent.click(screen.getByTestId('btn-validate'));
+
+		await waitFor(() => {
+			expect(screen.getByRole('alert')).toHaveTextContent(
+				'this-field-is-required'
+			);
+		});
+	});
+
+	it('fails validation and shows inline error when no space is selected', async () => {
+		render(<CMSUploadModal {...defaultProps} spaces={MULTIPLE_SPACES} />);
+
+		fireEvent.click(screen.getByTestId('btn-validate'));
+
+		await waitFor(() => {
+			expect(screen.getByRole('alert')).toHaveTextContent(
+				'this-field-is-required'
+			);
+		});
+	});
+
+	it('passes validation after a space is selected', async () => {
+		render(<CMSUploadModal {...defaultProps} spaces={MULTIPLE_SPACES} />);
+
+		fireEvent.change(screen.getByRole('combobox'), {
+			target: {value: 'space-erc-1'},
+		});
+
+		fireEvent.click(screen.getByTestId('btn-validate'));
+
+		await waitFor(() => {
+			expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+		});
+	});
+
+	it('clears the inline error immediately when a space is selected', async () => {
+		render(<CMSUploadModal {...defaultProps} spaces={MULTIPLE_SPACES} />);
+
+		fireEvent.click(screen.getByTestId('btn-validate'));
+
+		await waitFor(() => {
+			expect(screen.getByRole('alert')).toBeInTheDocument();
+		});
+
+		fireEvent.change(screen.getByRole('combobox'), {
+			target: {value: 'space-erc-1'},
+		});
+
+		expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+	});
+});
+
+describe('CMSFilesUploadModal — upload completion', () => {
+	it('calls onUploadSuccess and shows a toast on successful upload', () => {
+		render(<CMSUploadModal {...defaultProps} spaces={ONE_SPACE} />);
+
+		fireEvent.change(screen.getByRole('combobox'), {
+			target: {value: 'space-erc-1'},
+		});
+
+		fireEvent.click(screen.getByTestId('btn-complete-success-single'));
+
+		expect(defaultProps.onUploadSuccess).toHaveBeenCalledTimes(1);
+		expect(mockOpenToast).toHaveBeenCalledWith(
+			expect.objectContaining({type: 'success'})
+		);
+	});
+
+	it('uses the singular message key for a single uploaded file', () => {
+		render(<CMSUploadModal {...defaultProps} spaces={ONE_SPACE} />);
+
+		fireEvent.change(screen.getByRole('combobox'), {
+			target: {value: 'space-erc-1'},
+		});
+
+		fireEvent.click(screen.getByTestId('btn-complete-success-single'));
+
+		expect(mockSub).toHaveBeenCalledWith(
+			'x-file-was-successfully-uploaded-to-x-space',
+			expect.anything()
+		);
+	});
+
+	it('uses the plural message key for multiple uploaded files', () => {
+		render(<CMSUploadModal {...defaultProps} spaces={ONE_SPACE} />);
+
+		fireEvent.change(screen.getByRole('combobox'), {
+			target: {value: 'space-erc-1'},
+		});
+
+		fireEvent.click(screen.getByTestId('btn-complete-success-multiple'));
+
+		expect(mockSub).toHaveBeenCalledWith(
+			'x-files-were-successfully-uploaded-to-x-space',
+			expect.anything()
+		);
+	});
+
+	it('includes the space name in the toast message', () => {
+		render(<CMSUploadModal {...defaultProps} spaces={ONE_SPACE} />);
+
+		fireEvent.change(screen.getByRole('combobox'), {
+			target: {value: 'space-erc-1'},
+		});
+
+		fireEvent.click(screen.getByTestId('btn-complete-success-single'));
+
+		expect(mockSub).toHaveBeenCalledWith(
+			expect.any(String),
+			expect.arrayContaining(['Space One'])
+		);
+	});
+
+	it('closes the modal when upload completes with no failures', () => {
+		render(<CMSUploadModal {...defaultProps} spaces={ONE_SPACE} />);
+
+		fireEvent.click(screen.getByTestId('btn-complete-success-single'));
+
+		expect(defaultProps.onModalClose).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not close the modal when there are failed files', () => {
+		render(<CMSUploadModal {...defaultProps} spaces={ONE_SPACE} />);
+
+		fireEvent.click(screen.getByTestId('btn-complete-with-failures'));
+
+		expect(defaultProps.onModalClose).not.toHaveBeenCalled();
+	});
+
+	it('does not call onUploadSuccess when there are no successful files', () => {
+		render(<CMSUploadModal {...defaultProps} spaces={ONE_SPACE} />);
+
+		fireEvent.click(screen.getByTestId('btn-complete-with-failures'));
+
+		expect(defaultProps.onUploadSuccess).not.toHaveBeenCalled();
+	});
+});

--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "ce14860aca6059282fc6997bdd5a499126cc5df6",
+	"@generated": "9ed594cbc63bbcb5fab2a2cbeede372375820811",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -16,6 +16,9 @@
 			],
 			"@liferay/frontend-js-item-selector-web": [
 				"../../../../../../../frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/index.ts"
+			],
+			"@liferay/frontend-js-react-web": [
+				"../../../../../../../frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/index.ts"
 			],
 			"@liferay/object-js-components-web": [
 				"../../../../../../object-js-components-web/src/main/resources/META-INF/resources/index.ts"
@@ -60,6 +63,9 @@
 		},
 		{
 			"path": "../../../../../../../frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/tsconfig.json"
+		},
+		{
+			"path": "../../../../../../../frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/tsconfig.json"
 		},
 		{
 			"path": "../../../../../../object-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"

--- a/modules/test/playwright/tests/object-web/entry/objectEntry.spec.ts
+++ b/modules/test/playwright/tests/object-web/entry/objectEntry.spec.ts
@@ -521,6 +521,8 @@ cmsTest.describe('Manage attachment ObjectField storage locations', () => {
 
 			await viewObjectEntriesPage.selectFileButton.first().click();
 
+			await page.getByRole('img', {name: spaceName}).click();
+
 			await page.getByLabel(fileTitle, {exact: true}).click();
 
 			await page
@@ -544,6 +546,107 @@ cmsTest.describe('Manage attachment ObjectField storage locations', () => {
 			await expect(
 				viewObjectEntriesPage.page.getByText(fileName)
 			).toBeVisible();
+
+			await expect(
+				viewObjectEntriesPage.page.getByText('astronaut.png')
+			).toBeVisible();
+		}
+	);
+
+	cmsTest(
+		'can upload file to CMS through CMSFilesItemSelector',
+		async ({apiHelpers, page, viewObjectEntriesPage}) => {
+			const spaceName = getRandomString();
+
+			await test.step('Create a new Space', async () => {
+				await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+					name: spaceName,
+					settings: {},
+					type: 'Space',
+				});
+			});
+
+			const objectFields = generateObjectFields({
+				objectFieldBusinessTypes: [
+					{
+						businessType: 'Attachment',
+						name: 'cmsBasicDocument',
+						objectFieldSettings: [
+							{
+								name: 'acceptedFileExtensions',
+								value: 'jpeg, jpg, pdf, png, txt',
+							},
+							{
+								name: 'maximumFileSize',
+								value: 0,
+							},
+							{
+								name: 'fileSource',
+								value: 'CMSBasicDocument',
+							},
+						],
+					},
+				],
+			});
+
+			const objectDefinition =
+				await apiHelpers.objectAdmin.postRandomObjectDefinition({
+					objectFields,
+					status: {code: 0},
+				});
+
+			apiHelpers.data.push({
+				id: objectDefinition.id,
+				type: 'objectDefinition',
+			});
+
+			await viewObjectEntriesPage.goto(objectDefinition.className);
+
+			await viewObjectEntriesPage.clickAddObjectEntry(
+				objectDefinition.label['en_US']
+			);
+
+			await viewObjectEntriesPage.selectFileButton.first().click();
+
+			await page.getByRole('img', {name: spaceName}).click();
+
+			await page
+				.locator('[data-testid="fdsCreationActionButton"]')
+				.first()
+				.click();
+
+			const fileChooserPromise = page.waitForEvent('filechooser');
+
+			await page.getByRole('button', {name: 'Select Files'}).click();
+
+			const fileChooser = await fileChooserPromise;
+
+			await fileChooser.setFiles(
+				path.join(__dirname, '../dependencies', 'astronaut.png')
+			);
+
+			await page.getByLabel('SpaceMandatory').selectOption(spaceName);
+
+			await page.getByRole('button', {name: 'Upload (1)'}).click();
+
+			await waitForAlert(
+				page,
+				`Success:1 file was successfully uploaded to ${spaceName} space.`
+			);
+
+			await page.getByLabel('astronaut.png', {exact: true}).click();
+
+			await page
+				.getByRole('button', {exact: true, name: 'Select'})
+				.click();
+
+			await page
+				.getByRole('button', {name: 'astronaut.png'})
+				.waitFor({state: 'visible'});
+
+			await viewObjectEntriesPage.saveObjectEntryButton.click();
+
+			await waitForAlert(page);
 
 			await expect(
 				viewObjectEntriesPage.page.getByText('astronaut.png')
@@ -727,6 +830,8 @@ cmsTest.describe('Manage attachment ObjectField storage locations', () => {
 			);
 
 			await viewObjectEntriesPage.selectFileButton.click();
+
+			await page.getByRole('img', {name: space.name}).click();
 
 			await expect(page.getByText('No Results Found')).toBeVisible();
 		}


### PR DESCRIPTION
hey team, could you review the first commit in this pr? from our side it has already been review and approved, see: https://github.com/liferay-bpm/liferay-portal/pull/6001


### Why this change to ItemSelectorModal

- I'm using ItemSelectorModal from CMSFilesItemSelectorModal (in the object module) and need a custom upload entry in the creation menu — it opens our own CMSFilesUploadModal instead of going through FilesUploaderComponent, so the standard setViewType('upload') flow doesn't apply.

### The change does two things:

- Extracts the existing default menu (built from FilesUploaderComponent / createItemURL) into a defaultCreationMenu const.
- Lets callers override it via fdsProps.creationMenu, falling back to defaultCreationMenu when not set: fdsProps.creationMenu ?? defaultCreationMenu.
- Backwards compatible. When fdsProps.creationMenu is not provided, the resolved menu is byte-identical to the previous inline expression — all existing callers behave the same.
 
story ticket: [LPD-82544](https://liferay.atlassian.net/browse/LPD-82544)

video of new capabilities:
https://github.com/user-attachments/assets/00b10024-aeb9-4c63-88fd-cc928c44b597

you can see the video to understand our flow better, and feel free to reach out in case there any questions. thanks!!