### PR TITLE
LPD-87247 Run CMS multi-file uploads sequentially

### DIFF
--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.ts
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.ts
@@ -47,6 +47,7 @@ export {ModalStatus} from './modal/components/Modal';
 export {default as MultipleFileUploader} from './multiple_file_uploader/MultipleFileUploader';
 export {
 	type FileData,
+	type UploadBatchesCallback,
 	type UploadMessages,
 	type UploadRequestCallback,
 } from './multiple_file_uploader/types';

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/multiple_file_uploader/MultipleFileUploader.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/multiple_file_uploader/MultipleFileUploader.tsx
@@ -20,6 +20,7 @@ import {LoadingMessage} from './LoadingMessage';
 import {
 	FailedFile,
 	FileData,
+	UploadBatchesCallback,
 	UploadMessages,
 	UploadRequestCallback,
 } from './types';
@@ -54,37 +55,9 @@ interface MultipleFileUploaderProps {
 		successFiles: string[];
 	}) => void;
 	scopeSelectorElement?: JSX.Element;
+	uploadBatches?: UploadBatchesCallback;
 	uploadRequest: UploadRequestCallback;
 	validExtensions?: string;
-}
-
-function getBaseName(filename: string): string {
-	const index = filename.lastIndexOf('.');
-
-	return index > 0 ? filename.substring(0, index) : filename;
-}
-
-function getUploadBatches(files: FileData[]): FileData[][] {
-	const batches: {baseNames: Set<string>; files: FileData[]}[] = [];
-
-	for (const fileData of files) {
-		const baseName = getBaseName(fileData.name);
-
-		const batch = batches.find((batch) => !batch.baseNames.has(baseName));
-
-		if (batch) {
-			batch.files.push(fileData);
-			batch.baseNames.add(baseName);
-		}
-		else {
-			batches.push({
-				baseNames: new Set([baseName]),
-				files: [fileData],
-			});
-		}
-	}
-
-	return batches.map((batch) => batch.files);
 }
 
 export default function MultipleFileUploader({
@@ -97,6 +70,7 @@ export default function MultipleFileUploader({
 	onModalClose,
 	onUploadComplete,
 	scopeSelectorElement,
+	uploadBatches = (files) => [files],
 	uploadRequest,
 	validExtensions = '*',
 }: MultipleFileUploaderProps) {
@@ -224,7 +198,7 @@ export default function MultipleFileUploader({
 		const failedFiles: FailedFile[] = [];
 		const uploadedFiles: string[] = [];
 
-		for (const uploadBatch of getUploadBatches(filesToUpload)) {
+		for (const uploadBatch of uploadBatches(filesToUpload)) {
 			await Promise.allSettled(
 				uploadBatch.map(async (fileData: FileData) => {
 					try {

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/multiple_file_uploader/types.ts
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/multiple_file_uploader/types.ts
@@ -18,6 +18,8 @@ export interface FailedFile {
 	size?: number;
 }
 
+export type UploadBatchesCallback = (files: FileData[]) => FileData[][];
+
 export type UploadRequestCallback = ({
 	fileData,
 }: {

--- a/modules/apps/frontend-js/frontend-js-components-web/test/multiple_file_uploader/MultipleFileUploader.test.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/test/multiple_file_uploader/MultipleFileUploader.test.tsx
@@ -13,6 +13,7 @@ import '@testing-library/jest-dom';
 import {checkAccessibility} from '@liferay/layout-js-components-web/test/__lib__/index';
 
 import MultipleFileUploader from '../../src/main/resources/META-INF/resources/multiple_file_uploader/MultipleFileUploader';
+import {UploadBatchesCallback} from '../../src/main/resources/META-INF/resources/multiple_file_uploader/types';
 
 jest.mock('frontend-js-web', () => ({
 	formatStorage: (str: string) => `${str} MB`,
@@ -436,61 +437,7 @@ describe('MultipleFileUploader', () => {
 	});
 
 	describe('batch upload', () => {
-		it('uploads files with the same base name in separate sequential batches', async () => {
-			const callOrder: string[] = [];
-			let resolveFirstBatch!: () => void;
-
-			const mockBatchRequest = jest.fn().mockImplementation(
-				({fileData}: {fileData: {name: string}}) =>
-					new Promise<{error: boolean}>((resolve) => {
-						callOrder.push(fileData.name);
-
-						if (fileData.name === 'A.pdf') {
-							resolveFirstBatch = () => resolve({error: false});
-						}
-						else {
-							resolve({error: false});
-						}
-					})
-			);
-
-			const {container} = render(
-				<MultipleFileUploader
-					{...DEFAULT_PROPS}
-					uploadRequest={mockBatchRequest}
-				/>
-			);
-
-			const input =
-				container.querySelector<HTMLInputElement>(
-					'input[type="file"]'
-				)!;
-
-			fireEvent.change(input, {
-				target: {
-					files: [
-						createFile('A.pdf', 1024),
-						createFile('A.txt', 1024),
-					],
-				},
-			});
-
-			expect(await screen.findByText('A.pdf')).toBeInTheDocument();
-
-			fireEvent.click(screen.getByRole('button', {name: /upload/i}));
-
-			await waitFor(() => expect(callOrder).toContain('A.pdf'));
-
-			expect(callOrder).not.toContain('A.txt');
-
-			resolveFirstBatch();
-
-			await waitFor(() => expect(callOrder).toContain('A.txt'));
-
-			await waitFor(() => expect(mockUploadComplete).toHaveBeenCalled());
-		});
-
-		it('uploads files with different base names in parallel within the same batch', async () => {
+		it('uploads all files in parallel by default', async () => {
 			const started: string[] = [];
 			let resolveFirst!: () => void;
 
@@ -524,7 +471,7 @@ describe('MultipleFileUploader', () => {
 				target: {
 					files: [
 						createFile('A.pdf', 1024),
-						createFile('B.pdf', 1024),
+						createFile('A.txt', 1024),
 					],
 				},
 			});
@@ -535,9 +482,67 @@ describe('MultipleFileUploader', () => {
 
 			await waitFor(() => expect(started).toContain('A.pdf'));
 
-			expect(started).toContain('B.pdf');
+			expect(started).toContain('A.txt');
 
 			resolveFirst();
+
+			await waitFor(() => expect(mockUploadComplete).toHaveBeenCalled());
+		});
+
+		it('uploads files sequentially when uploadBatches returns one file per batch', async () => {
+			const callOrder: string[] = [];
+			let resolveFirstBatch!: () => void;
+
+			const mockBatchRequest = jest.fn().mockImplementation(
+				({fileData}: {fileData: {name: string}}) =>
+					new Promise<{error: boolean}>((resolve) => {
+						callOrder.push(fileData.name);
+
+						if (fileData.name === 'A.pdf') {
+							resolveFirstBatch = () => resolve({error: false});
+						}
+						else {
+							resolve({error: false});
+						}
+					})
+			);
+
+			const sequentialUploadBatches: UploadBatchesCallback = (files) =>
+				files.map((file) => [file]);
+
+			const {container} = render(
+				<MultipleFileUploader
+					{...DEFAULT_PROPS}
+					uploadBatches={sequentialUploadBatches}
+					uploadRequest={mockBatchRequest}
+				/>
+			);
+
+			const input =
+				container.querySelector<HTMLInputElement>(
+					'input[type="file"]'
+				)!;
+
+			fireEvent.change(input, {
+				target: {
+					files: [
+						createFile('A.pdf', 1024),
+						createFile('B.pdf', 1024),
+					],
+				},
+			});
+
+			expect(await screen.findByText('A.pdf')).toBeInTheDocument();
+
+			fireEvent.click(screen.getByRole('button', {name: /upload/i}));
+
+			await waitFor(() => expect(callOrder).toContain('A.pdf'));
+
+			expect(callOrder).not.toContain('B.pdf');
+
+			resolveFirstBatch();
+
+			await waitFor(() => expect(callOrder).toContain('B.pdf'));
 
 			await waitFor(() => expect(mockUploadComplete).toHaveBeenCalled());
 		});

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/modal/ImportTranslationModalContent.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/modal/ImportTranslationModalContent.tsx
@@ -7,6 +7,7 @@ import ClayModal from '@clayui/modal';
 import {
 	FileData,
 	MultipleFileUploader,
+	UploadBatchesCallback,
 	UploadMessages,
 	openToast,
 } from 'frontend-js-components-web';
@@ -16,6 +17,9 @@ import React from 'react';
 import ApiHelper from '../../common/services/ApiHelper';
 
 const VALID_EXTENSIONS = '.xliff,.xlf,.zip';
+
+const sequentialUploadBatches: UploadBatchesCallback = (files) =>
+	files.map((file) => [file]);
 
 const IMPORT_MESSAGES: UploadMessages = {
 	anotherFileButton: Liferay.Language.get('import-another-file'),
@@ -143,6 +147,7 @@ export default function ImportTranslationModalContent({
 				messages={IMPORT_MESSAGES}
 				onModalClose={onModalClose}
 				onUploadComplete={onUploadComplete}
+				uploadBatches={sequentialUploadBatches}
 				uploadRequest={uploadRequest}
 				validExtensions={VALID_EXTENSIONS}
 			/>

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/modal/MultipleFilesUploadModalContent.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/modal/MultipleFilesUploadModalContent.tsx
@@ -8,6 +8,7 @@ import {
 	FieldBase,
 	FileData,
 	MultipleFileUploader,
+	UploadBatchesCallback,
 	UploadRequestCallback,
 	openToast,
 } from 'frontend-js-components-web';
@@ -18,6 +19,9 @@ import SpaceSelector from '../../common/components/SpaceSelector';
 import ApiHelper from '../../common/services/ApiHelper';
 import {AssetLibrary} from '../../common/types/AssetLibrary';
 import {Space} from '../../common/types/Space';
+
+const sequentialUploadBatches: UploadBatchesCallback = (files) =>
+	files.map((file) => [file]);
 
 export default function MultipleFilesUploadModalContent({
 	assetLibraries,
@@ -182,6 +186,7 @@ export default function MultipleFilesUploadModalContent({
 						</div>
 					) : undefined
 				}
+				uploadBatches={sequentialUploadBatches}
 				uploadRequest={uploadRequest}
 			/>
 		</>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87247

## What is being fixed

Concurrent multi-file uploads in CMS Files trigger a check-then-act race in the lazy creation of the per-user attachment folder, causing a PostgreSQL unique-constraint violation on `DLFolder(groupId, parentFolderId, name, ctCollectionId)`. The underlying backend race will be addressed in a separate ticket; this pull request introduces a frontend-side mitigation so the symptom no longer reaches users in the meantime.

## How it is being fixed

This pull request mitigates the race from the frontend by running uploads launched from site-cms-site-initializer one-at-a-time. The batching strategy in `MultipleFileUploader` is lifted out as an injectable `uploadBatches` callback (with an `UploadBatchesCallback` type). When no callback is provided the component now defaults to a single batch — all files in parallel. The two callers in site-cms-site-initializer (`MultipleFilesUploadModalContent` and `ImportTranslationModalContent`) opt into sequential behavior by passing a callback that returns one batch per file. The previous internal `getUploadBatches`/`getBaseName` helpers are removed; the unit tests that covered batching are rewritten to verify the new default (parallel) and the sequential opt-in.