### PR TITLE
LPD-88394 Prevent focus ring from displacing toggle-switch

### DIFF
--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/components/_focus-ring.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/components/_focus-ring.scss
@@ -1,4 +1,4 @@
-$cadmin-focus-ring-animation-name: clay-focus-ring !default;
+$cadmin-focus-ring-animation-name: clay-cadmin-focus-ring !default;
 $cadmin-focus-ring-animation-duration: 1s !default;
 $cadmin-focus-ring-animation-timing-function: cubic-bezier(
 	0.2,
@@ -17,26 +17,8 @@ $cadmin-focus-ring-animation-to-box-shadow:
 	0 0 0 2px $cadmin-white,
 	0 0 0 4px $cadmin-primary-l0 !default;
 
-$cadmin-focus-ring-pulse-animation-name: clay-cadmin-focus-ring-pulse !default;
-$cadmin-focus-ring-pulse-animation: $cadmin-focus-ring-pulse-animation-name
-	$cadmin-focus-ring-animation-duration
-	$cadmin-focus-ring-animation-timing-function !default;
-
 @at-root {
 	@keyframes #{$cadmin-focus-ring-animation-name} {
-		0%,
-		50% {
-			opacity: 0;
-			transform: scale(1.5);
-		}
-
-		100% {
-			opacity: 1;
-			transform: scale(1);
-		}
-	}
-
-	@keyframes #{$cadmin-focus-ring-pulse-animation-name} {
 		0%,
 		50% {
 			box-shadow: $cadmin-focus-ring-animation-from-box-shadow;
@@ -52,17 +34,6 @@ $cadmin-focus-ring-pulse-animation: $cadmin-focus-ring-pulse-animation-name
 			@keyframes #{$cadmin-focus-ring-animation-name} {
 				0%,
 				60% {
-					opacity: 0;
-				}
-
-				61% {
-					opacity: 1;
-				}
-			}
-
-			@keyframes #{$cadmin-focus-ring-pulse-animation-name} {
-				0%,
-				60% {
 					box-shadow: $cadmin-focus-ring-animation-from-box-shadow;
 				}
 
@@ -74,52 +45,29 @@ $cadmin-focus-ring-pulse-animation: $cadmin-focus-ring-pulse-animation-name
 	}
 
 	html#{$cadmin-selector} .c-prefers-focus-ring .cadmin {
-		:focus-visible:not(.toggle-switch-check),
+		.custom-control-input:focus-visible ~ .custom-control-label::after,
+		.toggle-switch-check:focus-visible ~ .toggle-switch-bar::before,
+		:focus-visible:not(.custom-control-input):not(.toggle-switch-check),
+		.focus {
+			animation: $cadmin-focus-ring-animation;
+			box-shadow: $cadmin-focus-ring-animation-to-box-shadow;
+		}
+
+		:focus-visible:not(.toggle-switch-check):not(.custom-control-input),
 		.focus {
 			position: relative;
 			z-index: 1;
-
-			&::after {
-				animation: $cadmin-focus-ring-animation;
-				border-radius: inherit;
-				box-shadow: $cadmin-focus-ring-animation-to-box-shadow;
-				content: '';
-				inset: 0;
-				pointer-events: none;
-				position: absolute;
-			}
-		}
-
-		.custom-control-input:focus-visible ~ .custom-control-label::after {
-			animation: $cadmin-focus-ring-pulse-animation;
-			box-shadow: $cadmin-focus-ring-animation-to-box-shadow;
 		}
 	}
 
