### PR TITLE
LPD-44313 ClayDropdownWithItems it not passing props down

### DIFF
--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-drop-down/src/DropDown.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-drop-down/src/DropDown.tsx
@@ -30,13 +30,11 @@ import Section from './Section';
 
 import type {AlignPoints, InternalDispatch} from '@clayui/shared';
 
+import type {DropDownHTMLAttributes} from './types';
+
 const {Collection} = __NOT_PUBLIC_COLLECTION;
 
-interface IProps<T>
-	extends Omit<
-		React.HTMLAttributes<HTMLDivElement | HTMLLIElement>,
-		'children'
-	> {
+interface IProps<T> extends DropDownHTMLAttributes {
 
 	/**
 	 * Flag to indicate if the DropDown menu is active or not (controlled).

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-drop-down/src/DropDownWithDrilldown.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-drop-down/src/DropDownWithDrilldown.tsx
@@ -24,6 +24,7 @@ import type {AlignPoints} from '@clayui/shared';
 
 import type {Item} from './Items';
 import type {IProps as SearchProps} from './Search';
+import type {DropDownHTMLAttributes} from './types';
 
 type Messages = {
 	back: string;
@@ -189,7 +190,7 @@ export type Props = {
 	 * Flag indicating if the caret icon should be displayed on the right side.
 	 */
 	triggerIcon?: string | null;
-} & Omit<React.HTMLAttributes<HTMLDivElement | HTMLLIElement>, 'children'>;
+} & DropDownHTMLAttributes;
 
 type History = {
 	id: string;

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-drop-down/src/DropDownWithDrilldown.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-drop-down/src/DropDownWithDrilldown.tsx
@@ -189,7 +189,7 @@ export type Props = {
 	 * Flag indicating if the caret icon should be displayed on the right side.
 	 */
 	triggerIcon?: string | null;
-};
+} & Omit<React.HTMLAttributes<HTMLDivElement | HTMLLIElement>, 'children'>;
 
 type History = {
 	id: string;
@@ -226,6 +226,7 @@ export function ClayDropDownWithDrilldown({
 	spritemap,
 	trigger,
 	triggerIcon = null,
+	...otherProps
 }: Props) {
 	const [activeMenu, setActiveMenu] = useState(
 		defaultActiveMenu ?? initialActiveMenu
@@ -302,6 +303,7 @@ export function ClayDropDownWithDrilldown({
 
 	return (
 		<DropDown
+			{...otherProps}
 			active={active}
 			alignmentByViewport={alignmentByViewport}
 			alignmentPosition={alignmentPosition}

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-drop-down/src/DropDownWithItems.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-drop-down/src/DropDownWithItems.tsx
@@ -242,6 +242,7 @@ export function ClayDropDownWithItems({
 	if (hasContextual && isMobile) {
 		return (
 			<ClayDropDownWithDrilldown
+				{...otherProps}
 				active={internalActive}
 				alignmentByViewport={alignmentByViewport}
 				alignmentPosition={alignmentPosition}

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-drop-down/src/DropDownWithItems.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-drop-down/src/DropDownWithItems.tsx
@@ -150,7 +150,7 @@ export type Props = {
 	 * Flag indicating if the caret icon should be displayed on the right side.
 	 */
 	triggerIcon?: string | null;
-};
+} & Omit<React.HTMLAttributes<HTMLDivElement | HTMLLIElement>, 'children'>;
 
 let counter = 0;
 
@@ -208,6 +208,7 @@ export function ClayDropDownWithItems({
 	triggerIcon = null,
 	spritemap,
 	trigger,
+	...otherProps
 }: Props) {
 	const triggerElementRef = useRef<HTMLButtonElement | null>(null);
 	const [internalActive, setInternalActive] = useControlledState({
@@ -269,6 +270,7 @@ export function ClayDropDownWithItems({
 	else {
 		return (
 			<ClayDropDown
+				{...otherProps}
 				active={internalActive}
 				alignmentByViewport={alignmentByViewport}
 				alignmentPosition={alignmentPosition}

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-drop-down/src/DropDownWithItems.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-drop-down/src/DropDownWithItems.tsx
@@ -18,6 +18,7 @@ import type {AlignPoints, InternalDispatch} from '@clayui/shared';
 
 import type {Item} from './Items';
 import type {IProps as SearchProps} from './Search';
+import type {DropDownHTMLAttributes} from './types';
 
 export type Props = {
 
@@ -150,7 +151,7 @@ export type Props = {
 	 * Flag indicating if the caret icon should be displayed on the right side.
 	 */
 	triggerIcon?: string | null;
-} & Omit<React.HTMLAttributes<HTMLDivElement | HTMLLIElement>, 'children'>;
+} & DropDownHTMLAttributes;
 
 let counter = 0;
 

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-drop-down/src/__tests__/DropDownWithDrilldown.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-drop-down/src/__tests__/DropDownWithDrilldown.tsx
@@ -9,7 +9,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {cleanup, fireEvent, render} from '@testing-library/react';
+import {cleanup, fireEvent, render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
@@ -198,5 +198,27 @@ describe('ClayDropDownWithDrilldown', () => {
 		expect(onActiveChange).toBeCalled();
 
 		expect(document.body).toMatchSnapshot();
+	});
+
+	it('forwards other props to the underlying DropDown container', () => {
+		const onMouseEnter = jest.fn();
+
+		render(
+			<ClayDropDownWithDrilldown
+				data-testid="drilldown"
+				defaultActive
+				defaultActiveMenu="x0a3"
+				menus={{
+					x0a3: [{href: '#', title: 'Hash Link'}],
+				}}
+				onMouseEnter={onMouseEnter}
+				spritemap="#"
+				trigger={<button data-testid="trigger" />}
+			/>
+		);
+
+		fireEvent.mouseEnter(screen.getByTestId('drilldown'));
+
+		expect(onMouseEnter).toHaveBeenCalledTimes(1);
 	});
 });

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-drop-down/src/__tests__/DropDownWithItems.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-drop-down/src/__tests__/DropDownWithItems.tsx
@@ -233,4 +233,22 @@ describe('ClayDropDownWithItems', () => {
 
 		expect(screen.getByText('linkable')).toBeDefined();
 	});
+
+	it('forwards other props to the underlying ClayDropDown container', () => {
+		const onMouseEnter = jest.fn();
+
+		render(
+			<ClayDropDownWithItems
+				data-testid="dropdown"
+				items={[{label: 'clickable'}]}
+				onMouseEnter={onMouseEnter}
+				spritemap={spritemap}
+				trigger={<ClayButton>Click Me</ClayButton>}
+			/>
+		);
+
+		fireEvent.mouseEnter(screen.getByTestId('dropdown'));
+
+		expect(onMouseEnter).toHaveBeenCalledTimes(1);
+	});
 });

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-drop-down/src/types.ts
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-drop-down/src/types.ts
@@ -1,0 +1,11 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import type React from 'react';
+
+export type DropDownHTMLAttributes = Omit<
+	React.HTMLAttributes<HTMLDivElement | HTMLLIElement>,
+	'children'
+>;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-44313

## What is being fixed

`ClayDropDownWithItems` strips every prop that is not in its named list, so consumers cannot attach event listeners (`onMouseEnter`, `onFocus`) or arbitrary HTML attributes (`data-*`, `aria-*`) on the dropdown container. The sibling `ClayDropDown` already forwards these via `...otherProps`; `ClayDropDownWithItems` should do the same.

## How it is being fixed

`Props` is intersected with `Omit<React.HTMLAttributes<HTMLDivElement | HTMLLIElement>, 'children'>` so arbitrary attributes type-check, the destructure captures `...otherProps`, and the standard (non-mobile-drilldown) branch spreads them onto the inner `ClayDropDown`, which already forwards to its `ContainerElement`. The change is purely additive — when `otherProps` is empty the spread is a no-op, so existing snapshots and the 236 existing consumers in the repo behave identically.