### PR TITLE
LPD-44626 Preserve badge letter-spacing on vertical nav hover/active

### DIFF
--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/components/_menubar.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/components/_menubar.scss
@@ -25,6 +25,10 @@
 		@include clay-menubar-vertical-variant(
 			$cadmin-menubar-vertical-transparent-md
 		);
+
+		.nav-link * {
+			letter-spacing: normal;
+		}
 	}
 
 	&.menubar-decorated {
@@ -63,6 +67,10 @@
 		@include clay-menubar-vertical-variant(
 			$cadmin-menubar-vertical-transparent-lg
 		);
+
+		.nav-link * {
+			letter-spacing: normal;
+		}
 	}
 
 	&.menubar-decorated {

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/components/_menubar.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/components/_menubar.scss
@@ -25,6 +25,10 @@
 		@include clay-menubar-vertical-variant(
 			$menubar-vertical-transparent-md
 		);
+
+		.nav-link * {
+			letter-spacing: normal;
+		}
 	}
 
 	&.menubar-decorated {
@@ -61,6 +65,10 @@
 		@include clay-menubar-vertical-variant(
 			$menubar-vertical-transparent-lg
 		);
+
+		.nav-link * {
+			letter-spacing: normal;
+		}
 	}
 
 	&.menubar-decorated {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-44626

**What is being fixed:** When a vertical-navigation item containing a child label or badge (for example, the "Deprecated" badge on the Featured Content fragment set in Fragments admin, or the "Draft" indicator next to the Design entry in Page Configuration) was hovered or marked as the active page, the badge's letter-spacing visibly tightened. The effect was caused by the link itself, so it appeared on every vertical-nav surface that hosts a status label inside a nav-link.

**How it is being fixed:** The `menubar-vertical-transparent` Sass maps for the atlas, atlas-custom-properties, and cadmin variants were setting `letter-spacing: 0` on the `nav-link` in both the `hover` and `active-class` states. Because `letter-spacing` is inherited, that override propagated into every descendant — including any clay label sitting inside the link. Removing the four `letter-spacing: 0` declarations (one per state, per variant) lets the parent's existing `letter-spacing` flow through unchanged on hover and on active, while the intended `font-weight: semi-bold` change stays in place.