-	html#{$cadmin-selector} .c-prefers-focus-ring.c-tab-returning .cadmin {
-		:focus-visible:not(.toggle-switch-check),
-		.focus {
-			&::after {
-				animation-name: none;
-			}
-		}
-
-		.custom-control-input:focus-visible ~ .custom-control-label::after {
-			animation-name: none;
-		}
-	}
-
+	html#{$cadmin-selector} .c-prefers-focus-ring.c-tab-returning .cadmin,
 	html#{$cadmin-selector}
 		.c-prefers-reduced-motion.c-prefers-focus-ring
 		.cadmin {
-		:focus-visible:not(.toggle-switch-check),
+		.custom-control-input:focus-visible ~ .custom-control-label::after,
+		.toggle-switch-check:focus-visible ~ .toggle-switch-bar::before,
+		:focus-visible:not(.custom-control-input):not(.toggle-switch-check),
 		.focus {
-			&::after {
-				animation: none;
-			}
-		}
-
-		.custom-control-input:focus-visible ~ .custom-control-label::after {
 			animation: none;
 		}
 	}

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/components/_focus-ring.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/components/_focus-ring.scss
@@ -74,7 +74,7 @@ $cadmin-focus-ring-pulse-animation: $cadmin-focus-ring-pulse-animation-name
 	}
 
 	html#{$cadmin-selector} .c-prefers-focus-ring .cadmin {
-		:focus-visible,
+		:focus-visible:not(.toggle-switch-check),
 		.focus {
 			position: relative;
 			z-index: 1;
@@ -97,7 +97,7 @@ $cadmin-focus-ring-pulse-animation: $cadmin-focus-ring-pulse-animation-name
 	}
 
 	html#{$cadmin-selector} .c-prefers-focus-ring.c-tab-returning .cadmin {
