### PR TITLE
LPD-88962 Set Platform Experience team as codeowners of Clay module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -91,6 +91,7 @@ modules/apps/frontend-data-set/    @liferay-frontend
 modules/apps/frontend-editor/    @liferay-frontend
 modules/apps/frontend-icons/    @liferay-frontend
 modules/apps/frontend-js/    @liferay-frontend
+modules/apps/frontend-js/frontend-js-clay-web/    @liferay-platform-experience
 modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/multiple_file_uploader/    @liferay-platform-experience
 modules/apps/frontend-js/frontend-js-item-selector-sample-web/    @liferay-platform-experience
 modules/apps/frontend-js/frontend-js-item-selector-web/    @liferay-platform-experience


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88962

## What is being fixed

The `modules/apps/frontend-js/frontend-js-clay-web` module had no specific CODEOWNERS entry, so changes fell through to the parent rule and were assigned to `@liferay-frontend`. The Platform Experience team owns this module and should be the reviewer for PRs touching it.

## How it is being fixed

Adds a CODEOWNERS line mapping `modules/apps/frontend-js/frontend-js-clay-web` to `@liferay-platform-experience`, placed directly under the existing `frontend-js` entry so the more specific path takes precedence.

## Why are there no tests?

CODEOWNERS is a configuration file; there is no behavior to test.