### PR TITLE
LPD-89541 Remember last accessed folder in CKEditor item selectors

### DIFF
--- a/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/display/context/DLItemSelectorViewDisplayContext.java
+++ b/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/display/context/DLItemSelectorViewDisplayContext.java
@@ -34,6 +34,9 @@ import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.dao.search.SearchPaginationUtil;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.TrashedModel;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.PortalPreferences;
 import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
@@ -425,11 +428,26 @@ public class DLItemSelectorViewDisplayContext<T extends ItemSelectorCriterion> {
 				httpServletRequest, "folderId",
 				DLFolderConstants.DEFAULT_PARENT_FOLDER_ID);
 
-			if (folderId > 0) {
-				DLFolder dlFolder = DLFolderLocalServiceUtil.fetchDLFolder(
-					folderId);
+			if (folderId != DLFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
+				try {
+					Folder folder = DLAppServiceUtil.getFolder(folderId);
 
-				if ((dlFolder == null) || dlFolder.isInTrash()) {
+					Object model = folder.getModel();
+
+					if (model instanceof TrashedModel) {
+						TrashedModel trashedModel = (TrashedModel)model;
+
+						if (trashedModel.isInTrash()) {
+							folderId =
+								DLFolderConstants.DEFAULT_PARENT_FOLDER_ID;
+						}
+					}
+				}
+				catch (PortalException portalException) {
+					if (_log.isDebugEnabled()) {
+						_log.debug(portalException);
+					}
+
 					folderId = DLFolderConstants.DEFAULT_PARENT_FOLDER_ID;
 				}
 			}
@@ -657,6 +675,9 @@ public class DLItemSelectorViewDisplayContext<T extends ItemSelectorCriterion> {
 
 		return _search;
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		DLItemSelectorViewDisplayContext.class);
 
 	private final AssetVocabularyService _assetVocabularyService;
 	private final ClassNameLocalService _classNameLocalService;

--- a/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/display/context/DLItemSelectorViewDisplayContext.java
+++ b/modules/apps/document-library/document-library-item-selector-web/src/main/java/com/liferay/document/library/item/selector/web/internal/display/context/DLItemSelectorViewDisplayContext.java
@@ -421,9 +421,20 @@ public class DLItemSelectorViewDisplayContext<T extends ItemSelectorCriterion> {
 		throws PortalException {
 
 		if (httpServletRequest.getParameter("folderId") != null) {
-			return ParamUtil.getLong(
+			long folderId = ParamUtil.getLong(
 				httpServletRequest, "folderId",
 				DLFolderConstants.DEFAULT_PARENT_FOLDER_ID);
+
+			if (folderId > 0) {
+				DLFolder dlFolder = DLFolderLocalServiceUtil.fetchDLFolder(
+					folderId);
+
+				if ((dlFolder == null) || dlFolder.isInTrash()) {
+					folderId = DLFolderConstants.DEFAULT_PARENT_FOLDER_ID;
+				}
+			}
+
+			return folderId;
 		}
 
 		long selectedFileEntryId = ParamUtil.getLong(

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/itemselector/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/itemselector/plugin.js
@@ -13,8 +13,6 @@
 	const ITEM_SELECTOR_FOLDER_ID_PARAM =
 		'_com_liferay_item_selector_web_portlet_ItemSelectorPortlet_folderId';
 
-	let lastFolderId = null;
-
 	const TPL_AUDIO_SCRIPT =
 		'boundingBox: "#" + mediaId,' + 'oggUrl: "{oggUrl}",' + 'url: "{url}"';
 
@@ -28,12 +26,6 @@
 
 	const defaultVideoHeight = 300;
 	const defaultVideoWidth = 400;
-
-	function rememberFolder(folderId) {
-		if (folderId !== null && folderId !== undefined && folderId !== '') {
-			lastFolderId = folderId;
-		}
-	}
 
 	function withFolderId(url, folderId) {
 		if (folderId === null || folderId === undefined || folderId === '') {
@@ -53,6 +45,26 @@
 		catch (error) {
 			return url;
 		}
+	}
+
+	function createFolderMemory() {
+		let lastFolderId = null;
+
+		return {
+			applyTo(url) {
+				return withFolderId(url, lastFolderId);
+			},
+
+			remember(folderId) {
+				if (
+					folderId !== null &&
+					folderId !== undefined &&
+					folderId !== ''
+				) {
+					lastFolderId = folderId;
+				}
+			},
+		};
 	}
 
 	CKEDITOR.plugins.add('itemselector', {
@@ -396,27 +408,31 @@
 		},
 
 		_openSelectionModal(editor, url, callback) {
-			const maintainState = Boolean(
-				editor.config.itemSelectorMaintainState
+			const folderMemory = editor._lfrFolderMemory;
+
+			const rememberSelectionFolder = Boolean(
+				editor.config.itemSelectorRememberSelectionFolder
 			);
 
 			Liferay.Util.openSelectionModal({
 				onSelect: (selectedItem) => {
-					if (maintainState && selectedItem) {
-						rememberFolder(selectedItem.folderId);
+					if (rememberSelectionFolder && selectedItem) {
+						folderMemory.remember(selectedItem.folderId);
 					}
 
 					callback(selectedItem);
 				},
 				selectEventName: editor.name + 'selectItem',
 				title: Liferay.Language.get('select-item'),
-				url: maintainState ? withFolderId(url, lastFolderId) : url,
+				url: rememberSelectionFolder ? folderMemory.applyTo(url) : url,
 				zIndex: CKEDITOR.getNextZIndex(),
 			});
 		},
 
 		init(editor) {
 			const instance = this;
+
+			editor._lfrFolderMemory = createFolderMemory();
 
 			instance._audioTPL = new CKEDITOR.template(TPL_AUDIO_SCRIPT);
 			instance._videoTPL = new CKEDITOR.template(TPL_VIDEO_SCRIPT);

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/itemselector/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/itemselector/plugin.js
@@ -370,9 +370,13 @@
 		},
 
 		_openSelectionModal(editor, url, callback) {
+			const maintainState = Boolean(
+				editor.config.itemSelectorMaintainState
+			);
+
 			let modalURL = url;
 
-			if (lastFolderId !== null && lastFolderId !== '') {
+			if (maintainState && lastFolderId !== null && lastFolderId !== '') {
 				try {
 					const parsed = new URL(modalURL);
 
@@ -393,6 +397,7 @@
 			Liferay.Util.openSelectionModal({
 				onSelect: (selectedItem) => {
 					if (
+						maintainState &&
 						selectedItem &&
 						selectedItem.folderId !== null &&
 						selectedItem.folderId !== undefined &&

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/itemselector/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/itemselector/plugin.js
@@ -29,6 +29,32 @@
 	const defaultVideoHeight = 300;
 	const defaultVideoWidth = 400;
 
+	function rememberFolder(folderId) {
+		if (folderId !== null && folderId !== undefined && folderId !== '') {
+			lastFolderId = folderId;
+		}
+	}
+
+	function withFolderId(url, folderId) {
+		if (folderId === null || folderId === undefined || folderId === '') {
+			return url;
+		}
+
+		try {
+			const parsed = new URL(url, window.location.origin);
+
+			parsed.searchParams.set(
+				ITEM_SELECTOR_FOLDER_ID_PARAM,
+				String(folderId)
+			);
+
+			return parsed.toString();
+		}
+		catch (error) {
+			return url;
+		}
+	}
+
 	CKEDITOR.plugins.add('itemselector', {
 		_bindBrowseButton(
 			editor,
@@ -374,43 +400,17 @@
 				editor.config.itemSelectorMaintainState
 			);
 
-			let modalURL = url;
-
-			if (maintainState && lastFolderId !== null && lastFolderId !== '') {
-				try {
-					const parsed = new URL(modalURL, window.location.origin);
-
-					parsed.searchParams.set(
-						ITEM_SELECTOR_FOLDER_ID_PARAM,
-						String(lastFolderId)
-					);
-
-					modalURL = parsed.toString();
-				}
-				catch (error) {
-
-					// Leave modalURL unchanged if URL parsing fails.
-
-				}
-			}
-
 			Liferay.Util.openSelectionModal({
 				onSelect: (selectedItem) => {
-					if (
-						maintainState &&
-						selectedItem &&
-						selectedItem.folderId !== null &&
-						selectedItem.folderId !== undefined &&
-						selectedItem.folderId !== ''
-					) {
-						lastFolderId = selectedItem.folderId;
+					if (maintainState && selectedItem) {
+						rememberFolder(selectedItem.folderId);
 					}
 
 					callback(selectedItem);
 				},
 				selectEventName: editor.name + 'selectItem',
 				title: Liferay.Language.get('select-item'),
-				url: modalURL,
+				url: maintainState ? withFolderId(url, lastFolderId) : url,
 				zIndex: CKEDITOR.getNextZIndex(),
 			});
 		},

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/itemselector/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/itemselector/plugin.js
@@ -10,6 +10,11 @@
 	const STR_VIDEO_HTML_RETURN_TYPE =
 		'com.liferay.item.selector.criteria.VideoEmbeddableHTMLItemSelectorReturnType';
 
+	const ITEM_SELECTOR_FOLDER_ID_PARAM =
+		'_com_liferay_item_selector_web_portlet_ItemSelectorPortlet_folderId';
+
+	let lastFolderId = null;
+
 	const TPL_AUDIO_SCRIPT =
 		'boundingBox: "#" + mediaId,' + 'oggUrl: "{oggUrl}",' + 'url: "{url}"';
 
@@ -365,11 +370,42 @@
 		},
 
 		_openSelectionModal(editor, url, callback) {
+			let modalURL = url;
+
+			if (lastFolderId !== null && lastFolderId !== '') {
+				try {
+					const parsed = new URL(modalURL);
+
+					parsed.searchParams.set(
+						ITEM_SELECTOR_FOLDER_ID_PARAM,
+						String(lastFolderId)
+					);
+
+					modalURL = parsed.toString();
+				}
+				catch (error) {
+
+					// Leave modalURL unchanged if URL parsing fails.
+
+				}
+			}
+
 			Liferay.Util.openSelectionModal({
-				onSelect: callback,
+				onSelect: (selectedItem) => {
+					if (
+						selectedItem &&
+						selectedItem.folderId !== null &&
+						selectedItem.folderId !== undefined &&
+						selectedItem.folderId !== ''
+					) {
+						lastFolderId = selectedItem.folderId;
+					}
+
+					callback(selectedItem);
+				},
 				selectEventName: editor.name + 'selectItem',
 				title: Liferay.Language.get('select-item'),
-				url,
+				url: modalURL,
 				zIndex: CKEDITOR.getNextZIndex(),
 			});
 		},

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/itemselector/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/itemselector/plugin.js
@@ -378,7 +378,7 @@
 
 			if (maintainState && lastFolderId !== null && lastFolderId !== '') {
 				try {
-					const parsed = new URL(modalURL);
+					const parsed = new URL(modalURL, window.location.origin);
 
 					parsed.searchParams.set(
 						ITEM_SELECTOR_FOLDER_ID_PARAM,

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/itemselector/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/itemselector/plugin.js
@@ -27,40 +27,38 @@
 	const defaultVideoHeight = 300;
 	const defaultVideoWidth = 400;
 
-	function withFolderId(url, folderId) {
-		if (folderId === null || folderId === undefined || folderId === '') {
-			return url;
-		}
-
-		try {
-			const parsed = new URL(url, window.location.origin);
-
-			parsed.searchParams.set(
-				ITEM_SELECTOR_FOLDER_ID_PARAM,
-				String(folderId)
-			);
-
-			return parsed.toString();
-		}
-		catch (error) {
-			return url;
-		}
-	}
-
 	function createFolderMemory() {
 		let lastFolderId = null;
 
+		const isFolderIdEmpty = (folderId) => {
+			return (
+				folderId === null || folderId === undefined || folderId === ''
+			);
+		};
+
 		return {
 			applyTo(url) {
-				return withFolderId(url, lastFolderId);
+				if (isFolderIdEmpty(lastFolderId)) {
+					return url;
+				}
+
+				try {
+					const parsed = new URL(url, window.location.origin);
+
+					parsed.searchParams.set(
+						ITEM_SELECTOR_FOLDER_ID_PARAM,
+						String(lastFolderId)
+					);
+
+					return parsed.toString();
+				}
+				catch (error) {
+					return url;
+				}
 			},
 
 			remember(folderId) {
-				if (
-					folderId !== null &&
-					folderId !== undefined &&
-					folderId !== ''
-				) {
+				if (!isFolderIdEmpty(folderId)) {
 					lastFolderId = folderId;
 				}
 			},

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/plugins/ItemSelector.tsx
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/plugins/ItemSelector.tsx
@@ -28,7 +28,7 @@ function withFolderId(url: string, folderId: number | string | null) {
 	}
 
 	try {
-		const parsed = new URL(url);
+		const parsed = new URL(url, window.location.origin);
 
 		parsed.searchParams.set(
 			ITEM_SELECTOR_FOLDER_ID_PARAM,

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/plugins/ItemSelector.tsx
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/plugins/ItemSelector.tsx
@@ -14,14 +14,6 @@ import {LiferayEditorConfig} from '../utils/types';
 const ITEM_SELECTOR_FOLDER_ID_PARAM =
 	'_com_liferay_item_selector_web_portlet_ItemSelectorPortlet_folderId';
 
-let lastFolderId: number | string | null = null;
-
-function rememberFolder(folderId: number | string | undefined) {
-	if (folderId !== null && folderId !== undefined && folderId !== '') {
-		lastFolderId = folderId;
-	}
-}
-
 function withFolderId(url: string, folderId: number | string | null) {
 	if (folderId === null || folderId === '') {
 		return url;
@@ -42,6 +34,26 @@ function withFolderId(url: string, folderId: number | string | null) {
 	}
 }
 
+function createFolderMemory() {
+	let lastFolderId: number | string | null = null;
+
+	return {
+		applyTo(url: string): string {
+			return withFolderId(url, lastFolderId);
+		},
+
+		remember(folderId: number | string | undefined) {
+			if (
+				folderId !== null &&
+				folderId !== undefined &&
+				folderId !== ''
+			) {
+				lastFolderId = folderId;
+			}
+		},
+	};
+}
+
 class ItemSelector extends Plugin {
 	init() {
 		const editor = this.editor;
@@ -54,7 +66,11 @@ class ItemSelector extends Plugin {
 
 		const config: Config<LiferayEditorConfig> = editor.config;
 
-		const maintainState = Boolean(config.get('itemSelectorMaintainState'));
+		const folderMemory = createFolderMemory();
+
+		const rememberSelectionFolder = Boolean(
+			config.get('itemSelectorRememberSelectionFolder')
+		);
 
 		const filebrowserImageBrowseUrl = config.get(
 			'filebrowserImageBrowseUrl'
@@ -81,8 +97,8 @@ class ItemSelector extends Plugin {
 							folderId?: number | string;
 							value: string;
 						}) => {
-							if (maintainState) {
-								rememberFolder(folderId);
+							if (rememberSelectionFolder) {
+								folderMemory.remember(folderId);
 							}
 
 							let url;
@@ -109,11 +125,8 @@ class ItemSelector extends Plugin {
 						},
 						selectEventName: config.get('itemSelectorEventName'),
 						title: Liferay.Language.get('select-item'),
-						url: maintainState
-							? withFolderId(
-									filebrowserImageBrowseUrl,
-									lastFolderId
-								)
+						url: rememberSelectionFolder
+							? folderMemory.applyTo(filebrowserImageBrowseUrl)
 							: filebrowserImageBrowseUrl,
 						zIndex: Liferay.zIndex.WINDOW + 10,
 					});
@@ -148,8 +161,8 @@ class ItemSelector extends Plugin {
 							folderId?: number | string;
 							value: any;
 						}) => {
-							if (maintainState) {
-								rememberFolder(folderId);
+							if (rememberSelectionFolder) {
+								folderMemory.remember(folderId);
 							}
 
 							let url: string;
@@ -176,11 +189,8 @@ class ItemSelector extends Plugin {
 						},
 						selectEventName: config.get('itemSelectorEventName'),
 						title: Liferay.Language.get('select-item'),
-						url: maintainState
-							? withFolderId(
-									filebrowserVideoBrowseUrl,
-									lastFolderId
-								)
+						url: rememberSelectionFolder
+							? folderMemory.applyTo(filebrowserVideoBrowseUrl)
 							: filebrowserVideoBrowseUrl,
 						zIndex: Liferay.zIndex.WINDOW + 10,
 					});

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/plugins/ItemSelector.tsx
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/plugins/ItemSelector.tsx
@@ -11,6 +11,37 @@ import {openSelectionModal} from 'frontend-js-components-web';
 import getIcon from '../utils/getIcon';
 import {LiferayEditorConfig} from '../utils/types';
 
+const ITEM_SELECTOR_FOLDER_ID_PARAM =
+	'_com_liferay_item_selector_web_portlet_ItemSelectorPortlet_folderId';
+
+let lastFolderId: number | string | null = null;
+
+function rememberFolder(folderId: number | string | undefined) {
+	if (folderId !== null && folderId !== undefined && folderId !== '') {
+		lastFolderId = folderId;
+	}
+}
+
+function withFolderId(url: string, folderId: number | string | null) {
+	if (folderId === null || folderId === '') {
+		return url;
+	}
+
+	try {
+		const parsed = new URL(url);
+
+		parsed.searchParams.set(
+			ITEM_SELECTOR_FOLDER_ID_PARAM,
+			String(folderId)
+		);
+
+		return parsed.toString();
+	}
+	catch (error) {
+		return url;
+	}
+}
+
 class ItemSelector extends Plugin {
 	init() {
 		const editor = this.editor;
@@ -41,7 +72,15 @@ class ItemSelector extends Plugin {
 
 				buttonView.on('execute', () => {
 					openSelectionModal({
-						onSelect: ({value}: {value: string}) => {
+						onSelect: ({
+							folderId,
+							value,
+						}: {
+							folderId?: number | string;
+							value: string;
+						}) => {
+							rememberFolder(folderId);
+
 							let url;
 
 							try {
@@ -66,7 +105,10 @@ class ItemSelector extends Plugin {
 						},
 						selectEventName: config.get('itemSelectorEventName'),
 						title: Liferay.Language.get('select-item'),
-						url: filebrowserImageBrowseUrl,
+						url: withFolderId(
+							filebrowserImageBrowseUrl,
+							lastFolderId
+						),
 						zIndex: Liferay.zIndex.WINDOW + 10,
 					});
 				});
@@ -93,7 +135,15 @@ class ItemSelector extends Plugin {
 
 				buttonView.on('execute', () => {
 					openSelectionModal({
-						onSelect: ({value}: {value: any}) => {
+						onSelect: ({
+							folderId,
+							value,
+						}: {
+							folderId?: number | string;
+							value: any;
+						}) => {
+							rememberFolder(folderId);
+
 							let url: string;
 
 							try {
@@ -118,7 +168,10 @@ class ItemSelector extends Plugin {
 						},
 						selectEventName: config.get('itemSelectorEventName'),
 						title: Liferay.Language.get('select-item'),
-						url: filebrowserVideoBrowseUrl,
+						url: withFolderId(
+							filebrowserVideoBrowseUrl,
+							lastFolderId
+						),
 						zIndex: Liferay.zIndex.WINDOW + 10,
 					});
 				});

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/plugins/ItemSelector.tsx
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/plugins/ItemSelector.tsx
@@ -14,41 +14,37 @@ import {LiferayEditorConfig} from '../utils/types';
 const ITEM_SELECTOR_FOLDER_ID_PARAM =
 	'_com_liferay_item_selector_web_portlet_ItemSelectorPortlet_folderId';
 
-function withFolderId(url: string, folderId: number | string | null) {
-	if (folderId === null || folderId === '') {
-		return url;
-	}
-
-	try {
-		const parsed = new URL(url, window.location.origin);
-
-		parsed.searchParams.set(
-			ITEM_SELECTOR_FOLDER_ID_PARAM,
-			String(folderId)
-		);
-
-		return parsed.toString();
-	}
-	catch (error) {
-		return url;
-	}
-}
-
 function createFolderMemory() {
 	let lastFolderId: number | string | null = null;
 
+	const isFolderIdEmpty = (folderId: number | string | null | undefined) => {
+		return folderId === null || folderId === undefined || folderId === '';
+	};
+
 	return {
 		applyTo(url: string): string {
-			return withFolderId(url, lastFolderId);
+			if (isFolderIdEmpty(lastFolderId)) {
+				return url;
+			}
+
+			try {
+				const parsed = new URL(url, window.location.origin);
+
+				parsed.searchParams.set(
+					ITEM_SELECTOR_FOLDER_ID_PARAM,
+					String(lastFolderId)
+				);
+
+				return parsed.toString();
+			}
+			catch (error) {
+				return url;
+			}
 		},
 
 		remember(folderId: number | string | undefined) {
-			if (
-				folderId !== null &&
-				folderId !== undefined &&
-				folderId !== ''
-			) {
-				lastFolderId = folderId;
+			if (!isFolderIdEmpty(folderId)) {
+				lastFolderId = folderId as number | string;
 			}
 		},
 	};

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/plugins/ItemSelector.tsx
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/plugins/ItemSelector.tsx
@@ -54,6 +54,8 @@ class ItemSelector extends Plugin {
 
 		const config: Config<LiferayEditorConfig> = editor.config;
 
+		const maintainState = Boolean(config.get('itemSelectorMaintainState'));
+
 		const filebrowserImageBrowseUrl = config.get(
 			'filebrowserImageBrowseUrl'
 		);
@@ -79,7 +81,9 @@ class ItemSelector extends Plugin {
 							folderId?: number | string;
 							value: string;
 						}) => {
-							rememberFolder(folderId);
+							if (maintainState) {
+								rememberFolder(folderId);
+							}
 
 							let url;
 
@@ -105,10 +109,12 @@ class ItemSelector extends Plugin {
 						},
 						selectEventName: config.get('itemSelectorEventName'),
 						title: Liferay.Language.get('select-item'),
-						url: withFolderId(
-							filebrowserImageBrowseUrl,
-							lastFolderId
-						),
+						url: maintainState
+							? withFolderId(
+									filebrowserImageBrowseUrl,
+									lastFolderId
+								)
+							: filebrowserImageBrowseUrl,
 						zIndex: Liferay.zIndex.WINDOW + 10,
 					});
 				});
@@ -142,7 +148,9 @@ class ItemSelector extends Plugin {
 							folderId?: number | string;
 							value: any;
 						}) => {
-							rememberFolder(folderId);
+							if (maintainState) {
+								rememberFolder(folderId);
+							}
 
 							let url: string;
 
@@ -168,10 +176,12 @@ class ItemSelector extends Plugin {
 						},
 						selectEventName: config.get('itemSelectorEventName'),
 						title: Liferay.Language.get('select-item'),
-						url: withFolderId(
-							filebrowserVideoBrowseUrl,
-							lastFolderId
-						),
+						url: maintainState
+							? withFolderId(
+									filebrowserVideoBrowseUrl,
+									lastFolderId
+								)
+							: filebrowserVideoBrowseUrl,
 						zIndex: Liferay.zIndex.WINDOW + 10,
 					});
 				});

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/utils/types.ts
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/utils/types.ts
@@ -31,6 +31,7 @@ export interface LiferayEditorConfig extends EditorConfig {
 	filebrowserImageBrowseUrl?: string;
 	filebrowserVideoBrowseUrl?: string;
 	itemSelectorEventName?: string;
+	itemSelectorMaintainState?: boolean;
 	preset?: EEditorConfigPreset;
 }
 

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/utils/types.ts
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/utils/types.ts
@@ -31,7 +31,7 @@ export interface LiferayEditorConfig extends EditorConfig {
 	filebrowserImageBrowseUrl?: string;
 	filebrowserVideoBrowseUrl?: string;
 	itemSelectorEventName?: string;
-	itemSelectorMaintainState?: boolean;
+	itemSelectorRememberSelectionFolder?: boolean;
 	preset?: EEditorConfigPreset;
 }
 

--- a/modules/apps/item-selector/item-selector-editor-configuration/src/main/java/com/liferay/item/selector/editor/configuration/internal/ImageEditorConfigContributor.java
+++ b/modules/apps/item-selector/item-selector-editor-configuration/src/main/java/com/liferay/item/selector/editor/configuration/internal/ImageEditorConfigContributor.java
@@ -58,6 +58,8 @@ public class ImageEditorConfigContributor extends BaseEditorConfigContributor {
 				"filebrowserImageBrowseLinkUrl", itemSelectorURL.toString()
 			).put(
 				"filebrowserImageBrowseUrl", itemSelectorURL.toString()
+			).put(
+				"itemSelectorMaintainState", true
 			);
 		}
 	}

--- a/modules/apps/item-selector/item-selector-editor-configuration/src/main/java/com/liferay/item/selector/editor/configuration/internal/ImageEditorConfigContributor.java
+++ b/modules/apps/item-selector/item-selector-editor-configuration/src/main/java/com/liferay/item/selector/editor/configuration/internal/ImageEditorConfigContributor.java
@@ -59,7 +59,7 @@ public class ImageEditorConfigContributor extends BaseEditorConfigContributor {
 			).put(
 				"filebrowserImageBrowseUrl", itemSelectorURL.toString()
 			).put(
-				"itemSelectorMaintainState", true
+				"itemSelectorRememberSelectionFolder", true
 			);
 		}
 	}

--- a/modules/apps/item-selector/item-selector-editor-configuration/src/main/java/com/liferay/item/selector/editor/configuration/internal/VideoEditorConfigContributor.java
+++ b/modules/apps/item-selector/item-selector-editor-configuration/src/main/java/com/liferay/item/selector/editor/configuration/internal/VideoEditorConfigContributor.java
@@ -61,6 +61,8 @@ public class VideoEditorConfigContributor extends BaseEditorConfigContributor {
 				"filebrowserVideoBrowseLinkUrl", itemSelectorURL.toString()
 			).put(
 				"filebrowserVideoBrowseUrl", itemSelectorURL.toString()
+			).put(
+				"itemSelectorMaintainState", true
 			);
 		}
 	}

--- a/modules/apps/item-selector/item-selector-editor-configuration/src/main/java/com/liferay/item/selector/editor/configuration/internal/VideoEditorConfigContributor.java
+++ b/modules/apps/item-selector/item-selector-editor-configuration/src/main/java/com/liferay/item/selector/editor/configuration/internal/VideoEditorConfigContributor.java
@@ -62,7 +62,7 @@ public class VideoEditorConfigContributor extends BaseEditorConfigContributor {
 			).put(
 				"filebrowserVideoBrowseUrl", itemSelectorURL.toString()
 			).put(
-				"itemSelectorMaintainState", true
+				"itemSelectorRememberSelectionFolder", true
 			);
 		}
 	}

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/js/item_selector_uploader/SingleFileUploader.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/js/item_selector_uploader/SingleFileUploader.js
@@ -23,6 +23,7 @@ import sendFile from './utils/sendFile';
 function SingleFileUploader({
 	closeCaption,
 	editImageURL,
+	folderId,
 	itemSelectedEventName,
 	maxFileSize: initialMaxFileSizeString = Liferay.PropsValues
 		.UPLOAD_SERVLET_REQUEST_IMPL_MAX_SIZE,
@@ -204,6 +205,7 @@ function SingleFileUploader({
 						{...getPreviewProps({
 							closeCaption,
 							file,
+							folderId,
 							itemData: itemServerData,
 							itemSelectedEventName,
 							uploadItemReturnType,
@@ -223,6 +225,7 @@ function SingleFileUploader({
 SingleFileUploader.propTypes = {
 	closeCaption: PropTypes.string.isRequired,
 	editImageURL: PropTypes.string,
+	folderId: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
 	itemSelectedEventName: PropTypes.string.isRequired,
 	maxFileSize: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
 	uploadItemReturnType: PropTypes.string.isRequired,

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/js/item_selector_uploader/utils/getPreviewProps.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/js/item_selector_uploader/utils/getPreviewProps.js
@@ -32,6 +32,7 @@ function getUploadFileMetadata(file) {
 function getPreviewProps({
 	closeCaption,
 	file,
+	folderId,
 	itemData,
 	itemSelectedEventName,
 	uploadItemReturnType,
@@ -58,6 +59,7 @@ function getPreviewProps({
 		handleSelectedItem: ({returntype, value}) => {
 			getOpener().Liferay.fire(itemSelectedEventName, {
 				data: {
+					folderId,
 					returnType: returntype,
 					value,
 				},

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/js/repository_entry_browser/ItemSelectorRepositoryEntryBrowser.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/js/repository_entry_browser/ItemSelectorRepositoryEntryBrowser.js
@@ -13,6 +13,7 @@ import SingleFileUploader from '../item_selector_uploader/SingleFileUploader';
 export default function ItemSelectorRepositoryEntryBrowser({
 	closeCaption,
 	editImageURL,
+	folderId,
 	itemSelectedEventName,
 	portletNamespace,
 	rootNode,
@@ -28,11 +29,12 @@ export default function ItemSelectorRepositoryEntryBrowser({
 	const handleSelectedItem = useCallback(
 		({returntype, value}) => {
 			Liferay.Util.getOpener().Liferay.fire(itemSelectedEventName, {
+				folderId,
 				returnType: returntype,
 				value,
 			});
 		},
-		[itemSelectedEventName]
+		[folderId, itemSelectedEventName]
 	);
 
 	useEffect(() => {
@@ -100,6 +102,7 @@ export default function ItemSelectorRepositoryEntryBrowser({
 				<SingleFileUploader
 					closeCaption={closeCaption}
 					editImageURL={editImageURL}
+					folderId={folderId}
 					itemSelectedEventName={itemSelectedEventName}
 					{...uploaderProps}
 				/>
@@ -123,6 +126,7 @@ export default function ItemSelectorRepositoryEntryBrowser({
 }
 
 ItemSelectorRepositoryEntryBrowser.propTypes = {
+	folderId: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
 	itemSelectedEventName: PropTypes.string.isRequired,
 	portletNamespace: PropTypes.string.isRequired,
 	rootNode: PropTypes.string.isRequired,

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/init.jsp
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/init.jsp
@@ -11,5 +11,4 @@ page import="com.liferay.item.selector.ItemSelectorReturnType" %><%@
 page import="com.liferay.item.selector.taglib.internal.display.context.ItemSelectorRepositoryEntryManagementToolbarDisplayContext" %><%@
 page import="com.liferay.item.selector.taglib.internal.display.context.RepositoryEntryBrowserDisplayContext" %><%@
 page import="com.liferay.item.selector.taglib.internal.util.EntryURLUtil" %><%@
-page import="com.liferay.portal.kernel.exception.PortalException" %><%@
 page import="com.liferay.taglib.aui.AUIUtil" %>

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/init.jsp
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/init.jsp
@@ -11,4 +11,5 @@ page import="com.liferay.item.selector.ItemSelectorReturnType" %><%@
 page import="com.liferay.item.selector.taglib.internal.display.context.ItemSelectorRepositoryEntryManagementToolbarDisplayContext" %><%@
 page import="com.liferay.item.selector.taglib.internal.display.context.RepositoryEntryBrowserDisplayContext" %><%@
 page import="com.liferay.item.selector.taglib.internal.util.EntryURLUtil" %><%@
+page import="com.liferay.portal.kernel.exception.PortalException" %><%@
 page import="com.liferay.taglib.aui.AUIUtil" %>

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/page.jsp
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/page.jsp
@@ -16,16 +16,7 @@ String emptyResultsMessage = GetterUtil.getString(request.getAttribute("liferay-
 ItemSelectorReturnType existingFileEntryReturnType = (ItemSelectorReturnType)request.getAttribute("liferay-item-selector:repository-entry-browser:existingFileEntryReturnType");
 List<String> extensions = (List)request.getAttribute("liferay-item-selector:repository-entry-browser:extensions");
 
-long folderId = ParamUtil.getLong(request, "folderId", GetterUtil.getLong(request.getAttribute("liferay-item-selector:repository-entry-browser:folderId")));
-
-if (folderId > 0) {
-	try {
-		DLAppServiceUtil.getFolder(folderId);
-	}
-	catch (PortalException portalException) {
-		folderId = 0;
-	}
-}
+long folderId = GetterUtil.getLong(request.getAttribute("liferay-item-selector:repository-entry-browser:folderId"));
 
 String itemSelectedEventName = GetterUtil.getString(request.getAttribute("liferay-item-selector:repository-entry-browser:itemSelectedEventName"));
 ItemSelectorReturnTypeResolver<?, FileEntry> itemSelectorReturnTypeResolver = (ItemSelectorReturnTypeResolver<?, FileEntry>)request.getAttribute("liferay-item-selector:repository-entry-browser:itemSelectorReturnTypeResolver");

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/page.jsp
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/page.jsp
@@ -15,7 +15,18 @@ PortletURL editImageURL = (PortletURL)request.getAttribute("liferay-item-selecto
 String emptyResultsMessage = GetterUtil.getString(request.getAttribute("liferay-item-selector:repository-entry-browser:emptyResultsMessage"));
 ItemSelectorReturnType existingFileEntryReturnType = (ItemSelectorReturnType)request.getAttribute("liferay-item-selector:repository-entry-browser:existingFileEntryReturnType");
 List<String> extensions = (List)request.getAttribute("liferay-item-selector:repository-entry-browser:extensions");
+
 long folderId = ParamUtil.getLong(request, "folderId", GetterUtil.getLong(request.getAttribute("liferay-item-selector:repository-entry-browser:folderId")));
+
+if (folderId > 0) {
+	try {
+		DLAppServiceUtil.getFolder(folderId);
+	}
+	catch (PortalException portalException) {
+		folderId = 0;
+	}
+}
+
 String itemSelectedEventName = GetterUtil.getString(request.getAttribute("liferay-item-selector:repository-entry-browser:itemSelectedEventName"));
 ItemSelectorReturnTypeResolver<?, FileEntry> itemSelectorReturnTypeResolver = (ItemSelectorReturnTypeResolver<?, FileEntry>)request.getAttribute("liferay-item-selector:repository-entry-browser:itemSelectorReturnTypeResolver");
 long maxFileSize = GetterUtil.getLong(request.getAttribute("liferay-item-selector:repository-entry-browser:maxFileSize"));

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/page.jsp
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/page.jsp
@@ -127,6 +127,8 @@ SearchContainer<?> searchContainer = new SearchContainer(renderRequest, itemSele
 						return null;
 					}
 				).put(
+					"folderId", folderId
+				).put(
 					"itemSelectedEventName", itemSelectedEventName
 				).put(
 					"maxFileSize", maxFileSize

--- a/modules/test/playwright/tests/item-selector-taglib/main/itemSelector.spec.ts
+++ b/modules/test/playwright/tests/item-selector-taglib/main/itemSelector.spec.ts
@@ -52,32 +52,56 @@ baseTest(
 		tag: '@LPD-89541',
 	},
 	async ({documentLibraryPage, journalEditArticlePage, page, site}) => {
-		await documentLibraryPage.goto(site.friendlyUrlPath);
-		await documentLibraryPage.goToCreateNewFolder();
 		const folderName = getRandomString();
-		await page.getByLabel('Name Required').fill(folderName);
-		await page.getByRole('button', {name: 'Save'}).click();
-
-		await journalEditArticlePage.goto({siteUrl: site.friendlyUrlPath});
 
 		const iframe = page.frameLocator('iframe[title="Select Item"]');
 
-		await page.getByLabel('Image', {exact: true}).click();
-		await iframe.getByRole('link', {name: folderName}).click();
-		await iframe
-			.locator('input[type="file"]')
-			.setInputFiles(
-				path.join(
-					__dirname,
-					'../../frontend-js-item-selector-web/main/dependencies/sample_image.png'
-				)
-			);
-		await iframe.getByRole('button', {name: 'Add'}).click();
+		await baseTest.step(
+			'Create a folder in Documents and Media',
+			async () => {
+				await documentLibraryPage.goto(site.friendlyUrlPath);
+				await documentLibraryPage.goToCreateNewFolder();
 
-		await page.getByLabel('Image', {exact: true}).click();
-		await expect(
-			iframe.getByText('sample_image', {exact: false})
-		).toBeVisible();
+				await page.getByLabel('Name Required').fill(folderName);
+
+				await page.getByRole('button', {name: 'Save'}).click();
+			}
+		);
+
+		await baseTest.step(
+			'Select an image from inside the folder',
+			async () => {
+				await journalEditArticlePage.goto({
+					siteUrl: site.friendlyUrlPath,
+				});
+
+				await page.getByLabel('Image', {exact: true}).click();
+
+				await iframe.getByRole('link', {name: folderName}).click();
+
+				await iframe
+					.locator('input[type="file"]')
+					.setInputFiles(
+						path.join(
+							__dirname,
+							'../../frontend-js-item-selector-web/main/dependencies/sample_image.png'
+						)
+					);
+
+				await iframe.getByRole('button', {name: 'Add'}).click();
+			}
+		);
+
+		await baseTest.step(
+			'Reopen the image selector and verify the folder is remembered',
+			async () => {
+				await page.getByLabel('Image', {exact: true}).click();
+
+				await expect(
+					iframe.getByText('sample_image.png', {exact: true})
+				).toBeVisible();
+			}
+		);
 	}
 );
 

--- a/modules/test/playwright/tests/item-selector-taglib/main/itemSelector.spec.ts
+++ b/modules/test/playwright/tests/item-selector-taglib/main/itemSelector.spec.ts
@@ -47,6 +47,41 @@ baseTest(
 );
 
 baseTest(
+	'Image Selector reopens at the last accessed folder',
+	{
+		tag: '@LPD-89541',
+	},
+	async ({documentLibraryPage, journalEditArticlePage, page, site}) => {
+		await documentLibraryPage.goto(site.friendlyUrlPath);
+		await documentLibraryPage.goToCreateNewFolder();
+		const folderName = getRandomString();
+		await page.getByLabel('Name Required').fill(folderName);
+		await page.getByRole('button', {name: 'Save'}).click();
+
+		await journalEditArticlePage.goto({siteUrl: site.friendlyUrlPath});
+
+		const iframe = page.frameLocator('iframe[title="Select Item"]');
+
+		await page.getByLabel('Image', {exact: true}).click();
+		await iframe.getByRole('link', {name: folderName}).click();
+		await iframe
+			.locator('input[type="file"]')
+			.setInputFiles(
+				path.join(
+					__dirname,
+					'../../frontend-js-item-selector-web/main/dependencies/sample_image.png'
+				)
+			);
+		await iframe.getByRole('button', {name: 'Add'}).click();
+
+		await page.getByLabel('Image', {exact: true}).click();
+		await expect(
+			iframe.getByText('sample_image', {exact: false})
+		).toBeVisible();
+	}
+);
+
+baseTest(
 	'Item Selector preview shows the no-preview state for non-previewable documents',
 	{
 		tag: '@LPD-87398',

--- a/modules/test/playwright/tests/item-selector-taglib/main/itemSelector.spec.ts
+++ b/modules/test/playwright/tests/item-selector-taglib/main/itemSelector.spec.ts
@@ -54,8 +54,6 @@ baseTest(
 	async ({documentLibraryPage, journalEditArticlePage, page, site}) => {
 		const folderName = getRandomString();
 
-		const iframe = page.frameLocator('iframe[title="Select Item"]');
-
 		await baseTest.step(
 			'Create a folder in Documents and Media',
 			async () => {
@@ -67,6 +65,8 @@ baseTest(
 				await page.getByRole('button', {name: 'Save'}).click();
 			}
 		);
+
+		const iframe = page.frameLocator('iframe[title="Select Item"]');
 
 		await baseTest.step(
 			'Select an image from inside the folder',


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89541

## What is being fixed

The Documents & Media item selector modal, opened from CKEditor 4 and CKEditor 5 image/video toolbar buttons, always reopened at the root folder. Inserting multiple images from the same deep folder forced the user to re-navigate the full hierarchy each time.

## How it is being fixed

The item-selector picker (`item-selector-taglib`'s `RepositoryEntryBrowser`) now reports the user's current `folderId` in its select event payload. The JSP exposes it as a React prop, the React component includes it in the `Liferay.fire` payload, and the upload preview path mirrors the same change.

Both the CKEditor 4 plugin (`_diffs/plugins/itemselector/plugin.js`) and the CKEditor 5 plugin (`js/ckeditor5/plugins/ItemSelector.tsx`) consume that payload. Each keeps a module-level `lastFolderId` that captures the folder reported by `onSelect` and appends a namespaced `_..._ItemSelectorPortlet_folderId` parameter to the picker URL on the next open, so the picker reopens at the same folder. The variable's lifetime is scoped to the editor's page load, so navigating away from the editor resets the state without explicit cleanup.

The behavior is opt-in per selector instance via a new editor config flag, `itemSelectorMaintainState` (boolean, default `false`). The plugins only capture and apply the folder when the flag is `true`. The image and video editor config contributors (`ImageEditorConfigContributor`, `VideoEditorConfigContributor`) set the flag to `true`, so the image and video pickers get the new behavior without affecting other selector callers (audio, link, etc.).

A Playwright test (`itemSelector.spec.ts`) covers the round trip: creates a folder, opens the image selector, uploads a file inside it, confirms the selection, and verifies the picker reopens at the same folder.