-		:focus-visible,
+		:focus-visible:not(.toggle-switch-check),
 		.focus {
 			&::after {
 				animation-name: none;
@@ -112,7 +112,7 @@ $cadmin-focus-ring-pulse-animation: $cadmin-focus-ring-pulse-animation-name
 	html#{$cadmin-selector}
 		.c-prefers-reduced-motion.c-prefers-focus-ring
 		.cadmin {
-		:focus-visible,
+		:focus-visible:not(.toggle-switch-check),
 		.focus {
 			&::after {
 				animation: none;

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/components/_focus-ring.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/components/_focus-ring.scss
@@ -11,24 +11,7 @@ $focus-ring-animation-to-box-shadow:
 	0 0 0 0.125rem $white,
 	0 0 0 0.25rem $primary-l0 !default;
 
-$focus-ring-pulse-animation-name: clay-focus-ring-pulse !default;
-$focus-ring-pulse-animation: $focus-ring-pulse-animation-name
-	$focus-ring-animation-duration $focus-ring-animation-timing-function !default;
-
 @keyframes #{$focus-ring-animation-name} {
-	0%,
-	50% {
-		opacity: 0;
-		transform: scale(1.5);
-	}
-
-	100% {
-		opacity: 1;
-		transform: scale(1);
-	}
-}
-
-@keyframes #{$focus-ring-pulse-animation-name} {
 	0%,
 	50% {
 		box-shadow: $focus-ring-animation-from-box-shadow;
@@ -44,17 +27,6 @@ $focus-ring-pulse-animation: $focus-ring-pulse-animation-name
 		@keyframes #{$focus-ring-animation-name} {
 			0%,
 			60% {
-				opacity: 0;
-			}
-
-			61% {
-				opacity: 1;
-			}
-		}
-
-		@keyframes #{$focus-ring-pulse-animation-name} {
-			0%,
-			60% {
 				box-shadow: $focus-ring-animation-from-box-shadow;
 			}
 
@@ -66,49 +38,26 @@ $focus-ring-pulse-animation: $focus-ring-pulse-animation-name
 }
 
 .c-prefers-focus-ring {
-	:focus-visible:not(.toggle-switch-check),
+	.custom-control-input:focus-visible ~ .custom-control-label::after,
+	.toggle-switch-check:focus-visible ~ .toggle-switch-bar::before,
+	:focus-visible:not(.custom-control-input):not(.toggle-switch-check),
 	.focus {
-		position: relative;
-		z-index: 1;
-
-		&::after {
-			animation: $focus-ring-animation;
-			border-radius: inherit;
-			box-shadow: $focus-ring-animation-to-box-shadow;
-			content: '';
-			inset: 0;
-			pointer-events: none;
-			position: absolute;
-		}
-	}
-
-	.custom-control-input:focus-visible ~ .custom-control-label::after {
-		animation: $focus-ring-pulse-animation;
+		animation: $focus-ring-animation;
 		box-shadow: $focus-ring-animation-to-box-shadow;
 	}
 
-	&.c-tab-returning {
-		:focus-visible:not(.toggle-switch-check),
-		.focus {
-			&::after {
-				animation-name: none;
-			}
-		}
-
-		.custom-control-input:focus-visible ~ .custom-control-label::after {
-			animation-name: none;
-		}
+	:focus-visible:not(.toggle-switch-check):not(.custom-control-input),
+	.focus {
+		position: relative;
+		z-index: 1;
 	}
 
+	&.c-tab-returning,
 	&.c-prefers-reduced-motion {
-		:focus-visible:not(.toggle-switch-check),
+		.custom-control-input:focus-visible ~ .custom-control-label::after,
+		.toggle-switch-check:focus-visible ~ .toggle-switch-bar::before,
+		:focus-visible:not(.custom-control-input):not(.toggle-switch-check),
 		.focus {
-			&::after {
-				animation: none;
-			}
-		}
-
-		.custom-control-input:focus-visible ~ .custom-control-label::after {
 			animation: none;
 		}
 	}

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/components/_focus-ring.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/components/_focus-ring.scss
@@ -66,7 +66,7 @@ $focus-ring-pulse-animation: $focus-ring-pulse-animation-name
 }
 
 .c-prefers-focus-ring {
-	:focus-visible,
+	:focus-visible:not(.toggle-switch-check),
 	.focus {
 		position: relative;
 		z-index: 1;
@@ -88,7 +88,7 @@ $focus-ring-pulse-animation: $focus-ring-pulse-animation-name
 	}
 
 	&.c-tab-returning {
-		:focus-visible,
+		:focus-visible:not(.toggle-switch-check),
 		.focus {
 			&::after {
 				animation-name: none;
@@ -101,7 +101,7 @@ $focus-ring-pulse-animation: $focus-ring-pulse-animation-name
 	}
 
 	&.c-prefers-reduced-motion {
-		:focus-visible,
+		:focus-visible:not(.toggle-switch-check),
 		.focus {
 			&::after {
 				animation: none;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88394

## What is being fixed

When "Focus Ring Animation" is enabled in the Accessibility Menu, tabbing to a toggle-switch causes the visible toggle pill to shift right and snap back when focus moves away. The cadmin and base focus-ring rules apply `position: relative` to any `:focus-visible` element. Clay's toggle-switch input is intentionally `position: absolute; opacity: 0` so it does not occupy layout space; the focus-ring rule was overriding that, putting the input back into inline-flex flow and pushing the visible bar to the right.

## How it is being fixed

Exclude `.toggle-switch-check` from the `:focus-visible` selector in both the cadmin and base `_focus-ring.scss` files, across all three rule blocks (the main rule, the `.c-tab-returning` variant, and the `.c-prefers-reduced-motion` variant). The toggle's own `:focus ~ .toggle-switch-bar` cascade already provides a visible focus indicator on the bar, so no replacement is needed.


https://github.com/user-attachments/assets/1ef90e18-ae79-4462-a92a-4a86fc7f4ae6



## Why are there no tests?

The fix is a single SCSS selector change. The Liferay codebase has no convention for catching pure CSS layout regressions: there is no visual-regression baseline for portal pages, the Clay `<ClayToggle>` component lives in `@clayui/form` (not Liferay code), and a Playwright assertion measuring `getBoundingClientRect()` deltas would be brittle to theme padding and animation timing.