### PR TITLE
LPD-89127 Bump frontend-token-definition package to 8.1.0

### DIFF
--- a/modules/apps/frontend-token/frontend-token-definition-api/bnd.bnd
+++ b/modules/apps/frontend-token/frontend-token-definition-api/bnd.bnd
@@ -1,4 +1,4 @@
 Bundle-Name: Liferay Frontend Token Definition API
 Bundle-SymbolicName: com.liferay.frontend.token.definition.api
-Bundle-Version: 8.0.1
+Bundle-Version: 8.1.0
 Export-Package: com.liferay.frontend.token.definition

--- a/modules/apps/frontend-token/frontend-token-definition-api/src/main/resources/com/liferay/frontend/token/definition/packageinfo
+++ b/modules/apps/frontend-token/frontend-token-definition-api/src/main/resources/com/liferay/frontend/token/definition/packageinfo
@@ -1,1 +1,1 @@
-version 8.0.0
+version 8.1.0


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPD-89127

## Summary

- The `modules-semantic-versioning` baseline test failed for `modules/apps/frontend-token` because `com.liferay.frontend.token.definition` gained a new abstract method, `FrontendTokenDefinition.getPriority()`. Bnd flagged a MINOR delta and required the exported package version to move to `8.1.0`.
- Fix: bump the package version exactly to bnd's recommended `8.1.0` so the baseline matches the API surface.

## How to test it

1. Build the module's baseline report:
   ```
   cd modules/apps/frontend-token/frontend-token-definition-api && ../../../../../gradlew baseline
   ```
2. Expected: no `VERSION INCREASE REQUIRED` warning; `com.liferay.frontend.token.definition` reports `CUR_VER 8.1.0` matching `REC_VER 8.1.0`.
3. Re-run the failing CI job `modules-semantic-versioning[modules/apps/frontend-token]` (or local equivalent) and confirm it passes.