### PR TITLE
LPD-88407 Unify CMS item selector upload across Web Content flows

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/plugins/HeadlessItemSelector.ts
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/plugins/HeadlessItemSelector.ts
@@ -57,7 +57,9 @@ class HeadlessItemSelector extends Plugin {
 			buttonView.on('execute', () => {
 				openCMSFileSelectorModal({
 					allowDragAndDrop: true,
-					allowedExtensions: ALLOWED_IMAGE_FILE_EXTENSIONS.join(','),
+					allowedExtensions: ALLOWED_IMAGE_FILE_EXTENSIONS.map(
+						(extension) => `.${extension}`
+					).join(','),
 					groupId: Liferay.ThemeDisplay.getSiteGroupId(),
 					itemTypeLabel: Liferay.Language.get('image'),
 					onSelect: (items) => {

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/plugins/HeadlessItemSelector.ts
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/plugins/HeadlessItemSelector.ts
@@ -33,13 +33,16 @@ const ALLOWED_VIDEO_FILE_EXTENSIONS = [
 	'wmv',
 ];
 
-const ALLOWED_IMAGE_EXTENSIONS_CSV = ALLOWED_IMAGE_FILE_EXTENSIONS.map(
-	(extension) => `.${extension}`
-).join(',');
+const toAllowedExtensionsCSV = (extensions: string[]) =>
+	extensions.map((extension) => `.${extension}`).join(',');
 
-const ALLOWED_VIDEO_EXTENSIONS_CSV = ALLOWED_VIDEO_FILE_EXTENSIONS.map(
-	(extension) => `.${extension}`
-).join(',');
+const ALLOWED_IMAGE_EXTENSIONS_CSV = toAllowedExtensionsCSV(
+	ALLOWED_IMAGE_FILE_EXTENSIONS
+);
+
+const ALLOWED_VIDEO_EXTENSIONS_CSV = toAllowedExtensionsCSV(
+	ALLOWED_VIDEO_FILE_EXTENSIONS
+);
 
 const VIDEO_FILTER = `((objectDefinitionExternalReferenceCode eq 'L_CMS_EXTERNAL_VIDEO') or (extension in ('${ALLOWED_VIDEO_FILE_EXTENSIONS.join(
 	"','"

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/plugins/HeadlessItemSelector.ts
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/plugins/HeadlessItemSelector.ts
@@ -37,6 +37,10 @@ const ALLOWED_IMAGE_EXTENSIONS_CSV = ALLOWED_IMAGE_FILE_EXTENSIONS.map(
 	(extension) => `.${extension}`
 ).join(',');
 
+const ALLOWED_VIDEO_EXTENSIONS_CSV = ALLOWED_VIDEO_FILE_EXTENSIONS.map(
+	(extension) => `.${extension}`
+).join(',');
+
 const VIDEO_FILTER = `((objectDefinitionExternalReferenceCode eq 'L_CMS_EXTERNAL_VIDEO') or (extension in ('${ALLOWED_VIDEO_FILE_EXTENSIONS.join(
 	"','"
 )}')))`;
@@ -107,6 +111,7 @@ class HeadlessItemSelector extends Plugin {
 			buttonView.on('execute', () => {
 				openCMSFileSelectorModal({
 					allowDragAndDrop: true,
+					allowedExtensions: ALLOWED_VIDEO_EXTENSIONS_CSV,
 					filters: [VIDEO_FILTER],
 					groupId: getGroupId(),
 					itemTypeLabel: Liferay.Language.get('video'),

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/plugins/HeadlessItemSelector.ts
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/plugins/HeadlessItemSelector.ts
@@ -33,6 +33,14 @@ const ALLOWED_VIDEO_FILE_EXTENSIONS = [
 	'wmv',
 ];
 
+const ALLOWED_IMAGE_EXTENSIONS_CSV = ALLOWED_IMAGE_FILE_EXTENSIONS.map(
+	(extension) => `.${extension}`
+).join(',');
+
+const VIDEO_FILTER = `((objectDefinitionExternalReferenceCode eq 'L_CMS_EXTERNAL_VIDEO') or (extension in ('${ALLOWED_VIDEO_FILE_EXTENSIONS.join(
+	"','"
+)}')))`;
+
 class HeadlessItemSelector extends Plugin {
 	init() {
 		const editor = this.editor;
@@ -42,6 +50,10 @@ class HeadlessItemSelector extends Plugin {
 		editor.commands.add(commandName, new Command(editor));
 
 		const command = editor.commands.get(commandName)!;
+
+		const getGroupId = () =>
+			Number(editor.config.get('groupId')) ||
+			Liferay.ThemeDisplay.getScopeGroupId();
 
 		editor.ui.componentFactory.add('headlessImageSelector', () => {
 			const buttonView = new ButtonView();
@@ -55,16 +67,10 @@ class HeadlessItemSelector extends Plugin {
 			buttonView.bind('isEnabled').to(command, 'isEnabled');
 
 			buttonView.on('execute', () => {
-				const groupId =
-					Number(editor.config.get('groupId')) ||
-					Liferay.ThemeDisplay.getScopeGroupId();
-
 				openCMSFileSelectorModal({
 					allowDragAndDrop: true,
-					allowedExtensions: ALLOWED_IMAGE_FILE_EXTENSIONS.map(
-						(extension) => `.${extension}`
-					).join(','),
-					groupId,
+					allowedExtensions: ALLOWED_IMAGE_EXTENSIONS_CSV,
+					groupId: getGroupId(),
 					itemTypeLabel: Liferay.Language.get('image'),
 					onSelect: (items) => {
 						const href = items[0]?.embedded?.file?.link?.href;
@@ -99,16 +105,10 @@ class HeadlessItemSelector extends Plugin {
 			buttonView.bind('isEnabled').to(command, 'isEnabled');
 
 			buttonView.on('execute', () => {
-				const groupId =
-					Number(editor.config.get('groupId')) ||
-					Liferay.ThemeDisplay.getScopeGroupId();
-
 				openCMSFileSelectorModal({
 					allowDragAndDrop: true,
-					filters: [
-						`((objectDefinitionExternalReferenceCode eq 'L_CMS_EXTERNAL_VIDEO') or (extension in ('${ALLOWED_VIDEO_FILE_EXTENSIONS.join("','")}')))`,
-					],
-					groupId,
+					filters: [VIDEO_FILTER],
+					groupId: getGroupId(),
 					itemTypeLabel: Liferay.Language.get('video'),
 					onSelect: (items) => {
 						const videoURL = items[0]?.embedded?.videoURL;

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/plugins/HeadlessItemSelector.ts
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/plugins/HeadlessItemSelector.ts
@@ -55,12 +55,16 @@ class HeadlessItemSelector extends Plugin {
 			buttonView.bind('isEnabled').to(command, 'isEnabled');
 
 			buttonView.on('execute', () => {
+				const groupId =
+					Number(editor.config.get('groupId')) ||
+					Liferay.ThemeDisplay.getScopeGroupId();
+
 				openCMSFileSelectorModal({
 					allowDragAndDrop: true,
 					allowedExtensions: ALLOWED_IMAGE_FILE_EXTENSIONS.map(
 						(extension) => `.${extension}`
 					).join(','),
-					groupId: Liferay.ThemeDisplay.getSiteGroupId(),
+					groupId,
 					itemTypeLabel: Liferay.Language.get('image'),
 					onSelect: (items) => {
 						const href = items[0]?.embedded?.file?.link?.href;
@@ -95,12 +99,16 @@ class HeadlessItemSelector extends Plugin {
 			buttonView.bind('isEnabled').to(command, 'isEnabled');
 
 			buttonView.on('execute', () => {
+				const groupId =
+					Number(editor.config.get('groupId')) ||
+					Liferay.ThemeDisplay.getScopeGroupId();
+
 				openCMSFileSelectorModal({
 					allowDragAndDrop: true,
 					filters: [
 						`((objectDefinitionExternalReferenceCode eq 'L_CMS_EXTERNAL_VIDEO') or (extension in ('${ALLOWED_VIDEO_FILE_EXTENSIONS.join("','")}')))`,
 					],
-					groupId: Liferay.ThemeDisplay.getSiteGroupId(),
+					groupId,
 					itemTypeLabel: Liferay.Language.get('video'),
 					onSelect: (items) => {
 						const videoURL = items[0]?.embedded?.videoURL;

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/plugins/HeadlessItemSelector.ts
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/plugins/HeadlessItemSelector.ts
@@ -116,7 +116,9 @@ class HeadlessItemSelector extends Plugin {
 					groupId: getGroupId(),
 					itemTypeLabel: Liferay.Language.get('video'),
 					onSelect: (items) => {
-						const videoURL = items[0]?.embedded?.videoURL;
+						const videoURL =
+							items[0]?.embedded?.videoURL ??
+							items[0]?.embedded?.file?.link?.href;
 
 						if (!videoURL) {
 							return;

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/plugins/HeadlessItemSelector.ts
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/plugins/HeadlessItemSelector.ts
@@ -33,8 +33,6 @@ const ALLOWED_VIDEO_FILE_EXTENSIONS = [
 	'wmv',
 ];
 
-const CMS_CREATE_ITEM_URL = `${location.origin}/web/cms/files?com.liferay.site.cms.site.initializer-filesSection_fdsConfig=(view:gallery)`;
-
 class HeadlessItemSelector extends Plugin {
 	init() {
 		const editor = this.editor;
@@ -58,8 +56,8 @@ class HeadlessItemSelector extends Plugin {
 
 			buttonView.on('execute', () => {
 				openCMSFileSelectorModal({
+					allowDragAndDrop: true,
 					allowedExtensions: ALLOWED_IMAGE_FILE_EXTENSIONS.join(','),
-					createItemURL: CMS_CREATE_ITEM_URL,
 					groupId: Liferay.ThemeDisplay.getSiteGroupId(),
 					itemTypeLabel: Liferay.Language.get('image'),
 					onSelect: (items) => {
@@ -96,7 +94,7 @@ class HeadlessItemSelector extends Plugin {
 
 			buttonView.on('execute', () => {
 				openCMSFileSelectorModal({
-					createItemURL: CMS_CREATE_ITEM_URL,
+					allowDragAndDrop: true,
 					filters: [
 						`((objectDefinitionExternalReferenceCode eq 'L_CMS_EXTERNAL_VIDEO') or (extension in ('${ALLOWED_VIDEO_FILE_EXTENSIONS.join("','")}')))`,
 					],

--- a/modules/apps/frontend-js/frontend-js-item-selector-sample-web/src/main/resources/META-INF/resources/js/ItemSelectorSamples.tsx
+++ b/modules/apps/frontend-js/frontend-js-item-selector-sample-web/src/main/resources/META-INF/resources/js/ItemSelectorSamples.tsx
@@ -478,7 +478,6 @@ export default function ItemSelectorSamples() {
 
 				<ItemSelectorModal<Document>
 					apiURL={documentsItemSelectorConfig.apiURL}
-					createItemURL={Liferay.ThemeDisplay.getPortalURL()}
 					fdsProps={{
 						...FDS_DEFAULT_PROPS,
 						id: `itemSelectorModal-documents-${getRandomId()}`,
@@ -524,7 +523,6 @@ export default function ItemSelectorSamples() {
 
 				<ItemSelectorModal<User>
 					apiURL={userAccountsItemSelectorConfig.apiURL}
-					createItemURL={Liferay.ThemeDisplay.getPortalURL()}
 					fdsProps={{
 						...FDS_DEFAULT_PROPS,
 						id: `itemSelectorModal-users-${getRandomId()}`,

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/ItemSelectorModal.tsx
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/ItemSelectorModal.tsx
@@ -9,7 +9,6 @@ import ClayLayout from '@clayui/layout';
 import ClayModal from '@clayui/modal';
 import {InternalDispatch} from '@clayui/shared';
 import {
-	ACTION_ITEM_TARGETS,
 	FrontendDataSet,
 	IFileDropSettings,
 	IFrontendDataSetProps,
@@ -68,11 +67,6 @@ export interface IItemSelectorModalProps<T> {
 	 * If the @clayui/breadcrumb items label should be visible or not
 	 */
 	breadcrumbsLabel?: boolean;
-
-	/**
-	 * URL for item creation used to open a new tab.
-	 */
-	createItemURL?: string;
 
 	/**
 	 * Configuration properties of the Frontend Data Set used to display data.
@@ -149,19 +143,11 @@ export interface IItemSelectorModalProps<T> {
 	title?: string;
 }
 
-const EMPTY_STATE_PROPS = {
-	description: Liferay.Language.get(
-		'fortunately-it-is-very-easy-to-add-new-ones'
-	),
-	title: Liferay.Language.get('no-items-were-found'),
-};
-
 function ItemSelectorModal<T extends Record<string, any>>({
 	allowedExtensions,
 	apiURL,
 	breadcrumbs,
 	breadcrumbsLabel = true,
-	createItemURL,
 	fdsProps,
 	filesUploaderComponent: FilesUploaderComponent,
 	groupId,
@@ -264,41 +250,21 @@ function ItemSelectorModal<T extends Record<string, any>>({
 						{...fdsProps}
 						apiURL={apiURL}
 						creationMenu={
-							FilesUploaderComponent || createItemURL
+							FilesUploaderComponent
 								? {
 										primaryItems: [
-											...(FilesUploaderComponent
-												? [
-														{
-															label: Liferay.Language.get(
-																'upload-files'
-															),
-															onClick: () =>
-																setViewType(
-																	'upload'
-																),
-														},
-													]
-												: []),
-											...(createItemURL
-												? [
-														{
-															href: createItemURL,
-															label: Liferay.Language.get(
-																'add-new-item'
-															),
-															target: ACTION_ITEM_TARGETS.BLANK,
-														},
-													]
-												: []),
+											{
+												label: Liferay.Language.get(
+													'upload-files'
+												),
+												onClick: () =>
+													setViewType('upload'),
+											},
 										],
 									}
 								: undefined
 						}
-						emptyState={
-							fdsProps.emptyState ||
-							(createItemURL ? EMPTY_STATE_PROPS : undefined)
-						}
+						emptyState={fdsProps.emptyState}
 						fileDropSettings={fileDropSettings}
 						key={fdsRefreshKey}
 						onSelectedItemsChange={setSelectedItems}

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/openCMSFileSelectorModal.ts
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/openCMSFileSelectorModal.ts
@@ -184,7 +184,6 @@ export default function openCMSFileSelectorModal({
 	allowDragAndDrop = false,
 	allowedExtensions,
 	config,
-	createItemURL,
 	fdsProps,
 	filters,
 	groupId,
@@ -195,7 +194,6 @@ export default function openCMSFileSelectorModal({
 	allowDragAndDrop?: boolean;
 	allowedExtensions?: string;
 	config?: Partial<CMSFileItemSelectorModalConfig>;
-	createItemURL?: string;
 	fdsProps?: Partial<CMSFileItemSelectorModalProps['fdsProps']>;
 	filters?: string[];
 	groupId: number;
@@ -224,7 +222,6 @@ export default function openCMSFileSelectorModal({
 		{
 			...finalConfig,
 			allowedExtensions,
-			createItemURL,
 			fdsProps: {
 				...FDS_PROPS,
 				emptyState: allowDragAndDrop

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/test/ItemSelectorModal.test.tsx
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/test/ItemSelectorModal.test.tsx
@@ -68,13 +68,11 @@ const mockedLoadClientExtensions = loadClientExtensions as jest.Mock;
 const mockedSub = sub as jest.Mock;
 
 const ItemSelectorModalWrapper = ({
-	createItemURL,
 	defaultOpen,
 	filesUploaderComponent,
 	onItemsChange,
 	selectedItems,
 }: {
-	createItemURL?: string;
 	defaultOpen: boolean;
 	filesUploaderComponent?: FilesUploaderComponent;
 	onItemsChange: (items: TestItem[]) => void;
@@ -88,7 +86,6 @@ const ItemSelectorModalWrapper = ({
 
 			<ItemSelectorModal<TestItem>
 				apiURL={`${location.origin}/o/headless-delivery/v1.0/test-api-url`}
-				createItemURL={createItemURL}
 				fdsProps={{
 					id: `itemSelectorModal-test-0001`,
 					pagination: {
@@ -176,29 +173,6 @@ describe('ItemSelectorModal component', () => {
 		expect(select).toBeInTheDocument();
 
 		expect(select).toBeDisabled();
-	});
-
-	it('renders an item selector modal with a create new item link that opens in a new tab', async () => {
-		const createItemURL = 'www.example.com';
-
-		const {findByRole} = render(
-			<ItemSelectorModalWrapper
-				createItemURL={createItemURL}
-				defaultOpen={true}
-				onItemsChange={jest.fn()}
-				selectedItems={[]}
-			/>
-		);
-
-		const modal = await findByRole('dialog');
-
-		const newItemLink = await within(modal).findByText('add-new-item');
-
-		expect(newItemLink).toBeInTheDocument();
-
-		expect(newItemLink.getAttribute('href')).toEqual(createItemURL);
-
-		expect(newItemLink.getAttribute('target')).toEqual('_blank');
 	});
 
 	it('renders items with radio for single selection type', async () => {

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/editor/config/RichTextFragmentCKEditor5EditorConfigContributor.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/editor/config/RichTextFragmentCKEditor5EditorConfigContributor.java
@@ -5,13 +5,17 @@
 
 package com.liferay.site.cms.site.initializer.internal.editor.config;
 
+import com.liferay.info.constants.InfoDisplayWebKeys;
 import com.liferay.portal.kernel.editor.configuration.BaseEditorConfigContributor;
 import com.liferay.portal.kernel.editor.configuration.EditorConfigContributor;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactory;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+
+import jakarta.servlet.http.HttpServletRequest;
 
 import java.util.Map;
 
@@ -37,6 +41,19 @@ public class RichTextFragmentCKEditor5EditorConfigContributor
 
 		if (!scopeGroup.isCMS()) {
 			return;
+		}
+
+		HttpServletRequest httpServletRequest = themeDisplay.getRequest();
+
+		if (httpServletRequest != null) {
+			Object infoItem = httpServletRequest.getAttribute(
+				InfoDisplayWebKeys.INFO_ITEM);
+
+			if (infoItem instanceof GroupedModel) {
+				GroupedModel groupedModel = (GroupedModel)infoItem;
+
+				jsonObject.put("groupId", groupedModel.getGroupId());
+			}
 		}
 
 		jsonObject.put(

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/contentEditor.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/contentEditor.spec.ts
@@ -1922,6 +1922,38 @@ test(
 );
 
 test(
+	'Image selector lets the user open the multiple file uploader from the Upload Files button',
+	{tag: '@LPD-88407'},
+	async ({contentsPage, page}) => {
+		await contentsPage.goto();
+
+		await contentsPage.createContent('Basic Web Content');
+
+		await waitForEditor({page});
+
+		await page.getByRole('button', {name: 'Image'}).click();
+
+		await expect(page.getByText('Select Image')).toBeVisible();
+
+		const uploadFilesButton = page.getByRole('button', {
+			name: 'Upload Files',
+		});
+
+		await expect(uploadFilesButton).toBeVisible();
+
+		await uploadFilesButton.click();
+
+		await expect(
+			page.getByText('Drag and Drop your files or')
+		).toBeVisible();
+
+		await expect(
+			page.getByRole('button', {name: 'Select Files'})
+		).toBeVisible();
+	}
+);
+
+test(
 	'Tags are not cleared after saving content when the categories panel is never opened',
 	{tag: '@LPD-79085'},
 	async ({contentsPage, page}) => {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88407

## What is being fixed

When inserting an image or video in the CKEditor Web Content flow, clicking the "Add New Item" button in the Item Selector modal redirected the user to a separate browser tab at `/web/cms/files`. The Object Attachment (Structure creation) flow already opened an inline uploader inside the same modal, so the two CMS upload flows behaved differently. 

## How it is being fixed

Switch the CKEditor image and video buttons to the inline `CMSFileUploaderComponent` flow used by Object Attachment, by passing `allowDragAndDrop: true` to `openCMSFileSelectorModal` and dropping the `createItemURL` prop. With no remaining consumer needing the new-tab redirect, remove `createItemURL` entirely from `ItemSelectorModal`, `openCMSFileSelectorModal`, the sample, and the unit test that asserted the old behavior — both flows now converge on the same code path.

For the upload target, expose the article's owning groupId on the editor config: `RichTextFragmentCKEditor5EditorConfigContributor` reads it from the request's `INFO_ITEM` (a `GroupedModel`) — the same pattern used in `FragmentEntryInputTemplateNodeContextHelperImpl._getGroupId` — and the CKEditor plugin reads `editor.config.get('groupId')` with a `getScopeGroupId` fallback. Allowed extensions are now passed dot-prefixed (`.jpg,.png,…`) so `MultipleFileUploader`'s react-dropzone validation accepts valid files; the same restriction is applied to the video selector. The video onSelect callback falls back to the uploaded file's link when the selected item is a basic-document rather than an external-video reference.


Note: I have noticed that selecting an uploaded video is not working (only with External Videos), but apparently is also failing in master, so I will open a bug for this.