### PR TITLE
LPD-79840 Apply quick-win visual improvements to the existing Clay Card component

### DIFF
--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_c-root.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_c-root.scss
@@ -220,6 +220,7 @@ $c-root: map-merge(
 
 		--border-radius-lg: 0.375rem,
 		--border-radius-sm: 0.1875rem,
+		--border-radius-xl: 1rem,
 
 		--rounded-0-border-radius: 0,
 		--rounded-border-radius: $border-radius,

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_cards.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_cards.scss
@@ -872,6 +872,12 @@ $card-interactive-secondary: map-deep-merge(
 $card-type-asset: () !default;
 $card-type-asset: map-deep-merge(
 	(
+		transition: $card-transition,
+
+		hover: (
+			transform: translateY(-0.25rem),
+		),
+
 		aspect-ratio: (
 			border-color: $gray-300,
 			border-style: solid,
@@ -1175,7 +1181,13 @@ $template-card-body: map-deep-merge(
 $template-card: () !default;
 $template-card: map-deep-merge(
 	(
+		transition: $card-transition,
+
 		card-body: $template-card-body,
+
+		hover: (
+			transform: translateY(-0.25rem),
+		),
 	),
 	$template-card
 );

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_cards.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_cards.scss
@@ -6,7 +6,7 @@ $card-border-color: var(
 $card-border-style: var(--card-border-style, solid) !default;
 $card-border-width: var(--card-border-width, 0px) !default;
 
-$card-border-radius: var(--card-border-radius, $border-radius) !default;
+$card-border-radius: var(--card-border-radius, $border-radius-xl) !default;
 $card-inner-border-radius: calc(
 	#{$card-border-radius} - #{$card-border-width}
 ) !default;

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_cards.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_cards.scss
@@ -1,20 +1,22 @@
 $card-bg: var(--card-bg, $white) !default;
 $card-border-color: var(
 	--card-border-color,
-	unquote('hsl(from #{$black} h s l / 0.125)')
+	unquote('hsl(from #{$secondary-l2} h s l / 0.125)')
 ) !default;
-$card-border-style: var(--card-border-style, solid) !default;
-$card-border-width: var(--card-border-width, 0px) !default;
-
 $card-border-radius: var(--card-border-radius, $border-radius-xl) !default;
+$card-border-style: var(--card-border-style, solid) !default;
+$card-border-width: var(--card-border-width, 1px) !default;
+
+$card-box-shadow: var(--card-box-shadow, none) !default;
+$card-hover-box-shadow: var(
+	--card-hover-box-shadow,
+	0 0.25rem 0.75rem -0.25rem unquote('hsl(from #{$black} h s l / 0.25)')
+) !default;
+
 $card-inner-border-radius: calc(
 	#{$card-border-radius} - #{$card-border-width}
 ) !default;
 
-$card-box-shadow: var(
-	--card-box-shadow,
-	0 1px 3px -1px rgba(0, 0, 0, 0.6)
-) !default;
 $card-color: var(--card-color, inherit) !default;
 $card-height: null !default;
 $card-margin-bottom: var(--card-margin-bottom, 24px) !default;
@@ -24,6 +26,10 @@ $card-spacer-y: var(--card-spacer-y, 12px) !default;
 
 $card-cap-bg: unquote('hsl(from #{$black} h s l / 0.03)') !default;
 $card-cap-color: null !default;
+
+$card-transitions:
+	$component-transition,
+	transform 0.15s ease-in-out !default;
 
 // .card-body
 
@@ -186,12 +192,15 @@ $card: map-deep-merge(
 		border-radius: clay-enable-rounded($card-border-radius),
 		border-style: $card-border-style,
 		border-width: $card-border-width,
-		box-shadow: clay-enable-shadows($card-box-shadow),
 		display: block,
 		height: $card-height,
 		margin-bottom: $card-margin-bottom,
 		min-width: 0,
+		outline-color: transparent,
+		outline-style: solid,
+		outline-width: $card-border-width,
 		position: relative,
+		transition: $card-transitions,
 		word-wrap: break-word,
 
 		aspect-ratio: (
@@ -215,6 +224,10 @@ $card: map-deep-merge(
 		hr: (
 			margin-left: 0,
 			margin-right: 0,
+		),
+
+		hover: (
+			box-shadow: clay-enable-shadows($card-hover-box-shadow),
 		),
 	),
 	$card
@@ -399,14 +412,9 @@ $checkbox-right-card-padding: var(
 
 $checkbox-position: var(--checkbox-position, 16px) !default;
 
-$form-check-card-checked-box-shadow: var(
-	--form-check-card-checked-box-shadow,
-	0 0 0 2px unquote('hsl(from #{$component-active-bg} h s calc(l + 22.94))')
-) !default;
-
 // .form-check-card
 
-$form-check-card-checked-box-shadow: $input-btn-focus-box-shadow !default;
+$form-check-card-checked-box-shadow: c-unset !default;
 
 $form-check-card: () !default;
 $form-check-card: map-deep-merge(
@@ -417,19 +425,22 @@ $form-check-card: map-deep-merge(
 
 		hover: (
 			card: (
-				box-shadow: $form-check-card-checked-box-shadow,
+				border-color: $primary-l1,
+				outline-color: $primary-l1,
 			),
 		),
 
 		active: (
 			card: (
-				box-shadow: $form-check-card-checked-box-shadow,
+				border-color: $primary,
+				outline-color: $primary,
 			),
 		),
 
 		checked: (
 			card: (
-				box-shadow: $form-check-card-checked-box-shadow,
+				border-color: $primary,
+				outline-color: $primary,
 			),
 		),
 
@@ -472,9 +483,11 @@ $form-check-card: map-deep-merge(
 			custom-control-input: (
 				z-index: 2,
 
-				checked: (
+				disabled: (
 					card: (
-						box-shadow: $form-check-card-checked-box-shadow,
+						box-shadow: none,
+						border-color: $card-border-color,
+						outline: none,
 					),
 				),
 			),
@@ -760,8 +773,8 @@ $card-interactive: () !default;
 $card-interactive: map-deep-merge(
 	(
 		cursor: $link-cursor,
-		outline: 0,
-		transition: $component-transition,
+		outline: c-unset,
+		transition: $card-transitions,
 
 		hover: (
 			background-color: #f7f8f9,
@@ -769,15 +782,19 @@ $card-interactive: map-deep-merge(
 		),
 
 		focus: (
-			box-shadow: #{0 0 0 2px #fff,
-			0 0 0 4px #719aff},
+			border-color: $primary-l1,
+			box-shadow: none,
+			outline-color: $primary-l1,
+			outline-offset: 0,
+			outline-style: solid,
+			outline-width: $card-border-width,
 		),
 
 		active: (
 			background-color: #f1f2f5,
 		),
 
-		after-highlight: $card-interactive-after-highlight,
+		after-highlight: c-unset,
 
 		card-body: $card-interactive-card-body,
 	),
@@ -807,15 +824,18 @@ $card-interactive-primary-after-highlight: map-deep-merge(
 $card-interactive-primary: () !default;
 $card-interactive-primary: map-deep-merge(
 	(
+		hover: (
+			box-shadow: $card-interactive-primary-box-shadow,
+		),
+
 		focus: (
-			background-color: $gray-100,
+			box-shadow: $card-interactive-primary-box-shadow,
 		),
 
 		active: (
-			background-color: $gray-200,
+			box-shadow: $card-interactive-primary-box-shadow,
 		),
-
-		after-highlight: $card-interactive-primary-after-highlight,
+		after-highlight: c-unset,
 	),
 	$card-interactive-primary
 );
@@ -830,13 +850,13 @@ $card-interactive-secondary: map-deep-merge(
 		hover: (
 			background-color: $white,
 			border-color: transparent,
-			box-shadow: 0 0 0 2px #719aff,
+			box-shadow: $card-hover-box-shadow,
 			color: $gray-900,
 		),
 
 		focus: (
 			border-color: transparent,
-			box-shadow: 0 0 0 2px #719aff,
+			box-shadow: $card-hover-box-shadow,
 		),
 
 		active: (

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_cards.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_cards.scss
@@ -1,8 +1,5 @@
 $card-bg: var(--card-bg, $white) !default;
-$card-border-color: var(
-	--card-border-color,
-	unquote('hsl(from #{$secondary-l2} h s l / 0.125)')
-) !default;
+$card-border-color: var(--card-border-color, $secondary-l2) !default;
 $card-border-radius: var(--card-border-radius, $border-radius-xl) !default;
 $card-border-style: var(--card-border-style, solid) !default;
 $card-border-width: var(--card-border-width, 1px) !default;
@@ -820,6 +817,10 @@ $card-interactive-primary-after-highlight: map-deep-merge(
 	),
 	$card-interactive-primary-after-highlight
 );
+
+$card-interactive-primary-box-shadow: unquote(
+	'#{$card-hover-box-shadow}, 0px -2.5rem 0px -2.25rem #{$primary} inset'
+) !default;
 
 $card-interactive-primary: () !default;
 $card-interactive-primary: map-deep-merge(

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_cards.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_cards.scss
@@ -24,7 +24,7 @@ $card-spacer-y: var(--card-spacer-y, 12px) !default;
 $card-cap-bg: unquote('hsl(from #{$black} h s l / 0.03)') !default;
 $card-cap-color: null !default;
 
-$card-transitions:
+$card-transition:
 	$component-transition,
 	transform 0.15s ease-in-out !default;
 
@@ -197,7 +197,7 @@ $card: map-deep-merge(
 		outline-style: solid,
 		outline-width: $card-border-width,
 		position: relative,
-		transition: $card-transitions,
+		transition: $card-transition,
 		word-wrap: break-word,
 
 		aspect-ratio: (
@@ -771,7 +771,7 @@ $card-interactive: map-deep-merge(
 	(
 		cursor: $link-cursor,
 		outline: c-unset,
-		transition: $card-transitions,
+		transition: $card-transition,
 
 		hover: (
 			background-color: #f7f8f9,

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_cards.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_cards.scss
@@ -13,7 +13,7 @@ $card-inner-border-radius: calc(
 
 $card-box-shadow: var(
 	--card-box-shadow,
-	0 0.25rem 1.5rem 0 rgba($black, 0.15)
+	0 1px 3px -1px rgba(0, 0, 0, 0.6)
 ) !default;
 $card-color: var(--card-color, inherit) !default;
 $card-height: null !default;
@@ -31,10 +31,6 @@ $card-body-padding-bottom: var(--card-body-padding-bottom, 16px) !default;
 $card-body-padding-left: var(--card-body-padding-left, 16px) !default;
 $card-body-padding-right: var(--card-body-padding-right, 16px) !default;
 $card-body-padding-top: var(--card-body-padding-top, 16px) !default;
-
-$card-transition:
-	$component-transition,
-	transform 0.15s ease-in-out !default;
 
 // `flex` enable `flex-grow: 1` for decks and groups so that card blocks take up
 // as much space as possible, ensuring footers are aligned to the bottom.
@@ -190,7 +186,7 @@ $card: map-deep-merge(
 		border-radius: clay-enable-rounded($card-border-radius),
 		border-style: $card-border-style,
 		border-width: $card-border-width,
-		box-shadow: none,
+		box-shadow: clay-enable-shadows($card-box-shadow),
 		display: block,
 		height: $card-height,
 		margin-bottom: $card-margin-bottom,
@@ -410,7 +406,7 @@ $form-check-card-checked-box-shadow: var(
 
 // .form-check-card
 
-$form-check-card-checked-box-shadow: none !default;
+$form-check-card-checked-box-shadow: $input-btn-focus-box-shadow !default;
 
 $form-check-card: () !default;
 $form-check-card: map-deep-merge(
@@ -418,38 +414,22 @@ $form-check-card: map-deep-merge(
 		margin-bottom: $card-margin-bottom,
 		margin-top: 0rem,
 		padding-left: 0rem,
-		transition: transform 0.15s ease-in-out,
 
 		hover: (
 			card: (
-				border-color: $primary-l1,
-				box-shadow: $card-box-shadow,
-				outline-color: $primary-l1,
-				outline-style: solid,
-				outline-width: $border-width,
-				transform: none,
+				box-shadow: $form-check-card-checked-box-shadow,
 			),
-
-			transform: translateY(-0.75rem),
 		),
 
 		active: (
 			card: (
-				border-color: $primary,
-				box-shadow: null,
-				outline-color: $primary,
-				outline-style: solid,
-				outline-width: $border-width,
+				box-shadow: $form-check-card-checked-box-shadow,
 			),
 		),
 
 		checked: (
 			card: (
-				border-color: $primary,
-				box-shadow: null,
-				outline-color: $primary,
-				outline-style: solid,
-				outline-width: $border-width,
+				box-shadow: $form-check-card-checked-box-shadow,
 			),
 		),
 
@@ -494,7 +474,7 @@ $form-check-card: map-deep-merge(
 
 				checked: (
 					card: (
-						box-shadow: null,
+						box-shadow: $form-check-card-checked-box-shadow,
 					),
 				),
 			),
@@ -722,6 +702,52 @@ $form-check-top-left: map-deep-merge(
 
 // Card Interactive
 
+$card-interactive-after-highlight: () !default;
+$card-interactive-after-highlight: map-deep-merge(
+	(
+		border-radius:
+			var(
+				--card-interactive-after-highlight-border-radius,
+				0 0 $card-border-radius $card-border-radius
+			),
+		bottom:
+			var(
+				--card-interactive-after-highlight-bottom,
+				calc(#{$card-border-width} * -1)
+			),
+		content: '',
+		height: var(--card-interactive-after-highlight-height, 0),
+		left:
+			var(
+				--card-interactive-after-highlight-left,
+				calc(#{$card-border-width} * -1)
+			),
+		position: var(--card-interactive-after-highlight-position, absolute),
+		right:
+			var(
+				--card-interactive-after-highlight-right,
+				calc(#{$card-border-width} * -1)
+			),
+		transition:
+			var(
+				--card-interactive-after-highlight-transition,
+				height 0.15s ease-out
+			),
+		hover: (
+			height: var(--card-interactive-after-highlight-hover-height, 4px),
+		),
+
+		focus: (
+			height: var(--card-interactive-after-highlight-focus-height, 4px),
+		),
+
+		active: (
+			height: var(--card-interactive-after-highlight-active-height, 4px),
+		),
+	),
+	$card-interactive-after-highlight
+);
+
 $card-interactive-card-body: () !default;
 $card-interactive-card-body: map-deep-merge(
 	(
@@ -735,7 +761,7 @@ $card-interactive: map-deep-merge(
 	(
 		cursor: $link-cursor,
 		outline: 0,
-		transition: $card-transition,
+		transition: $component-transition,
 
 		hover: (
 			background-color: #f7f8f9,
@@ -743,14 +769,15 @@ $card-interactive: map-deep-merge(
 		),
 
 		focus: (
-			box-shadow: $component-focus-box-shadow,
+			box-shadow: #{0 0 0 2px #fff,
+			0 0 0 4px #719aff},
 		),
 
 		active: (
 			background-color: #f1f2f5,
 		),
 
-		after-highlight: null,
+		after-highlight: $card-interactive-after-highlight,
 
 		card-body: $card-interactive-card-body,
 	),
@@ -759,14 +786,27 @@ $card-interactive: map-deep-merge(
 
 // Card Interactive Primary
 
+$card-interactive-primary-after-highlight: () !default;
+$card-interactive-primary-after-highlight: map-deep-merge(
+	(
+		hover: (
+			background-color: $component-active-bg,
+		),
+
+		focus: (
+			background-color: $component-active-bg,
+		),
+
+		active: (
+			background-color: $component-active-bg,
+		),
+	),
+	$card-interactive-primary-after-highlight
+);
+
 $card-interactive-primary: () !default;
 $card-interactive-primary: map-deep-merge(
 	(
-		hover: (
-			box-shadow:
-				'#{$card-box-shadow}, 0px -2.5rem 0px -2.25rem #{$primary} inset',
-		),
-
 		focus: (
 			background-color: $gray-100,
 		),
@@ -774,6 +814,8 @@ $card-interactive-primary: map-deep-merge(
 		active: (
 			background-color: $gray-200,
 		),
+
+		after-highlight: $card-interactive-primary-after-highlight,
 	),
 	$card-interactive-primary
 );
@@ -787,14 +829,14 @@ $card-interactive-secondary: map-deep-merge(
 
 		hover: (
 			background-color: $white,
-			border-color: null,
-			box-shadow: null,
+			border-color: transparent,
+			box-shadow: 0 0 0 2px #719aff,
 			color: $gray-900,
 		),
 
 		focus: (
-			border-color: null,
-			box-shadow: null,
+			border-color: transparent,
+			box-shadow: 0 0 0 2px #719aff,
 		),
 
 		active: (

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_cards.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_cards.scss
@@ -13,7 +13,7 @@ $card-inner-border-radius: calc(
 
 $card-box-shadow: var(
 	--card-box-shadow,
-	0 1px 3px -1px rgba(0, 0, 0, 0.6)
+	0 0.25rem 1.5rem 0 rgba($black, 0.15)
 ) !default;
 $card-color: var(--card-color, inherit) !default;
 $card-height: null !default;
@@ -31,6 +31,10 @@ $card-body-padding-bottom: var(--card-body-padding-bottom, 16px) !default;
 $card-body-padding-left: var(--card-body-padding-left, 16px) !default;
 $card-body-padding-right: var(--card-body-padding-right, 16px) !default;
 $card-body-padding-top: var(--card-body-padding-top, 16px) !default;
+
+$card-transition:
+	$component-transition,
+	transform 0.15s ease-in-out !default;
 
 // `flex` enable `flex-grow: 1` for decks and groups so that card blocks take up
 // as much space as possible, ensuring footers are aligned to the bottom.
@@ -186,7 +190,7 @@ $card: map-deep-merge(
 		border-radius: clay-enable-rounded($card-border-radius),
 		border-style: $card-border-style,
 		border-width: $card-border-width,
-		box-shadow: clay-enable-shadows($card-box-shadow),
+		box-shadow: none,
 		display: block,
 		height: $card-height,
 		margin-bottom: $card-margin-bottom,
@@ -406,7 +410,7 @@ $form-check-card-checked-box-shadow: var(
 
 // .form-check-card
 
-$form-check-card-checked-box-shadow: $input-btn-focus-box-shadow !default;
+$form-check-card-checked-box-shadow: none !default;
 
 $form-check-card: () !default;
 $form-check-card: map-deep-merge(
@@ -414,22 +418,38 @@ $form-check-card: map-deep-merge(
 		margin-bottom: $card-margin-bottom,
 		margin-top: 0rem,
 		padding-left: 0rem,
+		transition: transform 0.15s ease-in-out,
 
 		hover: (
 			card: (
-				box-shadow: $form-check-card-checked-box-shadow,
+				border-color: $primary-l1,
+				box-shadow: $card-box-shadow,
+				outline-color: $primary-l1,
+				outline-style: solid,
+				outline-width: $border-width,
+				transform: none,
 			),
+
+			transform: translateY(-0.75rem),
 		),
 
 		active: (
 			card: (
-				box-shadow: $form-check-card-checked-box-shadow,
+				border-color: $primary,
+				box-shadow: null,
+				outline-color: $primary,
+				outline-style: solid,
+				outline-width: $border-width,
 			),
 		),
 
 		checked: (
 			card: (
-				box-shadow: $form-check-card-checked-box-shadow,
+				border-color: $primary,
+				box-shadow: null,
+				outline-color: $primary,
+				outline-style: solid,
+				outline-width: $border-width,
 			),
 		),
 
@@ -474,7 +494,7 @@ $form-check-card: map-deep-merge(
 
 				checked: (
 					card: (
-						box-shadow: $form-check-card-checked-box-shadow,
+						box-shadow: null,
 					),
 				),
 			),
@@ -702,52 +722,6 @@ $form-check-top-left: map-deep-merge(
 
 // Card Interactive
 
-$card-interactive-after-highlight: () !default;
-$card-interactive-after-highlight: map-deep-merge(
-	(
-		border-radius:
-			var(
-				--card-interactive-after-highlight-border-radius,
-				0 0 $card-border-radius $card-border-radius
-			),
-		bottom:
-			var(
-				--card-interactive-after-highlight-bottom,
-				calc(#{$card-border-width} * -1)
-			),
-		content: '',
-		height: var(--card-interactive-after-highlight-height, 0),
-		left:
-			var(
-				--card-interactive-after-highlight-left,
-				calc(#{$card-border-width} * -1)
-			),
-		position: var(--card-interactive-after-highlight-position, absolute),
-		right:
-			var(
-				--card-interactive-after-highlight-right,
-				calc(#{$card-border-width} * -1)
-			),
-		transition:
-			var(
-				--card-interactive-after-highlight-transition,
-				height 0.15s ease-out
-			),
-		hover: (
-			height: var(--card-interactive-after-highlight-hover-height, 4px),
-		),
-
-		focus: (
-			height: var(--card-interactive-after-highlight-focus-height, 4px),
-		),
-
-		active: (
-			height: var(--card-interactive-after-highlight-active-height, 4px),
-		),
-	),
-	$card-interactive-after-highlight
-);
-
 $card-interactive-card-body: () !default;
 $card-interactive-card-body: map-deep-merge(
 	(
@@ -761,7 +735,7 @@ $card-interactive: map-deep-merge(
 	(
 		cursor: $link-cursor,
 		outline: 0,
-		transition: $component-transition,
+		transition: $card-transition,
 
 		hover: (
 			background-color: #f7f8f9,
@@ -769,15 +743,14 @@ $card-interactive: map-deep-merge(
 		),
 
 		focus: (
-			box-shadow: #{0 0 0 2px #fff,
-			0 0 0 4px #719aff},
+			box-shadow: $component-focus-box-shadow,
 		),
 
 		active: (
 			background-color: #f1f2f5,
 		),
 
-		after-highlight: $card-interactive-after-highlight,
+		after-highlight: null,
 
 		card-body: $card-interactive-card-body,
 	),
@@ -786,27 +759,14 @@ $card-interactive: map-deep-merge(
 
 // Card Interactive Primary
 
-$card-interactive-primary-after-highlight: () !default;
-$card-interactive-primary-after-highlight: map-deep-merge(
-	(
-		hover: (
-			background-color: $component-active-bg,
-		),
-
-		focus: (
-			background-color: $component-active-bg,
-		),
-
-		active: (
-			background-color: $component-active-bg,
-		),
-	),
-	$card-interactive-primary-after-highlight
-);
-
 $card-interactive-primary: () !default;
 $card-interactive-primary: map-deep-merge(
 	(
+		hover: (
+			box-shadow:
+				'#{$card-box-shadow}, 0px -2.5rem 0px -2.25rem #{$primary} inset',
+		),
+
 		focus: (
 			background-color: $gray-100,
 		),
@@ -814,8 +774,6 @@ $card-interactive-primary: map-deep-merge(
 		active: (
 			background-color: $gray-200,
 		),
-
-		after-highlight: $card-interactive-primary-after-highlight,
 	),
 	$card-interactive-primary
 );
@@ -829,14 +787,14 @@ $card-interactive-secondary: map-deep-merge(
 
 		hover: (
 			background-color: $white,
-			border-color: transparent,
-			box-shadow: 0 0 0 2px #719aff,
+			border-color: null,
+			box-shadow: null,
 			color: $gray-900,
 		),
 
 		focus: (
-			border-color: transparent,
-			box-shadow: 0 0 0 2px #719aff,
+			border-color: null,
+			box-shadow: null,
 		),
 
 		active: (

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_globals.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_globals.scss
@@ -319,6 +319,7 @@ $border-radius: var(--border-radius) !default;
 
 $border-radius-lg: var(--border-radius-lg) !default;
 $border-radius-sm: var(--border-radius-sm) !default;
+$border-radius-xl: var(--border-radius-xl) !default;
 
 $rounded-0-border-radius: var(--rounded-0-border-radius) !default;
 $rounded-border-radius: var(--rounded-border-radius) !default;

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas/variables/_cards.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas/variables/_cards.scss
@@ -3,7 +3,7 @@ $card-border-radius: $border-radius-xl !default;
 $card-border-width: $border-width !default;
 
 $card-box-shadow: c-unset !default;
-$card-hover-box-shadow: 0 0.25rem 0.75rem -0.25rem unquote('hsl(from #{$black} h s l / 0.25)') !default;
+$card-hover-box-shadow: 0 0.25rem 0.75rem -0.25rem unquote('rgb(from #{$black} r g b / 0.25)') !default;
 
 $card-body-padding-bottom: 1rem !default;
 $card-body-padding-left: 1rem !default;

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas/variables/_cards.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas/variables/_cards.scss
@@ -102,7 +102,6 @@ $form-check-card: map-deep-merge(
 		transition: transform 0.15s ease-in-out,
 
 		hover: (
-			transform: translateY(-0.75rem),
 			card: (
 				border-color: $primary-l1,
 				box-shadow: $card-box-shadow,
@@ -111,6 +110,8 @@ $form-check-card: map-deep-merge(
 				outline-width: $border-width,
 				transform: none,
 			),
+
+			transform: translateY(-0.75rem),
 		),
 
 		active: (
@@ -167,8 +168,23 @@ $card-interactive: map-deep-merge(
 		active: (
 			background-color: #f1f2f5,
 		),
+
+		after-highlight: null,
 	),
 	$card-interactive
+);
+
+// Card Interactive Primary
+
+$card-interactive-primary: () !default;
+$card-interactive-primary: map-deep-merge(
+	(
+		hover: (
+			box-shadow:
+				'#{$card-box-shadow}, 0px -2.5rem 0px -2.25rem #{$primary} inset',
+		),
+	),
+	$card-interactive-primary
 );
 
 // Card Interactive Secondary
@@ -177,13 +193,13 @@ $card-interactive-secondary: () !default;
 $card-interactive-secondary: map-deep-merge(
 	(
 		hover: (
-			border-color: transparent,
-			box-shadow: 0 0 0 2px $primary-l0,
+			border-color: null,
+			box-shadow: null,
 		),
 
 		focus: (
-			border-color: transparent,
-			box-shadow: 0 0 0 2px $primary-l0,
+			border-color: null,
+			box-shadow: null,
 		),
 	),
 	$card-interactive-secondary

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas/variables/_cards.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas/variables/_cards.scss
@@ -1,16 +1,11 @@
-$card-border-color: $secondary-l2 !default;
 $card-border-radius: $border-radius-xl !default;
-$card-border-width: $border-width !default;
-$card-box-shadow: 0 0.25rem 1.5rem 0 rgba($black, 0.15) !default;
+$card-border-width: 0px !default;
+$card-box-shadow: 0 1px 3px -1px rgba(0, 0, 0, 0.6) !default;
 
 $card-body-padding-bottom: 1rem !default;
 $card-body-padding-left: 1rem !default;
 $card-body-padding-right: 1rem !default;
 $card-body-padding-top: 1rem !default;
-
-$card-transition:
-	$component-transition,
-	transform 0.15s ease-in-out !default;
 
 $card-inner-border-radius: calc(
 	#{$card-border-radius} - #{$card-border-width}
@@ -23,13 +18,7 @@ $card: map-deep-merge(
 	(
 		border-radius: clay-enable-rounded($card-border-radius),
 		border-width: $card-border-width,
-		box-shadow: none,
-		transition: clay-enable-transitions($card-transition),
-
-		hover: (
-			box-shadow: $card-box-shadow,
-			transform: translateY(-0.75rem),
-		),
+		box-shadow: clay-enable-shadows($card-box-shadow),
 	),
 	$card
 );
@@ -93,70 +82,14 @@ $card-link: map-deep-merge(
 
 $checkbox-left-card-padding: 50px !default;
 
-// .form-check-card
-
-$form-check-card-checked-box-shadow: none !default;
-
-$form-check-card: () !default;
-$form-check-card: map-deep-merge(
-	(
-		transition: transform 0.15s ease-in-out,
-
-		hover: (
-			card: (
-				border-color: $primary-l1,
-				box-shadow: $card-box-shadow,
-				outline-color: $primary-l1,
-				outline-style: solid,
-				outline-width: $border-width,
-				transform: none,
-			),
-
-			transform: translateY(-0.75rem),
-		),
-
-		active: (
-			card: (
-				border-color: $primary,
-				box-shadow: null,
-				outline-color: $primary,
-				outline-style: solid,
-				outline-width: $border-width,
-			),
-		),
-
-		checked: (
-			card: (
-				border-color: $primary,
-				box-shadow: null,
-				outline-color: $primary,
-				outline-style: solid,
-				outline-width: $border-width,
-			),
-		),
-
-		custom-control: (
-			display: inline,
-
-			custom-control-input: (
-				checked: (
-					card: (
-						box-shadow: null,
-					),
-				),
-			),
-		),
-	),
-	$form-check-card
-);
+$form-check-card-checked-box-shadow: 0 0 0 2px
+	clay-lighten($component-active-bg, 22.94) !default;
 
 // Card Interactive
 
 $card-interactive: () !default;
 $card-interactive: map-deep-merge(
 	(
-		transition: $card-transition,
-
 		hover: (
 			background-color: #f7f8f9,
 		),
@@ -169,23 +102,8 @@ $card-interactive: map-deep-merge(
 		active: (
 			background-color: #f1f2f5,
 		),
-
-		after-highlight: null,
 	),
 	$card-interactive
-);
-
-// Card Interactive Primary
-
-$card-interactive-primary: () !default;
-$card-interactive-primary: map-deep-merge(
-	(
-		hover: (
-			box-shadow:
-				'#{$card-box-shadow}, 0px -2.5rem 0px -2.25rem #{$primary} inset',
-		),
-	),
-	$card-interactive-primary
 );
 
 // Card Interactive Secondary
@@ -194,13 +112,13 @@ $card-interactive-secondary: () !default;
 $card-interactive-secondary: map-deep-merge(
 	(
 		hover: (
-			border-color: null,
-			box-shadow: null,
+			border-color: transparent,
+			box-shadow: 0 0 0 2px $primary-l0,
 		),
 
 		focus: (
-			border-color: null,
-			box-shadow: null,
+			border-color: transparent,
+			box-shadow: 0 0 0 2px $primary-l0,
 		),
 	),
 	$card-interactive-secondary

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas/variables/_cards.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas/variables/_cards.scss
@@ -1,11 +1,16 @@
+$card-border-color: $secondary-l2 !default;
 $card-border-radius: $border-radius-xl !default;
-$card-border-width: 0px !default;
-$card-box-shadow: 0 1px 3px -1px rgba(0, 0, 0, 0.6) !default;
+$card-border-width: $border-width !default;
+$card-box-shadow: 0 0.25rem 1.5rem 0 rgba($black, 0.15) !default;
 
 $card-body-padding-bottom: 1rem !default;
 $card-body-padding-left: 1rem !default;
 $card-body-padding-right: 1rem !default;
 $card-body-padding-top: 1rem !default;
+
+$card-transition:
+	$component-transition,
+	transform 0.15s ease-in-out !default;
 
 $card-inner-border-radius: calc(
 	#{$card-border-radius} - #{$card-border-width}
@@ -18,7 +23,12 @@ $card: map-deep-merge(
 	(
 		border-radius: clay-enable-rounded($card-border-radius),
 		border-width: $card-border-width,
-		box-shadow: clay-enable-shadows($card-box-shadow),
+		box-shadow: none,
+		transition: clay-enable-transitions($card-transition),
+		hover: (
+			box-shadow: $card-box-shadow,
+			transform: translateY(-0.75rem),
+		),
 	),
 	$card
 );
@@ -82,14 +92,69 @@ $card-link: map-deep-merge(
 
 $checkbox-left-card-padding: 50px !default;
 
-$form-check-card-checked-box-shadow: 0 0 0 2px
-	clay-lighten($component-active-bg, 22.94) !default;
+// .form-check-card
+
+$form-check-card-checked-box-shadow: none !default;
+
+$form-check-card: () !default;
+$form-check-card: map-deep-merge(
+	(
+		transition: transform 0.15s ease-in-out,
+
+		hover: (
+			transform: translateY(-0.75rem),
+			card: (
+				border-color: $primary-l1,
+				box-shadow: $card-box-shadow,
+				outline-color: $primary-l1,
+				outline-style: solid,
+				outline-width: $border-width,
+				transform: none,
+			),
+		),
+
+		active: (
+			card: (
+				border-color: $primary,
+				box-shadow: null,
+				outline-color: $primary,
+				outline-style: solid,
+				outline-width: $border-width,
+			),
+		),
+
+		checked: (
+			card: (
+				border-color: $primary,
+				box-shadow: null,
+				outline-color: $primary,
+				outline-style: solid,
+				outline-width: $border-width,
+			),
+		),
+
+		custom-control: (
+			display: inline,
+
+			custom-control-input: (
+				checked: (
+					card: (
+						box-shadow: null,
+					),
+				),
+			),
+		),
+	),
+	$form-check-card
+);
 
 // Card Interactive
 
 $card-interactive: () !default;
 $card-interactive: map-deep-merge(
 	(
+		transition: $card-transition,
+
 		hover: (
 			background-color: #f7f8f9,
 		),

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas/variables/_cards.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas/variables/_cards.scss
@@ -25,6 +25,7 @@ $card: map-deep-merge(
 		border-width: $card-border-width,
 		box-shadow: none,
 		transition: clay-enable-transitions($card-transition),
+
 		hover: (
 			box-shadow: $card-box-shadow,
 			transform: translateY(-0.75rem),

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas/variables/_cards.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas/variables/_cards.scss
@@ -214,6 +214,12 @@ $card-interactive-secondary: map-deep-merge(
 $card-type-asset: () !default;
 $card-type-asset: map-deep-merge(
 	(
+		transition: $card-transition,
+
+		hover: (
+			transform: translateY(-0.25rem),
+		),
+
 		aspect-ratio: (
 			border-color: $gray-300,
 		),
@@ -223,6 +229,20 @@ $card-type-asset: map-deep-merge(
 		),
 	),
 	$card-type-asset
+);
+
+// Template Card
+
+$template-card: () !default;
+$template-card: map-deep-merge(
+	(
+		transition: $card-transition,
+
+		hover: (
+			transform: translateY(-0.25rem),
+		),
+	),
+	$template-card
 );
 
 $image-card: () !default;

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas/variables/_cards.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas/variables/_cards.scss
@@ -1,8 +1,9 @@
 $card-border-color: $secondary-l2 !default;
 $card-border-radius: $border-radius-xl !default;
 $card-border-width: $border-width !default;
+
 $card-box-shadow: c-unset !default;
-$card-hover-box-shadow: 0 0.25rem 0.75rem -0.25rem unquote('rgb(from #{$black} r g b / 0.25)') !default;
+$card-hover-box-shadow: 0 0.25rem 0.75rem -0.25rem unquote('hsl(from #{$black} h s l / 0.25)') !default;
 
 $card-body-padding-bottom: 1rem !default;
 $card-body-padding-left: 1rem !default;

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas/variables/_cards.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas/variables/_cards.scss
@@ -2,8 +2,7 @@ $card-border-color: $secondary-l2 !default;
 $card-border-radius: $border-radius-xl !default;
 $card-border-width: $border-width !default;
 $card-box-shadow: c-unset !default;
-$card-hover-box-shadow: 0 0.25rem 1.5rem 0
-	unquote('rgb(from #{$black} r g b / 0.25)') !default;
+$card-hover-box-shadow: 0 0.25rem 0.75rem -0.25rem unquote('rgb(from #{$black} r g b / 0.25)') !default;
 
 $card-body-padding-bottom: 1rem !default;
 $card-body-padding-left: 1rem !default;
@@ -145,6 +144,7 @@ $card-interactive: () !default;
 $card-interactive: map-deep-merge(
 	(
 		outline: c-unset,
+		transition: $card-transitions,
 
 		hover: (
 			background-color: #f7f8f9,

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas/variables/_cards.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas/variables/_cards.scss
@@ -1,4 +1,4 @@
-$card-border-radius: $border-radius !default;
+$card-border-radius: $border-radius-xl !default;
 $card-border-width: 0px !default;
 $card-box-shadow: 0 1px 3px -1px rgba(0, 0, 0, 0.6) !default;
 

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas/variables/_cards.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas/variables/_cards.scss
@@ -1,6 +1,9 @@
 $card-border-color: $secondary-l2 !default;
 $card-border-radius: $border-radius-xl !default;
 $card-border-width: $border-width !default;
+$card-box-shadow: c-unset !default;
+$card-hover-box-shadow: 0 0.25rem 1.5rem 0
+	unquote('rgb(from #{$black} r g b / 0.25)') !default;
 
 $card-body-padding-bottom: 1rem !default;
 $card-body-padding-left: 1rem !default;
@@ -11,6 +14,10 @@ $card-inner-border-radius: calc(
 	#{$card-border-radius} - #{$card-border-width}
 ) !default;
 
+$card-transitions:
+	$component-transition,
+	transform 0.15s ease-in-out !default;
+
 // min-width, see https://github.com/twbs/bootstrap/pull/22740#issuecomment-305868106
 
 $card: () !default;
@@ -18,7 +25,14 @@ $card: map-deep-merge(
 	(
 		border-radius: clay-enable-rounded($card-border-radius),
 		border-width: $card-border-width,
-		box-shadow: $c-unset,
+		outline-color: transparent,
+		outline-style: solid,
+		outline-width: $card-border-width,
+		transition: $card-transitions,
+
+		hover: (
+			box-shadow: clay-enable-shadows($card-hover-box-shadow),
+		),
 	),
 	$card
 );
@@ -82,21 +96,67 @@ $card-link: map-deep-merge(
 
 $checkbox-left-card-padding: 50px !default;
 
-$form-check-card-checked-box-shadow: 0 0 0 2px
-	clay-lighten($component-active-bg, 22.94) !default;
+// .form-check-card
+
+$form-check-card-checked-box-shadow: c-unset !default;
+
+$form-check-card: () !default;
+$form-check-card: map-deep-merge(
+	(
+		hover: (
+			card: (
+				border-color: $primary-l1,
+				outline-color: $primary-l1,
+			),
+		),
+
+		active: (
+			card: (
+				border-color: $primary,
+				outline-color: $primary,
+			),
+		),
+
+		checked: (
+			card: (
+				border-color: $primary,
+				outline-color: $primary,
+			),
+		),
+
+		custom-control: (
+			custom-control-input: (
+				disabled: (
+					card: (
+						box-shadow: none,
+						border-color: $card-border-color,
+						outline: none,
+					),
+				),
+			),
+		),
+	),
+	$form-check-card
+);
 
 // Card Interactive
 
 $card-interactive: () !default;
 $card-interactive: map-deep-merge(
 	(
+		outline: c-unset,
+
 		hover: (
 			background-color: #f7f8f9,
 		),
 
 		focus: (
-			border-color: null,
-			box-shadow: $component-focus-box-shadow,
+			border-color: $primary-l1,
+			box-shadow: none,
+			outline-color: $primary-l1,
+			outline-offset: 0,
+			outline-style: solid,
+			outline-width: $card-border-width,
 		),
 
 		active: (
@@ -106,6 +166,14 @@ $card-interactive: map-deep-merge(
 	$card-interactive
 );
 
+$card-interactive-primary: () !default;
+$card-interactive-primary: map-deep-merge(
+	(
+		after-highlight: c-unset,
+	),
+	$card-interactive-primary
+);
+
 // Card Interactive Secondary
 
 $card-interactive-secondary: () !default;
@@ -113,12 +181,12 @@ $card-interactive-secondary: map-deep-merge(
 	(
 		hover: (
 			border-color: transparent,
-			box-shadow: 0 0 0 2px $primary-l0,
+			box-shadow: $card-hover-box-shadow,
 		),
 
 		focus: (
 			border-color: transparent,
-			box-shadow: 0 0 0 2px $primary-l0,
+			box-shadow: $card-hover-box-shadow,
 		),
 	),
 	$card-interactive-secondary

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas/variables/_cards.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas/variables/_cards.scss
@@ -166,9 +166,25 @@ $card-interactive: map-deep-merge(
 	$card-interactive
 );
 
+$card-interactive-primary-box-shadow: unquote(
+	'#{$card-hover-box-shadow}, 0px -2.5rem 0px -2.25rem #{$primary} inset'
+) !default;
+
 $card-interactive-primary: () !default;
 $card-interactive-primary: map-deep-merge(
 	(
+		hover: (
+			box-shadow: $card-interactive-primary-box-shadow,
+		),
+
+		focus: (
+			box-shadow: $card-interactive-primary-box-shadow,
+		),
+
+		active: (
+			box-shadow: $card-interactive-primary-box-shadow,
+		),
+
 		after-highlight: c-unset,
 	),
 	$card-interactive-primary

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas/variables/_cards.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas/variables/_cards.scss
@@ -1,6 +1,6 @@
+$card-border-color: $secondary-l2 !default;
 $card-border-radius: $border-radius-xl !default;
-$card-border-width: 0px !default;
-$card-box-shadow: 0 1px 3px -1px rgba(0, 0, 0, 0.6) !default;
+$card-border-width: $border-width !default;
 
 $card-body-padding-bottom: 1rem !default;
 $card-body-padding-left: 1rem !default;
@@ -18,7 +18,7 @@ $card: map-deep-merge(
 	(
 		border-radius: clay-enable-rounded($card-border-radius),
 		border-width: $card-border-width,
-		box-shadow: clay-enable-shadows($card-box-shadow),
+		box-shadow: $c-unset,
 	),
 	$card
 );
@@ -186,13 +186,4 @@ $card-type-template-aspect-ratio-item: map-deep-merge(
 		color: $gray-600,
 	),
 	$card-type-template-aspect-ratio-item
-);
-
-$card-type-template: () !default;
-$card-type-template: map-deep-merge(
-	(
-		border-width: 1px,
-		box-shadow: none,
-	),
-	$card-type-template
 );

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas/variables/_cards.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas/variables/_cards.scss
@@ -14,7 +14,7 @@ $card-inner-border-radius: calc(
 	#{$card-border-radius} - #{$card-border-width}
 ) !default;
 
-$card-transitions:
+$card-transition:
 	$component-transition,
 	transform 0.15s ease-in-out !default;
 
@@ -28,7 +28,7 @@ $card: map-deep-merge(
 		outline-color: transparent,
 		outline-style: solid,
 		outline-width: $card-border-width,
-		transition: $card-transitions,
+		transition: $card-transition,
 
 		hover: (
 			box-shadow: clay-enable-shadows($card-hover-box-shadow),
@@ -145,7 +145,7 @@ $card-interactive: () !default;
 $card-interactive: map-deep-merge(
 	(
 		outline: c-unset,
-		transition: $card-transitions,
+		transition: $card-transition,
 
 		hover: (
 			background-color: #f7f8f9,

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas/variables/_globals.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas/variables/_globals.scss
@@ -386,6 +386,7 @@ $border-width: 0.0625rem !default;
 $border-radius: 0.25rem !default; // 4px
 $border-radius-lg: 0.375rem !default; // 6px
 $border-radius-sm: 0.1875rem !default; // 3px
+$border-radius-xl: 1rem !default; // 16px
 
 $rounded-0-border-radius: 0px !default;
 $rounded-border-radius: $border-radius !default;

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/components/_cards.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/components/_cards.scss
@@ -351,18 +351,10 @@
 		position: static;
 	}
 
-	&.active .card,
-	.custom-control-input:checked ~ .card,
-	.form-check-input:checked ~ .card {
-		box-shadow: $cadmin-form-check-card-checked-box-shadow;
-	}
-}
-
-.form-check-card {
-	&:hover {
+	&:not(.active):has(.custom-control-input:is(:disabled, .disabled)):hover
 		.card {
-			box-shadow: $cadmin-form-check-card-checked-box-shadow;
-		}
+		border-color: $secondary-l2;
+		outline: none;
 	}
 }
 

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/components/_cards.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/components/_cards.scss
@@ -25,10 +25,6 @@
 	}
 }
 
-.card:not(:is(.card-horizontal, .template-card-horizontal)):hover {
-	transform: translateY(-0.25rem);
-}
-
 .card-body {
 	@include clay-css($cadmin-card-body);
 }
@@ -368,14 +364,14 @@
 	}
 
 	&:has(.custom-control-input:is(.disabled, :disabled, [disabled])) {
+		&:hover {
+			transform: none;
+		}
+
 		.card {
 			box-shadow: none;
 			border-color: $cadmin-card-border-color;
 			outline: none;
-		}
-
-		&:hover .card {
-			transform: none;
 		}
 	}
 }

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/components/_cards.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/components/_cards.scss
@@ -351,10 +351,18 @@
 		position: static;
 	}
 
-	&:not(.active):has(.custom-control-input:is(:disabled, .disabled)):hover
+	&.active .card,
+	.custom-control-input:checked ~ .card,
+	.form-check-input:checked ~ .card {
+		box-shadow: $cadmin-form-check-card-checked-box-shadow;
+	}
+}
+
+.form-check-card {
+	&:hover {
 		.card {
-		border-color: $cadmin-secondary-l2;
-		outline: none;
+			box-shadow: $cadmin-form-check-card-checked-box-shadow;
+		}
 	}
 }
 

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/components/_cards.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/components/_cards.scss
@@ -353,7 +353,7 @@
 
 	&:not(.active):has(.custom-control-input:is(:disabled, .disabled)):hover
 		.card {
-		border-color: $secondary-l2;
+		border-color: $cadmin-secondary-l2;
 		outline: none;
 	}
 }

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/components/_cards.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/components/_cards.scss
@@ -25,6 +25,10 @@
 	}
 }
 
+.card:not(:is(.card-horizontal, .template-card-horizontal)):hover {
+	transform: translateY(-0.25rem);
+}
+
 .card-body {
 	@include clay-css($cadmin-card-body);
 }
@@ -351,26 +355,27 @@
 		position: static;
 	}
 
+	&:hover .card {
+		border-color: $cadmin-primary-l1;
+		outline-color: $cadmin-primary-l1;
+	}
+
 	&.active .card,
 	.custom-control-input:checked ~ .card,
 	.form-check-input:checked ~ .card {
-		box-shadow: $cadmin-form-check-card-checked-box-shadow;
+		border-color: $cadmin-primary;
+		outline-color: $cadmin-primary;
 	}
-}
 
-.form-check-card {
-	&:hover {
+	&:has(.custom-control-input:is(.disabled, :disabled, [disabled])) {
 		.card {
-			box-shadow: $cadmin-form-check-card-checked-box-shadow;
+			box-shadow: none;
+			border-color: $cadmin-card-border-color;
+			outline: none;
 		}
-	}
-}
 
-.custom-control-input,
-.form-check-input {
-	&:hover {
-		~ .card {
-			box-shadow: $cadmin-form-check-card-checked-box-shadow;
+		&:hover .card {
+			transform: none;
 		}
 	}
 }

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/variables/_cards.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/variables/_cards.scss
@@ -204,7 +204,7 @@ $card: map-deep-merge(
 		),
 
 		hover: (
-			box-shadow: clay-enable-shadows($cadmin-card-box-shadow),
+			box-shadow: clay-enable-shadows($cadmin-card-hover-box-shadow),
 		),
 	),
 	$card
@@ -509,13 +509,13 @@ $cadmin-card-interactive-secondary: map-deep-merge(
 		hover: (
 			background-color: $cadmin-white,
 			border-color: transparent,
-			box-shadow: 0 0 0 2px #719aff,
+			box-shadow: $cadmin-card-hover-box-shadow,
 			color: $cadmin-gray-900,
 		),
 
 		focus: (
 			border-color: transparent,
-			box-shadow: 0 0 0 2px #719aff,
+			box-shadow: $cadmin-card-hover-box-shadow,
 		),
 
 		active: (

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/variables/_cards.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/variables/_cards.scss
@@ -1,14 +1,16 @@
 $cadmin-card-bg: $cadmin-white !default;
-$cadmin-card-border-color: rgba($cadmin-black, 0.125) !default;
+$cadmin-card-border-color: $cadmin-secondary-l2 !default;
 $cadmin-card-border-style: solid !default;
 $cadmin-card-border-width: 0px !default;
 
-$cadmin-card-border-radius: $cadmin-border-radius !default;
+$cadmin-card-border-radius: $cadmin-border-radius-xl !default;
 $cadmin-card-inner-border-radius: calc(
 	#{$cadmin-card-border-radius} - #{$cadmin-card-border-width}
 ) !default;
 
-$cadmin-card-box-shadow: 0 1px 3px -1px rgba(0, 0, 0, 0.6) !default;
+$cadmin-card-box-shadow: c-unset !default;
+$cadmin-card-hover-box-shadow: 0 0.25rem 0.75rem -0.25rem unquote('rgb(from #{$cadmin-black} r g b / 0.25)') !default;
+
 $cadmin-card-color: null !default;
 $cadmin-card-height: null !default;
 $cadmin-card-margin-bottom: 24px !default;
@@ -19,6 +21,9 @@ $cadmin-card-spacer-y: 12px !default;
 $cadmin-card-cap-bg: rgba($cadmin-black, 0.03) !default;
 $cadmin-card-cap-color: null !default;
 
+$cadmin-card-transitions:
+	$cadmin-component-transition,
+	transform 0.15s ease-in-out !default;
 // .card-body
 
 $cadmin-card-body-padding-bottom: 16px !default;
@@ -157,15 +162,18 @@ $card: map-deep-merge(
 	(
 		background-color: $cadmin-card-bg,
 		border-color: $cadmin-card-border-color,
-		border-radius: clay-enable-rounded($cadmin-card-border-radius),
+		border-radius: clay-enable-rounded(l$cadmin-card-border-radius),
 		border-style: $cadmin-card-border-style,
 		border-width: $cadmin-card-border-width,
-		box-shadow: clay-enable-shadows($cadmin-card-box-shadow),
 		display: block,
 		height: $cadmin-card-height,
 		margin-bottom: $cadmin-card-margin-bottom,
 		min-width: 0px,
+		outline-color: transparent,
+		outline-style: solid,
+		outline-width: $cadmin-card-border-width,
 		position: relative,
+		transition: $cadmin-card-transitions,
 		word-wrap: break-word,
 
 		aspect-ratio: (
@@ -193,6 +201,10 @@ $card: map-deep-merge(
 		hr: (
 			margin-left: 0px,
 			margin-right: 0px,
+		),
+
+		hover: (
+			box-shadow: clay-enable-shadows($cadmin-card-box-shadow),
 		),
 	),
 	$card
@@ -371,8 +383,7 @@ $cadmin-checkbox-right-card-padding: $cadmin-checkbox-left-card-padding !default
 
 $cadmin-checkbox-position: 16px !default;
 
-$cadmin-form-check-card-checked-box-shadow: 0 0 0 2px
-	clay-lighten($cadmin-component-active-bg, 22.94) !default;
+$cadmin-form-check-card-checked-box-shadow: c-unset !default;
 
 // Card Interactive
 
@@ -416,8 +427,8 @@ $cadmin-card-interactive: () !default;
 $cadmin-card-interactive: map-deep-merge(
 	(
 		cursor: $cadmin-link-cursor,
-		outline: 0,
-		transition: $cadmin-component-transition,
+		outline: c-unset,
+		transition: $cadmin-card-transitions,
 
 		hover: (
 			background-color: #f7f8f9,
@@ -425,8 +436,12 @@ $cadmin-card-interactive: map-deep-merge(
 		),
 
 		focus: (
-			box-shadow: #{0 0 0 2px #fff,
-			0 0 0 4px #719aff},
+			border-color: $cadmin-primary-l1,
+			box-shadow: none,
+			outline-color: $cadmin-primary-l1,
+			outline-offset: 0,
+			outline-style: solid,
+			outline-width: $cadmin-card-border-width,
 		),
 
 		active: (
@@ -460,18 +475,26 @@ $cadmin-card-interactive-primary-after-highlight: map-deep-merge(
 	$cadmin-card-interactive-primary-after-highlight
 );
 
+$cadmin-card-interactive-primary-box-shadow: unquote(
+	'#{$cadmin-card-hover-box-shadow}, 0px -2.5rem 0px -2.25rem #{$cadmin-primary} inset'
+) !default;
+
 $cadmin-card-interactive-primary: () !default;
 $cadmin-card-interactive-primary: map-deep-merge(
 	(
+		hover: (
+			box-shadow: $cadmin-card-interactive-primary-box-shadow,
+		),
+
 		focus: (
-			background-color: $cadmin-gray-100,
+			box-shadow: $cadmin-card-interactive-primary-box-shadow,
 		),
 
 		active: (
-			background-color: $cadmin-gray-200,
+			box-shadow: $cadmin-card-interactive-primary-box-shadow,
 		),
 
-		after-highlight: $cadmin-card-interactive-primary-after-highlight,
+		after-highlight: c-unset,
 	),
 	$cadmin-card-interactive-primary
 );

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/variables/_cards.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/variables/_cards.scss
@@ -1,15 +1,14 @@
 $cadmin-card-bg: $cadmin-white !default;
-$cadmin-card-border-color: $cadmin-secondary-l2 !default;
-$cadmin-card-border-radius: $cadmin-border-radius-xl !default;
+$cadmin-card-border-color: rgba($cadmin-black, 0.125) !default;
 $cadmin-card-border-style: solid !default;
-$cadmin-card-border-width: $cadmin-border-width !default;
+$cadmin-card-border-width: 0px !default;
 
-$cadmin-card-box-shadow: 0 0.25rem 1.5rem 0 rgba($cadmin-black, 0.15) !default;
-
+$cadmin-card-border-radius: $cadmin-border-radius !default;
 $cadmin-card-inner-border-radius: calc(
 	#{$cadmin-card-border-radius} - #{$cadmin-card-border-width}
 ) !default;
 
+$cadmin-card-box-shadow: 0 1px 3px -1px rgba(0, 0, 0, 0.6) !default;
 $cadmin-card-color: null !default;
 $cadmin-card-height: null !default;
 $cadmin-card-margin-bottom: 24px !default;
@@ -19,10 +18,6 @@ $cadmin-card-spacer-y: 12px !default;
 
 $cadmin-card-cap-bg: rgba($cadmin-black, 0.03) !default;
 $cadmin-card-cap-color: null !default;
-
-$cadmin-card-transition:
-	$cadmin-component-transition,
-	transform 0.15s ease-in-out !default;
 
 // .card-body
 
@@ -165,13 +160,12 @@ $card: map-deep-merge(
 		border-radius: clay-enable-rounded($cadmin-card-border-radius),
 		border-style: $cadmin-card-border-style,
 		border-width: $cadmin-card-border-width,
-		box-shadow: none,
+		box-shadow: clay-enable-shadows($cadmin-card-box-shadow),
 		display: block,
 		height: $cadmin-card-height,
 		margin-bottom: $cadmin-card-margin-bottom,
 		min-width: 0px,
 		position: relative,
-		transition: clay-enable-transitions($cadmin-card-transition),
 		word-wrap: break-word,
 
 		aspect-ratio: (
@@ -195,11 +189,6 @@ $card: map-deep-merge(
 
 		aspect-ratio-item-bottom-left:
 			$cadmin-card-aspect-ratio-item-bottom-left,
-
-		hover: (
-			box-shadow: $cadmin-card-box-shadow,
-			transform: translateY(-0.75rem),
-		),
 
 		hr: (
 			margin-left: 0px,
@@ -387,6 +376,34 @@ $cadmin-form-check-card-checked-box-shadow: 0 0 0 2px
 
 // Card Interactive
 
+$cadmin-card-interactive-after-highlight: () !default;
+$cadmin-card-interactive-after-highlight: map-deep-merge(
+	(
+		border-radius: 0px 0px $cadmin-card-border-radius
+			$cadmin-card-border-radius,
+		bottom: calc(#{$cadmin-card-border-width} * -1),
+		content: '',
+		height: 0px,
+		left: calc(#{$cadmin-card-border-width} * -1),
+		position: absolute,
+		right: calc(#{$cadmin-card-border-width} * -1),
+		transition: height 0.15s ease-out,
+
+		hover: (
+			height: 4px,
+		),
+
+		focus: (
+			height: 4px,
+		),
+
+		active: (
+			height: 4px,
+		),
+	),
+	$cadmin-card-interactive-after-highlight
+);
+
 $cadmin-card-interactive-card-body: () !default;
 $cadmin-card-interactive-card-body: map-deep-merge(
 	(
@@ -400,7 +417,7 @@ $cadmin-card-interactive: map-deep-merge(
 	(
 		cursor: $cadmin-link-cursor,
 		outline: 0,
-		transition: $cadmin-card-transition,
+		transition: $cadmin-component-transition,
 
 		hover: (
 			background-color: #f7f8f9,
@@ -408,15 +425,15 @@ $cadmin-card-interactive: map-deep-merge(
 		),
 
 		focus: (
-			border-color: null,
-			box-shadow: $cadmin-component-focus-box-shadow,
+			box-shadow: #{0 0 0 2px #fff,
+			0 0 0 4px #719aff},
 		),
 
 		active: (
 			background-color: #f1f2f5,
 		),
 
-		after-highlight: null,
+		after-highlight: $cadmin-card-interactive-after-highlight,
 
 		card-body: $cadmin-card-interactive-card-body,
 	),
@@ -425,14 +442,27 @@ $cadmin-card-interactive: map-deep-merge(
 
 // Card Interactive Primary
 
+$cadmin-card-interactive-primary-after-highlight: () !default;
+$cadmin-card-interactive-primary-after-highlight: map-deep-merge(
+	(
+		hover: (
+			background-color: $cadmin-component-active-bg,
+		),
+
+		focus: (
+			background-color: $cadmin-component-active-bg,
+		),
+
+		active: (
+			background-color: $cadmin-component-active-bg,
+		),
+	),
+	$cadmin-card-interactive-primary-after-highlight
+);
+
 $cadmin-card-interactive-primary: () !default;
 $cadmin-card-interactive-primary: map-deep-merge(
 	(
-		hover: (
-			box-shadow:
-				'#{$cadmin-card-box-shadow}, 0px -2.5rem 0px -2.25rem #{$cadmin-primary} inset',
-		),
-
 		focus: (
 			background-color: $cadmin-gray-100,
 		),
@@ -440,6 +470,8 @@ $cadmin-card-interactive-primary: map-deep-merge(
 		active: (
 			background-color: $cadmin-gray-200,
 		),
+
+		after-highlight: $cadmin-card-interactive-primary-after-highlight,
 	),
 	$cadmin-card-interactive-primary
 );
@@ -453,14 +485,14 @@ $cadmin-card-interactive-secondary: map-deep-merge(
 
 		hover: (
 			background-color: $cadmin-white,
-			border-color: null,
-			box-shadow: null,
+			border-color: transparent,
+			box-shadow: 0 0 0 2px #719aff,
 			color: $cadmin-gray-900,
 		),
 
 		focus: (
-			border-color: null,
-			box-shadow: null,
+			border-color: transparent,
+			box-shadow: 0 0 0 2px #719aff,
 		),
 
 		active: (

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/variables/_cards.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/variables/_cards.scss
@@ -1,14 +1,15 @@
 $cadmin-card-bg: $cadmin-white !default;
-$cadmin-card-border-color: rgba($cadmin-black, 0.125) !default;
+$cadmin-card-border-color: $cadmin-secondary-l2 !default;
+$cadmin-card-border-radius: $cadmin-border-radius-xl !default;
 $cadmin-card-border-style: solid !default;
-$cadmin-card-border-width: 0px !default;
+$cadmin-card-border-width: $cadmin-border-width !default;
 
-$cadmin-card-border-radius: $cadmin-border-radius !default;
+$cadmin-card-box-shadow: 0 0.25rem 1.5rem 0 rgba($cadmin-black, 0.15) !default;
+
 $cadmin-card-inner-border-radius: calc(
 	#{$cadmin-card-border-radius} - #{$cadmin-card-border-width}
 ) !default;
 
-$cadmin-card-box-shadow: 0 1px 3px -1px rgba(0, 0, 0, 0.6) !default;
 $cadmin-card-color: null !default;
 $cadmin-card-height: null !default;
 $cadmin-card-margin-bottom: 24px !default;
@@ -18,6 +19,10 @@ $cadmin-card-spacer-y: 12px !default;
 
 $cadmin-card-cap-bg: rgba($cadmin-black, 0.03) !default;
 $cadmin-card-cap-color: null !default;
+
+$cadmin-card-transition:
+	$cadmin-component-transition,
+	transform 0.15s ease-in-out !default;
 
 // .card-body
 
@@ -160,12 +165,13 @@ $card: map-deep-merge(
 		border-radius: clay-enable-rounded($cadmin-card-border-radius),
 		border-style: $cadmin-card-border-style,
 		border-width: $cadmin-card-border-width,
-		box-shadow: clay-enable-shadows($cadmin-card-box-shadow),
+		box-shadow: none,
 		display: block,
 		height: $cadmin-card-height,
 		margin-bottom: $cadmin-card-margin-bottom,
 		min-width: 0px,
 		position: relative,
+		transition: clay-enable-transitions($cadmin-card-transition),
 		word-wrap: break-word,
 
 		aspect-ratio: (
@@ -189,6 +195,11 @@ $card: map-deep-merge(
 
 		aspect-ratio-item-bottom-left:
 			$cadmin-card-aspect-ratio-item-bottom-left,
+
+		hover: (
+			box-shadow: $cadmin-card-box-shadow,
+			transform: translateY(-0.75rem),
+		),
 
 		hr: (
 			margin-left: 0px,
@@ -376,34 +387,6 @@ $cadmin-form-check-card-checked-box-shadow: 0 0 0 2px
 
 // Card Interactive
 
-$cadmin-card-interactive-after-highlight: () !default;
-$cadmin-card-interactive-after-highlight: map-deep-merge(
-	(
-		border-radius: 0px 0px $cadmin-card-border-radius
-			$cadmin-card-border-radius,
-		bottom: calc(#{$cadmin-card-border-width} * -1),
-		content: '',
-		height: 0px,
-		left: calc(#{$cadmin-card-border-width} * -1),
-		position: absolute,
-		right: calc(#{$cadmin-card-border-width} * -1),
-		transition: height 0.15s ease-out,
-
-		hover: (
-			height: 4px,
-		),
-
-		focus: (
-			height: 4px,
-		),
-
-		active: (
-			height: 4px,
-		),
-	),
-	$cadmin-card-interactive-after-highlight
-);
-
 $cadmin-card-interactive-card-body: () !default;
 $cadmin-card-interactive-card-body: map-deep-merge(
 	(
@@ -417,7 +400,7 @@ $cadmin-card-interactive: map-deep-merge(
 	(
 		cursor: $cadmin-link-cursor,
 		outline: 0,
-		transition: $cadmin-component-transition,
+		transition: $cadmin-card-transition,
 
 		hover: (
 			background-color: #f7f8f9,
@@ -425,15 +408,15 @@ $cadmin-card-interactive: map-deep-merge(
 		),
 
 		focus: (
-			box-shadow: #{0 0 0 2px #fff,
-			0 0 0 4px #719aff},
+			border-color: null,
+			box-shadow: $cadmin-component-focus-box-shadow,
 		),
 
 		active: (
 			background-color: #f1f2f5,
 		),
 
-		after-highlight: $cadmin-card-interactive-after-highlight,
+		after-highlight: null,
 
 		card-body: $cadmin-card-interactive-card-body,
 	),
@@ -442,27 +425,14 @@ $cadmin-card-interactive: map-deep-merge(
 
 // Card Interactive Primary
 
-$cadmin-card-interactive-primary-after-highlight: () !default;
-$cadmin-card-interactive-primary-after-highlight: map-deep-merge(
-	(
-		hover: (
-			background-color: $cadmin-component-active-bg,
-		),
-
-		focus: (
-			background-color: $cadmin-component-active-bg,
-		),
-
-		active: (
-			background-color: $cadmin-component-active-bg,
-		),
-	),
-	$cadmin-card-interactive-primary-after-highlight
-);
-
 $cadmin-card-interactive-primary: () !default;
 $cadmin-card-interactive-primary: map-deep-merge(
 	(
+		hover: (
+			box-shadow:
+				'#{$cadmin-card-box-shadow}, 0px -2.5rem 0px -2.25rem #{$cadmin-primary} inset',
+		),
+
 		focus: (
 			background-color: $cadmin-gray-100,
 		),
@@ -470,8 +440,6 @@ $cadmin-card-interactive-primary: map-deep-merge(
 		active: (
 			background-color: $cadmin-gray-200,
 		),
-
-		after-highlight: $cadmin-card-interactive-primary-after-highlight,
 	),
 	$cadmin-card-interactive-primary
 );
@@ -485,14 +453,14 @@ $cadmin-card-interactive-secondary: map-deep-merge(
 
 		hover: (
 			background-color: $cadmin-white,
-			border-color: transparent,
-			box-shadow: 0 0 0 2px #719aff,
+			border-color: null,
+			box-shadow: null,
 			color: $cadmin-gray-900,
 		),
 
 		focus: (
-			border-color: transparent,
-			box-shadow: 0 0 0 2px #719aff,
+			border-color: null,
+			box-shadow: null,
 		),
 
 		active: (

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/variables/_cards.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/variables/_cards.scss
@@ -162,7 +162,7 @@ $card: map-deep-merge(
 	(
 		background-color: $cadmin-card-bg,
 		border-color: $cadmin-card-border-color,
-		border-radius: clay-enable-rounded(l$cadmin-card-border-radius),
+		border-radius: clay-enable-rounded($cadmin-card-border-radius),
 		border-style: $cadmin-card-border-style,
 		border-width: $cadmin-card-border-width,
 		display: block,

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/variables/_cards.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/variables/_cards.scss
@@ -21,7 +21,7 @@ $cadmin-card-spacer-y: 12px !default;
 $cadmin-card-cap-bg: rgba($cadmin-black, 0.03) !default;
 $cadmin-card-cap-color: null !default;
 
-$cadmin-card-transitions:
+$cadmin-card-transition:
 	$cadmin-component-transition,
 	transform 0.15s ease-in-out !default;
 // .card-body
@@ -173,7 +173,7 @@ $card: map-deep-merge(
 		outline-style: solid,
 		outline-width: $cadmin-card-border-width,
 		position: relative,
-		transition: $cadmin-card-transitions,
+		transition: $cadmin-card-transition,
 		word-wrap: break-word,
 
 		aspect-ratio: (
@@ -428,7 +428,7 @@ $cadmin-card-interactive: map-deep-merge(
 	(
 		cursor: $cadmin-link-cursor,
 		outline: c-unset,
-		transition: $cadmin-card-transitions,
+		transition: $cadmin-card-transition,
 
 		hover: (
 			background-color: #f7f8f9,

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/variables/_cards.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/variables/_cards.scss
@@ -1,7 +1,7 @@
 $cadmin-card-bg: $cadmin-white !default;
 $cadmin-card-border-color: $cadmin-secondary-l2 !default;
 $cadmin-card-border-style: solid !default;
-$cadmin-card-border-width: 0px !default;
+$cadmin-card-border-width: $cadmin-border-width !default;
 
 $cadmin-card-border-radius: $cadmin-border-radius-xl !default;
 $cadmin-card-inner-border-radius: calc(

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/variables/_cards.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/variables/_cards.scss
@@ -530,6 +530,12 @@ $cadmin-card-interactive-secondary: map-deep-merge(
 $cadmin-card-type-asset: () !default;
 $cadmin-card-type-asset: map-deep-merge(
 	(
+		transition: $cadmin-card-transition,
+
+		hover: (
+			transform: translateY(-0.25rem),
+		),
+
 		aspect-ratio: (
 			border-color: $cadmin-gray-300,
 			border-style: solid,
@@ -833,7 +839,13 @@ $cadmin-template-card-body: map-deep-merge(
 $cadmin-template-card: () !default;
 $cadmin-template-card: map-deep-merge(
 	(
+		transition: $cadmin-card-transition,
+
 		card-body: $cadmin-template-card-body,
+
+		hover: (
+			transform: translateY(-0.25rem),
+		),
 	),
 	$cadmin-template-card
 );

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/variables/_globals.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/variables/_globals.scss
@@ -440,6 +440,7 @@ $cadmin-border-width: 1px !default;
 $cadmin-border-radius: 4px !default; // 4px
 $cadmin-border-radius-lg: 6px !default; // 6px
 $cadmin-border-radius-sm: 3px !default; // 3px
+$cadmin-border-radius-xl: 16px !default; // 16px
 
 $cadmin-rounded-0-border-radius: 0px !default;
 $cadmin-rounded-border-radius: $cadmin-border-radius !default;

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/variables/_globals.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/variables/_globals.scss
@@ -440,7 +440,6 @@ $cadmin-border-width: 1px !default;
 $cadmin-border-radius: 4px !default; // 4px
 $cadmin-border-radius-lg: 6px !default; // 6px
 $cadmin-border-radius-sm: 3px !default; // 3px
-$cadmin-border-radius-xl: 16px !default; // 16px
 
 $cadmin-rounded-0-border-radius: 0px !default;
 $cadmin-rounded-border-radius: $cadmin-border-radius !default;

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/components/_cards.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/components/_cards.scss
@@ -39,10 +39,6 @@
 	}
 }
 
-.card:not(:is(.card-horizontal, .template-card-horizontal)):hover {
-	transform: translateY(-0.25rem);
-}
-
 .card-body {
 	@include clay-css($card-body);
 }
@@ -492,7 +488,7 @@
 	}
 
 	&:has(.custom-control-input:is(.disabled, :disabled, [disabled])) {
-		&:hover .card {
+		&:hover {
 			transform: none;
 		}
 

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/components/_cards.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/components/_cards.scss
@@ -486,12 +486,6 @@
 			)
 		);
 	}
-
-	&:not(.active):has(.custom-control-input:is(:disabled, .disabled)):hover
-		.card {
-		border-color: $secondary-l2;
-		outline: none;
-	}
 }
 
 .form-check-bottom-left,

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/components/_cards.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/components/_cards.scss
@@ -486,6 +486,18 @@
 			)
 		);
 	}
+
+	&:has(.custom-control-input:is(.disabled, :disabled, [disabled])) .card {
+		@include clay-card-variant(
+			map-deep-get(
+				$form-check-card,
+				custom-control,
+				custom-control-input,
+				disabled,
+				card
+			)
+		);
+	}
 }
 
 .form-check-bottom-left,

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/components/_cards.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/components/_cards.scss
@@ -487,7 +487,8 @@
 		);
 	}
 
-	&:has(.custom-control-input:is(:disabled, .disabled)):hover .card {
+	&:not(.active):has(.custom-control-input:is(:disabled, .disabled)):hover
+		.card {
 		border-color: $secondary-l2;
 		outline: none;
 	}

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/components/_cards.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/components/_cards.scss
@@ -39,6 +39,10 @@
 	}
 }
 
+.card:not(:is(.card-horizontal, .template-card-horizontal)):hover {
+	transform: translateY(-0.25rem);
+}
+
 .card-body {
 	@include clay-css($card-body);
 }
@@ -487,16 +491,22 @@
 		);
 	}
 
-	&:has(.custom-control-input:is(.disabled, :disabled, [disabled])) .card {
-		@include clay-card-variant(
-			map-deep-get(
-				$form-check-card,
-				custom-control,
-				custom-control-input,
-				disabled,
-				card
-			)
-		);
+	&:has(.custom-control-input:is(.disabled, :disabled, [disabled])) {
+		&:hover .card {
+			transform: none;
+		}
+
+		.card {
+			@include clay-card-variant(
+				map-deep-get(
+					$form-check-card,
+					custom-control,
+					custom-control-input,
+					disabled,
+					card
+				)
+			);
+		}
 	}
 }
 

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/components/_cards.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/components/_cards.scss
@@ -486,6 +486,11 @@
 			)
 		);
 	}
+
+	&:has(.custom-control-input:is(:disabled, .disabled)):hover .card {
+		border-color: $secondary-l2;
+		outline: none;
+	}
 }
 
 .form-check-bottom-left,

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/mixins/_cards.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/mixins/_cards.scss
@@ -1961,6 +1961,8 @@
 
 			@if ($_hover) {
 				&:hover {
+					@include clay-css($_hover);
+
 					$_card: map-get($_hover, card);
 
 					@if ($_card) {

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/mixins/_cards.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/mixins/_cards.scss
@@ -1961,8 +1961,6 @@
 
 			@if ($_hover) {
 				&:hover {
-					@include clay-css($_hover);
-
 					$_card: map-get($_hover, card);
 
 					@if ($_card) {

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/variables/_cards.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/variables/_cards.scss
@@ -1,6 +1,6 @@
 $card-bg: $white !default;
 $card-border-color: rgba($black, 0.125) !default;
-$card-border-radius: $border-radius !default;
+$card-border-radius: $border-radius-xl !default;
 $card-border-style: solid !default;
 $card-border-width: $border-width !default;
 $card-box-shadow: null !default;

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/variables/_globals.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/variables/_globals.scss
@@ -382,6 +382,7 @@ $border-width: 0.0625rem !default;
 
 $border-radius-lg: 0.3rem !default;
 $border-radius-sm: 0.2rem !default;
+$border-radius-xl: 1rem !default;
 $border-radius: 0.25rem !default;
 
 $rounded-0-border-radius: 0px !default;


### PR DESCRIPTION
Ticket https://liferay.atlassian.net/browse/LPD-79840

## What is being adjusted

We need to reduce the visual gap between the current card and the revamped design, so we're shipping some CSS changes that can be applied to all existing card types without breaking their API or layouts.

## How it is being adjusted

- Define Card's `border` with `1px`;
- Increase of Card's `border-radius` to `16px`;
- Lift up the Card on hover, applying the proper shadow (* elevation doesn't apply to horizontal cards, nor disabled ones) ;
- For selectable, apply Cards (check/radio) outline for hover and active/selected states.

[Screencast from 2026-05-12 22-08-53.webm](https://github.com/user-attachments/assets/10f906a3-8458-4a5e-bc57-9160be9b71ef)

* Updated after design discussion