### PR TITLE
LPD-88163 Make active item in Global Menu clickable

### DIFF
--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/css/GlobalMenu.scss
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/css/GlobalMenu.scss
@@ -14,6 +14,7 @@ html#{$cadmin-selector} .cadmin.global-menu {
 			$cadmin-primary-l0 4px,
 			transparent 2px
 		);
+		pointer-events: auto;
 	}
 
 	.sites-list {

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/js/GlobalMenu.tsx
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/js/GlobalMenu.tsx
@@ -162,6 +162,7 @@ export default function GlobalMenu({
 					return (
 						<ClayDropdown.Item
 							active={active}
+							aria-current={active ? 'page' : undefined}
 							className={classNames(
 								'align-items-center c-mb-2 d-inline-flex',
 								className
@@ -211,6 +212,9 @@ export default function GlobalMenu({
 									<ClayDropdown.Item
 										{...item}
 										active={item.current}
+										aria-current={
+											item.current ? 'page' : undefined
+										}
 										className="c-py-1 text-primary"
 										href={item.url}
 										key={item.key}

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/test/GlobalMenu.test.tsx
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/test/GlobalMenu.test.tsx
@@ -22,9 +22,16 @@ const mockedData = {
 	cms: {},
 	items: [
 		{
+			active: true,
 			homeURL: '/category1',
 			key: 'category1',
 			label: 'Category 1',
+		},
+		{
+			active: false,
+			homeURL: '/category2',
+			key: 'category2',
+			label: 'Category 2',
 		},
 	],
 	portletNamespace: 'portletNamespace',
@@ -39,6 +46,7 @@ const mockedData = {
 		],
 		recentSites: [
 			{
+				current: true,
 				key: 'Recent1',
 				label: 'Recent Site 1',
 				logoURL: 'recentSite1Logo',
@@ -150,5 +158,25 @@ describe('GlobalMenu', () => {
 				screen.getByRole('menuitem', {name: 'view-all-sites'})
 			).toBeInTheDocument();
 		});
+	});
+
+	it('marks the active category and current site with aria-current="page"', async () => {
+		renderComponent();
+
+		userEvent.click(screen.getByTestId('globalMenu'));
+
+		await waitFor(() => {
+			expect(
+				screen.getByRole('menuitem', {name: 'Category 1'})
+			).toHaveAttribute('aria-current', 'page');
+		});
+
+		expect(
+			screen.getByRole('menuitem', {name: 'Category 2'})
+		).not.toHaveAttribute('aria-current');
+
+		expect(
+			screen.getByRole('menuitem', {name: 'Recent Site 1'})
+		).toHaveAttribute('aria-current', 'page');
 	});
 });


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88163

Slack conversation: https://liferay.slack.com/archives/C04A7NLM7L1/p1777453384971889

## What is being fixed

The active item in the Global Menu — the entry corresponding to the current section — could not be clicked. Cadmin's dropdown token map applies `pointer-events: none` to `.dropdown-item.active`, and the Global Menu inherits that rule because its dropdown is rendered with the `cadmin` class. Users could not navigate to (or refresh) a section's home URL by clicking its highlighted menu entry.

## How it is being fixed

Override the cadmin rule locally in `GlobalMenu.scss` by adding `pointer-events: auto` to the existing `.dropdown-item.active` rule, scoped to `.cadmin.global-menu`. This restores interactivity for the Global Menu without altering the cadmin token map, which selection-style dropdowns elsewhere (e.g., RangeSelectorsDropdown, FilterDropdown) rely on for their inert active items.

Mark the active dropdown items with `aria-current="page"` in `GlobalMenu.tsx` so screen readers announce them as the current page now that they are clickable.