### PR TITLE
LPD-2072: Align text to back button in Filter title

### DIFF
--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/variables/_dropdowns.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/variables/_dropdowns.scss
@@ -285,7 +285,9 @@ $cadmin-dropdown-subheader-text-transform: uppercase !default;
 $cadmin-dropdown-subheader: () !default;
 $cadmin-dropdown-subheader: map-deep-merge(
 	(
+		align-items: center,
 		color: $cadmin-dropdown-subheader-color,
+		display: flex,
 		font-size: $cadmin-dropdown-subheader-font-size,
 		font-weight: $cadmin-dropdown-subheader-font-weight,
 		margin-bottom: $cadmin-dropdown-subheader-margin-bottom,

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/variables/_dropdowns.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/variables/_dropdowns.scss
@@ -384,7 +384,9 @@ $dropdown-subheader-text-transform: uppercase !default;
 $dropdown-subheader: () !default;
 $dropdown-subheader: map-deep-merge(
 	(
+		align-items: center,
 		color: $dropdown-subheader-color,
+		display: flex,
 		font-size: $dropdown-subheader-font-size,
 		font-weight: $dropdown-subheader-font-weight,
 		margin-bottom: $dropdown-subheader-margin-bottom,


### PR DESCRIPTION
**Ticket**: [LPD-2072](https://liferay.atlassian.net/browse/LPD-2072)

This update fixes an issue with the text alignment of the back button in the Filter title.

**Misalignment:**

<img width="312" height="376" alt="image" src="https://github.com/user-attachments/assets/cbb33690-184a-4984-825a-16a0594af60a" />

**After fix:**
<img width="338" height="407" alt="image" src="https://github.com/user-attachments/assets/190f305c-d57d-4bf0-b909-1a35e3896a40" />

**How I fixed it:**
Added display: flex and align-items: center to the component.

**Note:** A new feature will replace this component completely once developed: [LPD-13323](https://liferay.atlassian.net/browse/LPD-13323).