### PR TITLE
LPD-58342 Improve the Repeatable Field pattern

### DIFF
--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/css/main.scss
@@ -1,11 +1,16 @@
 @import './variations-nav';
 
 .portlet-asset-list-web {
-	.timeline-item {
-		&:hover .container-trash.btn {
-			opacity: 1;
-		}
+	.asset-filter-builder-add,
+	.asset-filter-builder-remove {
+		min-height: 44px;
+	}
 
+	.asset-filter-builder-remove {
+		min-width: 44px;
+	}
+
+	.timeline-item {
 		.form-group {
 			display: inline-block;
 
@@ -15,16 +20,6 @@
 
 			.field-content:after {
 				overflow: visible;
-			}
-		}
-
-		.container-trash {
-			&.btn {
-				opacity: 0;
-
-				&:focus {
-					opacity: 1;
-				}
 			}
 		}
 	}

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/components/AssetFilterBuilder/index.js
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/components/AssetFilterBuilder/index.js
@@ -145,9 +145,9 @@ function Rule({
 	vocabularyIds,
 }) {
 	return (
-		<div className="align-items-baseline c-gap-3 d-flex justify-content-between">
+		<div className="align-items-baseline c-gap-2 d-flex">
 			<div className="border-top-0 panel panel-default">
-				<div className="align-items-baseline c-gap-3 d-flex flex-wrap mb-0 panel-body">
+				<div className="align-items-baseline c-gap-2 d-flex flex-wrap mb-0 panel-body">
 					<ClayForm.Group className="flex-shrink-0">
 						<ClaySelectWithOption
 							aria-label={Liferay.Language.get('query-contains')}
@@ -239,15 +239,15 @@ function Rule({
 				</div>
 			</div>
 
-			{!disabled && (
+			{index > 0 && !disabled && (
 				<ClayButton
 					aria-label={Liferay.Language.get('delete-condition')}
-					className="container-trash p-2"
+					borderless
+					className="asset-filter-builder-remove container-trash"
 					data-index={index}
 					displayType="secondary"
 					monospaced
 					onClick={onDeleteRule}
-					size="sm"
 					title={Liferay.Language.get('delete-condition')}
 				>
 					<ClayIcon symbol="trash" />
@@ -335,20 +335,20 @@ function AssetFilterBuilder({
 
 				{!disabled && (
 					<li className="timeline-item">
-						<div className="bg-white d-inline-block position-relative timeline-increment">
-							<ClayButton
-								aria-label={Liferay.Language.get(
-									'add-condition'
-								)}
-								className="rounded-circle"
-								monospaced
-								onClick={handleAddRule}
-								size="sm"
-								title={Liferay.Language.get('add-condition')}
-							>
+						<ClayButton
+							aria-label={Liferay.Language.get('add-option')}
+							borderless
+							className="asset-filter-builder-add"
+							displayType="secondary"
+							onClick={handleAddRule}
+							type="button"
+						>
+							<span className="inline-item inline-item-before">
 								<ClayIcon symbol="plus" />
-							</ClayButton>
-						</div>
+							</span>
+
+							{Liferay.Language.get('add-option')}
+						</ClayButton>
 					</li>
 				)}
 			</ul>

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/css/main.scss
@@ -38,11 +38,16 @@
 		border-radius: 0;
 	}
 
-	.timeline-item {
-		&:hover .container-trash.btn {
-			opacity: 1;
-		}
+	.asset-filter-builder-add,
+	.asset-filter-builder-remove {
+		min-height: 44px;
+	}
 
+	.asset-filter-builder-remove {
+		min-width: 44px;
+	}
+
+	.timeline-item {
 		& + .timeline-item > .panel {
 			border-top: none;
 		}
@@ -50,16 +55,6 @@
 		.form-group {
 			display: inline-block;
 			margin: 0 8px 8px 0;
-		}
-
-		.container-trash {
-			&.btn {
-				opacity: 0;
-
-				&:focus {
-					opacity: 1;
-				}
-			}
 		}
 	}
 }

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/js/components/AssetFilterBuilder/index.js
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/js/components/AssetFilterBuilder/index.js
@@ -144,7 +144,7 @@ function Rule({
 	vocabularyIds,
 }) {
 	return (
-		<div className="align-items-baseline d-flex justify-content-between">
+		<div className="align-items-baseline c-gap-3 d-flex">
 			<div className="panel panel-default">
 				<div className="align-items-baseline c-gap-3 d-flex mb-0 panel-body">
 					<ClayForm.Group>
@@ -238,18 +238,20 @@ function Rule({
 				</div>
 			</div>
 
-			<ClayButton
-				aria-label={Liferay.Language.get('delete-condition')}
-				className="container-trash"
-				data-index={index}
-				displayType="secondary"
-				monospaced
-				onClick={onDeleteRule}
-				size="sm"
-				title={Liferay.Language.get('delete-condition')}
-			>
-				<ClayIcon symbol="trash" />
-			</ClayButton>
+			{index > 0 && (
+				<ClayButton
+					aria-label={Liferay.Language.get('delete-condition')}
+					borderless
+					className="asset-filter-builder-remove container-trash"
+					data-index={index}
+					displayType="secondary"
+					monospaced
+					onClick={onDeleteRule}
+					title={Liferay.Language.get('delete-condition')}
+				>
+					<ClayIcon symbol="trash" />
+				</ClayButton>
+			)}
 		</div>
 	);
 }
@@ -329,17 +331,20 @@ function AssetFilterBuilder({
 				))}
 
 				<li className="timeline-item">
-					<div className="position-relative timeline-increment">
-						<ClayButton
-							aria-label={Liferay.Language.get('add-condition')}
-							className="rounded-circle"
-							monospaced
-							onClick={handleAddRule}
-							size="sm"
-						>
+					<ClayButton
+						aria-label={Liferay.Language.get('add-option')}
+						borderless
+						className="asset-filter-builder-add"
+						displayType="secondary"
+						onClick={handleAddRule}
+						type="button"
+					>
+						<span className="inline-item inline-item-before">
 							<ClayIcon symbol="plus" />
-						</ClayButton>
-					</div>
+						</span>
+
+						{Liferay.Language.get('add-option')}
+					</ClayButton>
 				</li>
 			</ul>
 		</>

--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/css/_utilities.scss
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/css/_utilities.scss
@@ -3,9 +3,3 @@
 	margin: 0.75rem 0;
 	position: relative;
 }
-
-.ddm-form-field-repeatable-add-button {
-	position: absolute;
-	right: 0;
-	top: 0;
-}

--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/css/main.scss
@@ -531,40 +531,6 @@ body .ddm-user-view-content {
 	padding-bottom: 30px;
 }
 
-.lfr-ddm-form-field-repeatable-toolbar {
-	.ddm-form-field-repeatable-add-button,
-	.ddm-form-field-repeatable-delete-button {
-		border-radius: 10px !important;
-		height: 18px;
-		padding: 2px !important;
-		position: absolute;
-		width: 18px;
-
-		.lexicon-icon {
-			height: 10px;
-			margin-bottom: 7px;
-			margin-top: 0;
-		}
-
-		.lexicon-icon-hr {
-			width: 8px;
-		}
-
-		.lexicon-icon-plus {
-			width: 10px;
-		}
-	}
-
-	.ddm-form-field-repeatable-delete-button {
-		margin-right: 4px !important;
-		right: 26px;
-	}
-
-	.ddm-form-field-repeatable-add-button {
-		right: 8px;
-	}
-}
-
 .liferay-ddm-form-field-fieldset {
 	margin-bottom: 0 !important;
 

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/css/file_size_mimetypes.scss
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/css/file_size_mimetypes.scss
@@ -1,33 +1,28 @@
 @import 'atlas-variables';
 
-.dm-field-repeatable-delete-button,
-.dm-field-repeatable-add-button {
-	border-radius: 10px;
-	height: 18px;
-	padding: 2px;
-	position: absolute;
-	top: 0;
-	width: 18px;
-
-	.lexicon-icon {
-		height: 10px;
-		margin-bottom: 7px;
-		margin-top: 0;
-		width: 10px;
-	}
-}
-
-.dm-field-repeatable-delete-button {
-	right: 38px;
-}
-
-.dm-field-repeatable-add-button {
-	right: 16px;
-}
-
-.size-limit-row {
+.file-size-mimetypes-item {
+	align-items: end;
+	display: grid;
+	gap: 1rem;
+	grid-template-columns: 1fr 44px;
 	margin-top: 2rem;
+
 	.form-feedback-group {
 		position: absolute;
 	}
+}
+
+.file-size-mimetypes-item-content {
+	min-width: 0;
+}
+
+.file-size-mimetypes-remove {
+	margin-bottom: 0;
+	min-height: 44px;
+	min-width: 44px;
+}
+
+.file-size-mimetypes-add {
+	margin-top: 1rem;
+	min-height: 44px;
 }

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/js/document_library/file-size-limit/FileSizeMimetypes.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/js/document_library/file-size-limit/FileSizeMimetypes.js
@@ -18,7 +18,6 @@ const NumberErrorMessage = `${Liferay.Language.get(
 )} ${Liferay.Language.get('please-enter-a-valid-number')}`;
 
 const FileSizeField = ({
-	handleAddClick,
 	handleRemoveClick,
 	index,
 	mimeType = '',
@@ -28,92 +27,90 @@ const FileSizeField = ({
 	const [sizeErrorMessage, setSizeErrorMessage] = useState('');
 
 	return (
-		<ClayLayout.Row className="mt-4 size-limit-row">
-			<ClayLayout.Col md="6">
-				<label htmlFor="mimeType">
-					{Liferay.Language.get('mime-type-field-label')}
+		<div className="file-size-mimetypes-item">
+			<div className="file-size-mimetypes-item-content">
+				<ClayLayout.Row>
+					<ClayLayout.Col md="6">
+						<label htmlFor="mimeType">
+							{Liferay.Language.get('mime-type-field-label')}
 
-					<span
-						className="inline-item-after"
-						title={Liferay.Language.get('mime-type-help-message')}
+							<span
+								className="inline-item-after"
+								title={Liferay.Language.get(
+									'mime-type-help-message'
+								)}
+							>
+								<ClayIcon symbol="question-circle-full" />
+							</span>
+						</label>
+
+						<ClayInput
+							defaultValue={mimeType}
+							id="mimeType"
+							name={`${portletNamespace}mimeType_${index}`}
+							type="text"
+						/>
+					</ClayLayout.Col>
+
+					<ClayLayout.Col
+						className={sizeErrorMessage ? 'has-error' : ''}
+						md="6"
 					>
-						<ClayIcon symbol="question-circle-full" />
-					</span>
-				</label>
+						<label htmlFor="size">
+							{Liferay.Language.get('maximum-file-size')}
 
-				<ClayInput
-					defaultValue={mimeType}
-					id="mimeType"
-					name={`${portletNamespace}mimeType_${index}`}
-					type="text"
-				/>
-			</ClayLayout.Col>
+							<span
+								className="inline-item-after"
+								title={Liferay.Language.get(
+									'maximum-file-size-help-message'
+								)}
+							>
+								<ClayIcon symbol="question-circle-full" />
+							</span>
+						</label>
 
-			<ClayLayout.Col
-				className={sizeErrorMessage ? 'has-error' : ''}
-				md="6"
-			>
-				<label htmlFor="size">
-					{Liferay.Language.get('maximum-file-size')}
+						<ClayInput
+							defaultValue={size}
+							id="size"
+							name={`${portletNamespace}size_${index}`}
+							onChange={({target}) => {
+								setSizeErrorMessage(
+									target.validity.valid &&
+										Number(target.value) >= 0
+										? ''
+										: NumberErrorMessage
+								);
+							}}
+							type="number"
+						/>
 
-					<span
-						className="inline-item-after"
-						title={Liferay.Language.get(
-							'maximum-file-size-help-message'
+						{sizeErrorMessage && (
+							<ClayForm.FeedbackGroup>
+								<ClayForm.FeedbackItem>
+									<ClayForm.FeedbackIndicator symbol="exclamation-full" />
+
+									{sizeErrorMessage}
+								</ClayForm.FeedbackItem>
+							</ClayForm.FeedbackGroup>
 						)}
-					>
-						<ClayIcon symbol="question-circle-full" />
-					</span>
-				</label>
+					</ClayLayout.Col>
+				</ClayLayout.Row>
+			</div>
 
-				<ClayInput
-					defaultValue={size}
-					id="size"
-					name={`${portletNamespace}size_${index}`}
-					onChange={({target}) => {
-						setSizeErrorMessage(
-							target.validity.valid && Number(target.value) >= 0
-								? ''
-								: NumberErrorMessage
-						);
-					}}
-					type="number"
-				/>
-
-				{index > 0 && (
-					<ClayButton
-						aria-label={Liferay.Language.get('remove')}
-						className="dm-field-repeatable-delete-button"
-						onClick={() => handleRemoveClick(index)}
-						small
-						title={Liferay.Language.get('remove')}
-						type="button"
-					>
-						<ClayIcon symbol="hr" />
-					</ClayButton>
-				)}
-
+			{index > 0 && (
 				<ClayButton
-					className="dm-field-repeatable-add-button"
-					onClick={() => handleAddClick(index)}
-					small
-					title={Liferay.Language.get('add')}
+					aria-label={Liferay.Language.get('remove')}
+					borderless
+					className="file-size-mimetypes-remove"
+					displayType="secondary"
+					monospaced
+					onClick={() => handleRemoveClick(index)}
 					type="button"
 				>
-					<ClayIcon symbol="plus" />
+					<ClayIcon symbol="trash" />
 				</ClayButton>
-
-				{sizeErrorMessage && (
-					<ClayForm.FeedbackGroup>
-						<ClayForm.FeedbackItem>
-							<ClayForm.FeedbackIndicator symbol="exclamation-full" />
-
-							{sizeErrorMessage}
-						</ClayForm.FeedbackItem>
-					</ClayForm.FeedbackGroup>
-				)}
-			</ClayLayout.Col>
-		</ClayLayout.Row>
+			)}
+		</div>
 	);
 };
 
@@ -124,16 +121,12 @@ const FileSizeMimetypes = ({
 }) => {
 	const emptyRow = () => ({id: uuidv4(), mimeType: '', size: ''});
 
-	const addRow = (index) => {
-		const tempList = [...sizesList];
-		tempList.splice(index + 1, 0, emptyRow());
-		setSizesList(tempList);
+	const addRow = () => {
+		setSizesList((prevSizesList) => [...prevSizesList, emptyRow()]);
 	};
 
 	const removeRow = (index) => {
-		const tempList = [...sizesList];
-		tempList.splice(index, 1);
-		setSizesList(tempList);
+		setSizesList((prevSizesList) => prevSizesList.toSpliced(index, 1));
 	};
 
 	const [sizesList, setSizesList] = useState(
@@ -148,7 +141,6 @@ const FileSizeMimetypes = ({
 
 			{sizesList.map((item, index) => (
 				<FileSizeField
-					handleAddClick={addRow}
 					handleRemoveClick={removeRow}
 					index={index}
 					key={item.id}
@@ -157,6 +149,21 @@ const FileSizeMimetypes = ({
 					size={item.size}
 				/>
 			))}
+
+			<ClayButton
+				aria-label={Liferay.Language.get('add-option')}
+				borderless
+				className="file-size-mimetypes-add"
+				displayType="secondary"
+				onClick={addRow}
+				type="button"
+			>
+				<span className="inline-item inline-item-before">
+					<ClayIcon symbol="plus" />
+				</span>
+
+				{Liferay.Language.get('add-option')}
+			</ClayButton>
 		</>
 	);
 };

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/api/FieldBase/FieldBase.scss
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/api/FieldBase/FieldBase.scss
@@ -18,6 +18,20 @@
 	}
 }
 
+.ddm-form-field-repeatable-add-button {
+	margin-top: 1rem;
+	min-height: 44px;
+}
+
+.ddm-form-field-repeatable-delete-button,
+.ddm-form-field-repeatable-delete-button-placeholder {
+	min-width: 44px;
+}
+
+.ddm-form-field-repeatable-delete-button {
+	min-height: 44px;
+}
+
 .ddm-form-field-repeatable-button-disabled {
 	cursor: not-allowed;
 	opacity: 0.5 !important;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/api/FieldBase/ReactFieldBase.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/api/FieldBase/ReactFieldBase.js
@@ -326,62 +326,123 @@ export default function FieldBase({
 		columns: [{fields: [field], size: 12}],
 	}));
 
-	const checkRepetitions = useMemo(() => {
-		if (repeatable && name) {
-			const currentFieldFieldsets = name.match(FIELDSET_REGEX);
-			const currentFieldsetRepeatIndexes = name.match(
+	const repeatableInfo = useMemo(() => {
+		if (!repeatable || !name) {
+			return {count: 0, index: -1};
+		}
+
+		const currentFieldFieldsets = name.match(FIELDSET_REGEX);
+		const currentFieldsetRepeatIndexes = name.match(
+			FIELDSET_REPEAT_INDEX_REGEX
+		);
+
+		if (currentFieldsetRepeatIndexes) {
+			currentFieldsetRepeatIndexes.pop();
+		}
+
+		const visitor = new PagesVisitor(pages);
+
+		const repeatableFields = [];
+
+		visitor.visitFields((field) => {
+			const fieldName = field.name ?? field.fieldName;
+
+			const fieldFieldsets = fieldName.match(FIELDSET_REGEX);
+			const fieldsetRepeatIndexes = fieldName.match(
 				FIELDSET_REPEAT_INDEX_REGEX
 			);
 
-			if (currentFieldsetRepeatIndexes) {
-				currentFieldsetRepeatIndexes.pop();
+			if (fieldsetRepeatIndexes) {
+				fieldsetRepeatIndexes.pop();
 			}
 
-			const visitor = new PagesVisitor(pages);
-
-			const repeatableFields = [];
-
-			visitor.visitFields((field) => {
-				const fieldName = field.name ?? field.fieldName;
-
-				const fieldFieldsets = fieldName.match(FIELDSET_REGEX);
-				const fieldsetRepeatIndexes = fieldName.match(
-					FIELDSET_REPEAT_INDEX_REGEX
+			const isSameFieldset =
+				currentFieldFieldsets &&
+				fieldFieldsets &&
+				currentFieldsetRepeatIndexes &&
+				fieldsetRepeatIndexes &&
+				currentFieldFieldsets.every(
+					(fieldFieldset, index) =>
+						fieldFieldset === fieldFieldsets[index]
+				) &&
+				currentFieldsetRepeatIndexes.every(
+					(fieldFieldset, index) =>
+						fieldFieldset === fieldsetRepeatIndexes[index]
 				);
 
-				if (fieldsetRepeatIndexes) {
-					fieldsetRepeatIndexes.pop();
-				}
+			if (fieldReference === field.fieldReference && isSameFieldset) {
+				repeatableFields.push(field);
+			}
 
-				const isSameFieldset =
-					currentFieldFieldsets &&
-					fieldFieldsets &&
-					currentFieldsetRepeatIndexes &&
-					fieldsetRepeatIndexes &&
-					currentFieldFieldsets.every(
-						(fieldFieldset, index) =>
-							fieldFieldset === fieldFieldsets[index]
-					) &&
-					currentFieldsetRepeatIndexes.every(
-						(fieldFieldset, index) =>
-							fieldFieldset === fieldsetRepeatIndexes[index]
-					);
+			if (
+				!currentFieldFieldsets &&
+				fieldReference === field.fieldReference
+			) {
+				repeatableFields.push(field);
+			}
+		});
 
-				if (fieldReference === field.fieldReference && isSameFieldset) {
-					repeatableFields.push(field);
-				}
+		const index = repeatableFields.findIndex(
+			(field) => (field.name ?? field.fieldName) === name
+		);
 
-				if (
-					!currentFieldFieldsets &&
-					fieldReference === field.fieldReference
-				) {
-					repeatableFields.push(field);
-				}
-			});
-
-			return repeatableFields.length;
-		}
+		return {count: repeatableFields.length, index};
 	}, [fieldReference, name, pages, repeatable]);
+
+	const showRepeatableDeleteButton = repeatable && repeatableInfo.index > 0;
+	const showRepeatableAddButton =
+		repeatable && repeatableInfo.index === repeatableInfo.count - 1;
+
+	const repeatableDeleteButton = showRepeatableDeleteButton ? (
+		<ClayButton
+			aria-label={sub(
+				Liferay.Language.get('remove-duplicate-field'),
+				label ? label : type
+			)}
+			borderless
+			className={classNames('ddm-form-field-repeatable-delete-button', {
+				'ddm-form-field-repeatable-button-disabled':
+					disabledRepeatableButton,
+			})}
+			disabled={readOnly || disabledRepeatableButton}
+			displayType="secondary"
+			monospaced
+			onClick={() => {
+				setTimeout(
+					() => {
+						dispatch({
+							payload: name,
+							type: CORE_EVENT_TYPES.FIELD.REMOVED,
+						});
+
+						Liferay.fire('journal:storeState', {
+							fieldName: Liferay.Language.get(
+								'remove-repeatable-field'
+							),
+						});
+					},
+					type === 'fieldset' || type === 'text' ? 1000 : 0
+				);
+			}}
+			title={Liferay.Language.get('remove')}
+			type="button"
+		>
+			<ClayIcon symbol="trash" />
+		</ClayButton>
+	) : null;
+
+	const renderChildren = (childrenContent) =>
+		repeatable ? (
+			<div className="align-items-center c-gap-3 d-flex">
+				<div className="flex-fill">{childrenContent}</div>
+
+				{repeatableDeleteButton ?? (
+					<div className="ddm-form-field-repeatable-delete-button-placeholder" />
+				)}
+			</div>
+		) : (
+			childrenContent
+		);
 
 	const translationFilterChange = useCallback(
 		(event) => {
@@ -533,92 +594,6 @@ export default function FieldBase({
 				'role': 'group',
 			})}
 		>
-			{repeatable && (
-				<div className="lfr-ddm-form-field-repeatable-toolbar">
-					{checkRepetitions > 1 && (
-						<ClayButton
-							aria-label={sub(
-								Liferay.Language.get('remove-duplicate-field'),
-								label ? label : type
-							)}
-							className={classNames(
-								'ddm-form-field-repeatable-delete-button p-0',
-								{
-									'ddm-form-field-repeatable-button-disabled':
-										disabledRepeatableButton,
-								}
-							)}
-							disabled={readOnly || disabledRepeatableButton}
-							onClick={() => {
-								setTimeout(
-									() => {
-										dispatch({
-											payload: name,
-											type: CORE_EVENT_TYPES.FIELD
-												.REMOVED,
-										});
-
-										Liferay.fire('journal:storeState', {
-											fieldName: Liferay.Language.get(
-												'remove-repeatable-field'
-											),
-										});
-									},
-									type === 'fieldset' || type === 'text'
-										? 1000
-										: 0
-								);
-							}}
-							small
-							title={Liferay.Language.get('remove')}
-							type="button"
-						>
-							<ClayIcon symbol="hr" />
-						</ClayButton>
-					)}
-
-					<ClayButton
-						aria-label={sub(
-							Liferay.Language.get('add-duplicate-field'),
-							label ? label : type
-						)}
-						className={classNames(
-							'ddm-form-field-repeatable-add-button p-0',
-							{
-								'ddm-form-field-repeatable-button-disabled':
-									disabledRepeatableButton,
-								'hide': overMaximumRepetitionsLimit,
-							}
-						)}
-						disabled={readOnly || disabledRepeatableButton}
-						onClick={() =>
-							setTimeout(
-								() => {
-									dispatch({
-										payload: name,
-										type: CORE_EVENT_TYPES.FIELD.REPEATED,
-									});
-
-									Liferay.fire('journal:storeState', {
-										fieldName: Liferay.Language.get(
-											'add-repeatable-field'
-										),
-									});
-								},
-								type === 'fieldset' || type === 'text'
-									? 1000
-									: 0
-							)
-						}
-						small
-						title={Liferay.Language.get('duplicate')}
-						type="button"
-					>
-						<ClayIcon symbol="plus" />
-					</ClayButton>
-				</div>
-			)}
-
 			{renderLabel && (
 				<>
 					{showGroup ? (
@@ -648,7 +623,7 @@ export default function FieldBase({
 								/>
 							)}
 
-							{children}
+							{renderChildren(children)}
 						</div>
 					) : (
 						<>
@@ -690,7 +665,7 @@ export default function FieldBase({
 								/>
 							)}
 
-							{children}
+							{renderChildren(children)}
 
 							{!showLabel && popoverOrTooltip && (
 								<FieldInformation
@@ -703,7 +678,7 @@ export default function FieldBase({
 				</>
 			)}
 
-			{!renderLabel && children}
+			{!renderLabel && renderChildren(children)}
 
 			{hiddenTranslations}
 
@@ -721,6 +696,51 @@ export default function FieldBase({
 				id={`${id ?? name}_fieldFeedback`}
 				warningMessage={warningMessage}
 			/>
+
+			{showRepeatableAddButton && (
+				<ClayButton
+					aria-label={sub(
+						Liferay.Language.get('add-duplicate-field'),
+						label ? label : type
+					)}
+					borderless
+					className={classNames(
+						'ddm-form-field-repeatable-add-button',
+						{
+							'ddm-form-field-repeatable-button-disabled':
+								disabledRepeatableButton,
+							'hide': overMaximumRepetitionsLimit,
+						}
+					)}
+					disabled={readOnly || disabledRepeatableButton}
+					displayType="secondary"
+					onClick={() =>
+						setTimeout(
+							() => {
+								dispatch({
+									payload: name,
+									type: CORE_EVENT_TYPES.FIELD.REPEATED,
+								});
+
+								Liferay.fire('journal:storeState', {
+									fieldName: Liferay.Language.get(
+										'add-repeatable-field'
+									),
+								});
+							},
+							type === 'fieldset' || type === 'text' ? 1000 : 0
+						)
+					}
+					title={Liferay.Language.get('duplicate')}
+					type="button"
+				>
+					<span className="inline-item inline-item-before">
+						<ClayIcon symbol="plus" />
+					</span>
+
+					{Liferay.Language.get('add-option')}
+				</ClayButton>
+			)}
 
 			{hasFieldDetails && (
 				<span

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/FieldBase/__snapshots__/ReactFieldBase.es.js.snap
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/FieldBase/__snapshots__/ReactFieldBase.es.js.snap
@@ -5,29 +5,20 @@ exports[`ReactFieldBase does not render the add button when repeatable is true a
   <div
     class="form-group hide"
   >
-    <div
-      class="lfr-ddm-form-field-repeatable-toolbar"
-    >
-      <button
-        aria-label="add-duplicate-field"
-        class="ddm-form-field-repeatable-add-button p-0 hide btn btn-sm btn-primary"
-        title="duplicate"
-        type="button"
-      >
-        <svg
-          class="lexicon-icon lexicon-icon-plus"
-          role="presentation"
-        >
-          <use
-            href="#plus"
-          />
-        </svg>
-      </button>
-    </div>
     <label
       aria-labelledby="id_fieldDetails"
       class="ddm-empty ddm-repeatable"
     />
+    <div
+      class="align-items-center c-gap-3 d-flex"
+    >
+      <div
+        class="flex-fill"
+      />
+      <div
+        class="ddm-form-field-repeatable-delete-button-placeholder"
+      />
+    </div>
     <input
       name="undefined_edited"
       type="hidden"
@@ -42,6 +33,26 @@ exports[`ReactFieldBase does not render the add button when repeatable is true a
         class="form-feedback-item"
       />
     </div>
+    <button
+      aria-label="add-duplicate-field"
+      class="ddm-form-field-repeatable-add-button hide btn btn-outline-borderless btn-outline-secondary"
+      title="duplicate"
+      type="button"
+    >
+      <span
+        class="inline-item inline-item-before"
+      >
+        <svg
+          class="lexicon-icon lexicon-icon-plus"
+          role="presentation"
+        >
+          <use
+            href="#plus"
+          />
+        </svg>
+      </span>
+      add-option
+    </button>
     <span
       class="sr-only"
       id="id_fieldDetails"
@@ -254,30 +265,21 @@ exports[`ReactFieldBase renders the add button when repeatable is true 1`] = `
     class="form-group hide"
     role="group"
   >
-    <div
-      class="lfr-ddm-form-field-repeatable-toolbar"
-    >
-      <button
-        aria-label="add-duplicate-field"
-        class="ddm-form-field-repeatable-add-button p-0 btn btn-sm btn-primary"
-        title="duplicate"
-        type="button"
-      >
-        <svg
-          class="lexicon-icon lexicon-icon-plus"
-          role="presentation"
-        >
-          <use
-            href="#plus"
-          />
-        </svg>
-      </button>
-    </div>
     <label
       aria-labelledby="undefined_fieldDetails"
       class="ddm-empty ddm-repeatable"
       id="undefined_fieldLabel"
     />
+    <div
+      class="align-items-center c-gap-3 d-flex"
+    >
+      <div
+        class="flex-fill"
+      />
+      <div
+        class="ddm-form-field-repeatable-delete-button-placeholder"
+      />
+    </div>
     <input
       name="undefined_edited"
       type="hidden"
@@ -292,6 +294,26 @@ exports[`ReactFieldBase renders the add button when repeatable is true 1`] = `
         class="form-feedback-item"
       />
     </div>
+    <button
+      aria-label="add-duplicate-field"
+      class="ddm-form-field-repeatable-add-button btn btn-outline-borderless btn-outline-secondary"
+      title="duplicate"
+      type="button"
+    >
+      <span
+        class="inline-item inline-item-before"
+      >
+        <svg
+          class="lexicon-icon lexicon-icon-plus"
+          role="presentation"
+        >
+          <use
+            href="#plus"
+          />
+        </svg>
+      </span>
+      add-option
+    </button>
     <span
       class="sr-only"
       id="undefined_fieldDetails"

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/css/components/_input_sets.scss
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/css/components/_input_sets.scss
@@ -1,0 +1,20 @@
+html#{$cadmin-selector} {
+	.input-sets-item.form-group {
+		margin-bottom: 0;
+	}
+
+	.input-sets-handle {
+		cursor: move;
+		min-height: 44px;
+		min-width: 44px;
+	}
+
+	.input-sets-remove {
+		min-height: 44px;
+		min-width: 44px;
+	}
+
+	.input-sets-add {
+		min-height: 44px;
+	}
+}

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/css/main.scss
@@ -1,6 +1,7 @@
 @import 'atlas-variables';
 @import 'cadmin-variables';
 
+@import 'components/input_sets';
 @import 'components/search_auto_fields';
 @import 'components/search_bar_configuration_suggestions';
 @import 'components/select_vocabularies';

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SortConfigurationOptions.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SortConfigurationOptions.js
@@ -424,7 +424,8 @@ function SortConfigurationOptions({
 
 						<ClayButton
 							aria-label={Liferay.Language.get('add-option')}
-							className={getCN({
+							borderless
+							className={getCN('input-sets-add', {
 								'c-mt-4': !fields.length,
 							})}
 							displayType="secondary"

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/shared/input_sets/Item.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/shared/input_sets/Item.js
@@ -35,25 +35,18 @@ function Item({
 			<DropZone index={index} move={onInputSetItemMove} />
 
 			<ClayForm.Group
-				className="c-mb-0 c-pl-2 c-pr-2 input-sets-item-form-group list-group-item rounded"
+				className="input-sets-item list-group-item rounded"
 				ref={dragPreview}
+				style={{opacity: isDragging ? 0.5 : 1}}
 			>
 				<ClayInput.Group>
-					<ClayInput.GroupItem
-						className="c-m-md-auto"
-						ref={drag}
-						shrink
-						style={{
-							cursor: 'move',
-							opacity: isDragging ? 0.5 : 1,
-						}}
-					>
+					<ClayInput.GroupItem ref={drag} shrink>
 						<ClayButton
 							aria-label={Liferay.Language.get('move')}
 							borderless
+							className="input-sets-handle"
 							displayType="secondary"
 							monospaced
-							small
 						>
 							<ClayIcon symbol="drag" />
 						</ClayButton>
@@ -61,11 +54,11 @@ function Item({
 
 					{children}
 
-					<ClayInput.GroupItem className="c-m-md-auto" shrink>
+					<ClayInput.GroupItem shrink>
 						<ClayButton
 							aria-label={Liferay.Language.get('delete')}
 							borderless
-							className="c-ml-2"
+							className="input-sets-remove"
 							disabled={!onInputSetItemDelete}
 							displayType="secondary"
 							monospaced
@@ -74,7 +67,6 @@ function Item({
 									? onInputSetItemDelete(index)
 									: undefined
 							}
-							small
 						>
 							<ClayIcon symbol="trash" />
 						</ClayButton>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/assetpublisher/APConfiguration.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/assetpublisher/APConfiguration.path
@@ -61,7 +61,7 @@
 
 <tr>
 	<td>RULE_BUILDER_ADD_CONDITION</td>
-	<td>//button[contains(@class,'form-builder-rule-add-condition')] | //button[@aria-label='Add Condition']</td>
+	<td>//button[contains(@class,'form-builder-rule-add-condition')] | //button[@aria-label='Add Condition'] | //button[@aria-label='Add Option']</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-58342

## What is being fixed

Several DXP UIs let users dynamically add and remove rows of inputs — File Size Limits, the Sort widget's configuration, the Asset Filter Builder used by Collections and Asset Publisher, and DDM repeatable fields used in web content articles and forms. Each one reinvented the same pattern with small per-row plus/hr buttons, ~28 px hit targets, and inconsistent layouts. The original report (LPD-19951) called out the small click area and outdated design; the Figma "Option 2" frame was selected as the unified design.

## How it is being fixed

The five commits apply the Figma "Option 2" design across the four in-scope consumers: a borderless `+ Add Option` button below the list, a per-row trash button that sits next to each row, and 44×44 px touch targets per WCAG 2.5.5. File Size Limits, the Asset Filter Builder, and DDM repeatable fields pin the first row so it cannot be deleted, matching the design. The shared `InputSets` primitive consumed by the Sort widget received the same visual polish so its row chrome and Add button stay aligned with the other consumers. One commit updates the Poshi locator `RULE_BUILDER_ADD_CONDITION` to accept the new `Add Option` aria-label.

<img width="919" height="486" alt="image" src="https://github.com/user-attachments/assets/8c9c42a1-54c0-4a01-9363-87b1f24c03d1" />
<hr/>
<img width="1244" height="984" alt="image" src="https://github.com/user-attachments/assets/e5d69ad5-1f7c-4349-861d-bf409d78d592" />
<hr/>
<img width="774" height="391" alt="image" src="https://github.com/user-attachments/assets/3c134033-2e6a-4e37-a678-f4b033ace7fc" />
<hr/>
<img width="1605" height="636" alt="image" src="https://github.com/user-attachments/assets/74cbc4a1-3cee-415e-9b57-7cfcd2f84af1" />
