### PR TITLE
LPD-87789 Fix test locator, previously matching two elements

### DIFF
--- a/modules/test/playwright/tests/client-extension-web/main/themeCSS.spec.ts
+++ b/modules/test/playwright/tests/client-extension-web/main/themeCSS.spec.ts
@@ -180,7 +180,9 @@ test('ThemeCSS client extension frontend token definition tokens appears stylebo
 	});
 
 	await test.step('Assert that the frontend token set defined in the frontendTokenDefinition.json file is available in the style book', async () => {
-		const frontendTokenSetLabel = page.getByText('primary-buttons');
+		const frontendTokenSetLabel = page.getByRole('button', {
+			name: 'primary-buttons',
+		});
 
 		await expect(frontendTokenSetLabel).toBeVisible();
 	});


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPD-87789

## Summary

Fixed a flaky test locator in the ThemeCSS client extension test that was matching multiple DOM elements. Changed from a text-based selector to a role-based selector to target the specific button element, eliminating ambiguity and improving test reliability.

## Changes

Updated the locator for `frontendTokenSetLabel` in `themeCSS.spec.ts` (line 183):
- **Before:** `page.getByText('primary-buttons')` — matches any element containing the text 'primary-buttons'
- **After:** `page.getByRole('button', { name: 'primary-buttons' })` — matches only button elements with the accessible name 'primary-buttons'

This role-based approach is more specific and follows Playwright best practices for accessible element targeting. It ensures the test targets the intended button without picking up text nodes or other incidental matches.

## How to test it

1. Navigate to the style book page containing the frontend token set definitions.
2. Run the ThemeCSS test
3. Verify the test step "Assert that the frontend token set defined in the frontendTokenDefinition.json file is available in the style book" passes consistently.
4. Confirm the primary-buttons button element is visible and the assertion succeeds without intermittent failures.