### PR TITLE
LPD-79840 Apply quick-win visual improvements to the existing Clay Card component

### DIFF
--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_c-root.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_c-root.scss
@@ -220,6 +220,7 @@ $c-root: map-merge(
 
 		--border-radius-lg: 0.375rem,
 		--border-radius-sm: 0.1875rem,
+		--border-radius-xl: 1rem,
 
 		--rounded-0-border-radius: 0,
 		--rounded-border-radius: $border-radius,

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_cards.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_cards.scss
@@ -1,26 +1,26 @@
 $card-bg: var(--card-bg, $white) !default;
-$card-border-color: var(
-	--card-border-color,
-	unquote('hsl(from #{$black} h s l / 0.125)')
-) !default;
+$card-border-color: var(--card-border-color, $secondary-l2) !default;
+$card-border-radius: var(--card-border-radius, $border-radius-xl) !default;
 $card-border-style: var(--card-border-style, solid) !default;
-$card-border-width: var(--card-border-width, 0px) !default;
-
-$card-border-radius: var(--card-border-radius, $border-radius) !default;
-$card-inner-border-radius: calc(
-	#{$card-border-radius} - #{$card-border-width}
-) !default;
-
-$card-box-shadow: var(
-	--card-box-shadow,
-	0 1px 3px -1px rgba(0, 0, 0, 0.6)
-) !default;
+$card-border-width: var(--card-border-width, 1px) !default;
+$card-box-shadow: var(--card-box-shadow, none) !default;
 $card-color: var(--card-color, inherit) !default;
 $card-height: null !default;
 $card-margin-bottom: var(--card-margin-bottom, 24px) !default;
-
 $card-spacer-x: var(--card-spacer-x, 20px) !default;
 $card-spacer-y: var(--card-spacer-y, 12px) !default;
+$card-transition:
+	$component-transition,
+	transform 0.15s ease-in-out !default;
+
+$card-hover-box-shadow: var(
+	--card-hover-box-shadow,
+	0 0.25rem 0.75rem -0.25rem unquote('hsl(from #{$black} h s l / 0.25)')
+) !default;
+
+$card-inner-border-radius: calc(
+	#{$card-border-radius} - #{$card-border-width}
+) !default;
 
 $card-cap-bg: unquote('hsl(from #{$black} h s l / 0.03)') !default;
 $card-cap-color: null !default;
@@ -186,12 +186,15 @@ $card: map-deep-merge(
 		border-radius: clay-enable-rounded($card-border-radius),
 		border-style: $card-border-style,
 		border-width: $card-border-width,
-		box-shadow: clay-enable-shadows($card-box-shadow),
 		display: block,
 		height: $card-height,
 		margin-bottom: $card-margin-bottom,
 		min-width: 0,
+		outline-color: transparent,
+		outline-style: solid,
+		outline-width: $card-border-width,
 		position: relative,
+		transition: $card-transition,
 		word-wrap: break-word,
 
 		aspect-ratio: (
@@ -215,6 +218,10 @@ $card: map-deep-merge(
 		hr: (
 			margin-left: 0,
 			margin-right: 0,
+		),
+
+		hover: (
+			box-shadow: clay-enable-shadows($card-hover-box-shadow),
 		),
 	),
 	$card
@@ -399,14 +406,9 @@ $checkbox-right-card-padding: var(
 
 $checkbox-position: var(--checkbox-position, 16px) !default;
 
-$form-check-card-checked-box-shadow: var(
-	--form-check-card-checked-box-shadow,
-	0 0 0 2px unquote('hsl(from #{$component-active-bg} h s calc(l + 22.94))')
-) !default;
-
 // .form-check-card
 
-$form-check-card-checked-box-shadow: $input-btn-focus-box-shadow !default;
+$form-check-card-checked-box-shadow: c-unset !default;
 
 $form-check-card: () !default;
 $form-check-card: map-deep-merge(
@@ -417,19 +419,22 @@ $form-check-card: map-deep-merge(
 
 		hover: (
 			card: (
-				box-shadow: $form-check-card-checked-box-shadow,
+				border-color: $primary-l1,
+				outline-color: $primary-l1,
 			),
 		),
 
 		active: (
 			card: (
-				box-shadow: $form-check-card-checked-box-shadow,
+				border-color: $primary,
+				outline-color: $primary,
 			),
 		),
 
 		checked: (
 			card: (
-				box-shadow: $form-check-card-checked-box-shadow,
+				border-color: $primary,
+				outline-color: $primary,
 			),
 		),
 
@@ -471,12 +476,6 @@ $form-check-card: map-deep-merge(
 
 			custom-control-input: (
 				z-index: 2,
-
-				checked: (
-					card: (
-						box-shadow: $form-check-card-checked-box-shadow,
-					),
-				),
 			),
 		),
 	),
@@ -760,8 +759,8 @@ $card-interactive: () !default;
 $card-interactive: map-deep-merge(
 	(
 		cursor: $link-cursor,
-		outline: 0,
-		transition: $component-transition,
+		outline: c-unset,
+		transition: c-unset,
 
 		hover: (
 			background-color: #f7f8f9,
@@ -769,15 +768,19 @@ $card-interactive: map-deep-merge(
 		),
 
 		focus: (
-			box-shadow: #{0 0 0 2px #fff,
-			0 0 0 4px #719aff},
+			border-color: $primary-l1,
+			box-shadow: none,
+			outline-color: $primary-l1,
+			outline-offset: 0,
+			outline-style: solid,
+			outline-width: $card-border-width,
 		),
 
 		active: (
 			background-color: #f1f2f5,
 		),
 
-		after-highlight: $card-interactive-after-highlight,
+		after-highlight: c-unset,
 
 		card-body: $card-interactive-card-body,
 	),
@@ -785,6 +788,10 @@ $card-interactive: map-deep-merge(
 );
 
 // Card Interactive Primary
+
+$card-interactive-primary-hover-box-shadow: unquote(
+	'#{$card-hover-box-shadow}, 0px -2.5rem 0px -2.25rem #{$primary} inset'
+) !default;
 
 $card-interactive-primary-after-highlight: () !default;
 $card-interactive-primary-after-highlight: map-deep-merge(
@@ -807,15 +814,18 @@ $card-interactive-primary-after-highlight: map-deep-merge(
 $card-interactive-primary: () !default;
 $card-interactive-primary: map-deep-merge(
 	(
+		hover: (
+			box-shadow: $card-interactive-primary-hover-box-shadow,
+		),
+
 		focus: (
-			background-color: $gray-100,
+			box-shadow: $card-interactive-primary-hover-box-shadow,
 		),
 
 		active: (
-			background-color: $gray-200,
+			box-shadow: $card-interactive-primary-hover-box-shadow,
 		),
-
-		after-highlight: $card-interactive-primary-after-highlight,
+		after-highlight: c-unset,
 	),
 	$card-interactive-primary
 );
@@ -829,14 +839,10 @@ $card-interactive-secondary: map-deep-merge(
 
 		hover: (
 			background-color: $white,
-			border-color: transparent,
-			box-shadow: 0 0 0 2px #719aff,
+			border-color: c-unset,
+			box-shadow: c-unset,
 			color: $gray-900,
-		),
-
-		focus: (
-			border-color: transparent,
-			box-shadow: 0 0 0 2px #719aff,
+			transform: translateY(-0.25rem),
 		),
 
 		active: (
@@ -851,6 +857,12 @@ $card-interactive-secondary: map-deep-merge(
 $card-type-asset: () !default;
 $card-type-asset: map-deep-merge(
 	(
+		transition: $card-transition,
+
+		hover: (
+			transform: translateY(-0.25rem),
+		),
+
 		aspect-ratio: (
 			border-color: $gray-300,
 			border-style: solid,
@@ -1155,6 +1167,10 @@ $template-card: () !default;
 $template-card: map-deep-merge(
 	(
 		card-body: $template-card-body,
+
+		hover: (
+			transform: translateY(-0.25rem),
+		),
 	),
 	$template-card
 );

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_globals.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_globals.scss
@@ -319,6 +319,7 @@ $border-radius: var(--border-radius) !default;
 
 $border-radius-lg: var(--border-radius-lg) !default;
 $border-radius-sm: var(--border-radius-sm) !default;
+$border-radius-xl: var(--border-radius-xl) !default;
 
 $rounded-0-border-radius: var(--rounded-0-border-radius) !default;
 $rounded-border-radius: var(--rounded-border-radius) !default;

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas/variables/_cards.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas/variables/_cards.scss
@@ -1,6 +1,12 @@
-$card-border-radius: $border-radius !default;
-$card-border-width: 0px !default;
-$card-box-shadow: 0 1px 3px -1px rgba(0, 0, 0, 0.6) !default;
+$card-border-color: $secondary-l2 !default;
+$card-border-radius: $border-radius-xl !default;
+$card-border-width: $border-width !default;
+$card-box-shadow: c-unset !default;
+$card-transition:
+	$component-transition,
+	transform 0.15s ease-in-out !default;
+
+$card-hover-box-shadow: 0 0.25rem 0.75rem -0.25rem unquote('rgb(from #{$black} r g b / 0.25)') !default;
 
 $card-body-padding-bottom: 1rem !default;
 $card-body-padding-left: 1rem !default;
@@ -18,7 +24,14 @@ $card: map-deep-merge(
 	(
 		border-radius: clay-enable-rounded($card-border-radius),
 		border-width: $card-border-width,
-		box-shadow: clay-enable-shadows($card-box-shadow),
+		outline-color: transparent,
+		outline-style: solid,
+		outline-width: $card-border-width,
+		transition: $card-transition,
+
+		hover: (
+			box-shadow: clay-enable-shadows($card-hover-box-shadow),
+		),
 	),
 	$card
 );
@@ -82,21 +95,58 @@ $card-link: map-deep-merge(
 
 $checkbox-left-card-padding: 50px !default;
 
-$form-check-card-checked-box-shadow: 0 0 0 2px
-	clay-lighten($component-active-bg, 22.94) !default;
+// .form-check-card
+
+$form-check-card-checked-box-shadow: c-unset !default;
+
+$form-check-card: () !default;
+$form-check-card: map-deep-merge(
+	(
+		transition: $card-transition,
+
+		hover: (
+			card: (
+				border-color: $primary-l1,
+				outline-color: $primary-l1,
+			),
+		),
+
+		active: (
+			card: (
+				border-color: $primary,
+				outline-color: $primary,
+			),
+		),
+
+		checked: (
+			card: (
+				border-color: $primary,
+				outline-color: $primary,
+			),
+		),
+	),
+	$form-check-card
+);
 
 // Card Interactive
 
 $card-interactive: () !default;
 $card-interactive: map-deep-merge(
 	(
+		outline: c-unset,
+		transition: c-unset,
+
 		hover: (
 			background-color: #f7f8f9,
 		),
 
 		focus: (
-			border-color: null,
-			box-shadow: $component-focus-box-shadow,
+			border-color: $primary-l1,
+			box-shadow: none,
+			outline-color: $primary-l1,
+			outline-offset: 0,
+			outline-style: solid,
+			outline-width: $card-border-width,
 		),
 
 		active: (
@@ -106,19 +156,45 @@ $card-interactive: map-deep-merge(
 	$card-interactive
 );
 
+$card-interactive-primary-hover-box-shadow: unquote(
+	'#{$card-hover-box-shadow}, 0px -2.5rem 0px -2.25rem #{$primary} inset'
+) !default;
+
+$card-interactive-primary: () !default;
+$card-interactive-primary: map-deep-merge(
+	(
+		hover: (
+			box-shadow: $card-interactive-primary-hover-box-shadow,
+		),
+
+		focus: (
+			box-shadow: $card-interactive-primary-hover-box-shadow,
+		),
+
+		active: (
+			box-shadow: $card-interactive-primary-hover-box-shadow,
+		),
+
+		after-highlight: c-unset,
+	),
+	$card-interactive-primary
+);
+
 // Card Interactive Secondary
 
 $card-interactive-secondary: () !default;
 $card-interactive-secondary: map-deep-merge(
 	(
 		hover: (
-			border-color: transparent,
-			box-shadow: 0 0 0 2px $primary-l0,
+			background-color: $white,
+			border-color: c-unset,
+			box-shadow: c-unset,
+			color: $gray-900,
+			transform: translateY(-0.25rem),
 		),
 
-		focus: (
-			border-color: transparent,
-			box-shadow: 0 0 0 2px $primary-l0,
+		active: (
+			background-color: $white,
 		),
 	),
 	$card-interactive-secondary
@@ -129,6 +205,12 @@ $card-interactive-secondary: map-deep-merge(
 $card-type-asset: () !default;
 $card-type-asset: map-deep-merge(
 	(
+		transition: $card-transition,
+
+		hover: (
+			transform: translateY(-0.25rem),
+		),
+
 		aspect-ratio: (
 			border-color: $gray-300,
 		),
@@ -138,6 +220,18 @@ $card-type-asset: map-deep-merge(
 		),
 	),
 	$card-type-asset
+);
+
+// Template Card
+
+$template-card: () !default;
+$template-card: map-deep-merge(
+	(
+		hover: (
+			transform: translateY(-0.25rem),
+		),
+	),
+	$template-card
 );
 
 $image-card: () !default;
@@ -186,13 +280,4 @@ $card-type-template-aspect-ratio-item: map-deep-merge(
 		color: $gray-600,
 	),
 	$card-type-template-aspect-ratio-item
-);
-
-$card-type-template: () !default;
-$card-type-template: map-deep-merge(
-	(
-		border-width: 1px,
-		box-shadow: none,
-	),
-	$card-type-template
 );

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas/variables/_globals.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas/variables/_globals.scss
@@ -386,6 +386,7 @@ $border-width: 0.0625rem !default;
 $border-radius: 0.25rem !default; // 4px
 $border-radius-lg: 0.375rem !default; // 6px
 $border-radius-sm: 0.1875rem !default; // 3px
+$border-radius-xl: 1rem !default; // 16px
 
 $rounded-0-border-radius: 0px !default;
 $rounded-border-radius: $border-radius !default;

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/components/_cards.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/components/_cards.scss
@@ -308,70 +308,18 @@
 // Checkbox and Radio Cards
 
 .form-check-card {
-	margin-bottom: $cadmin-card-margin-bottom;
-	margin-top: 0;
-	padding-left: 0;
+	@include clay-form-check-card-variant($cadmin-form-check-card);
 
-	.card {
-		margin-bottom: 0;
-	}
-
-	.custom-control {
-		display: inline;
-		margin-right: 0;
-		position: static;
-
-		> label {
-			font-weight: $cadmin-font-weight-normal;
-			padding-left: 0;
-		}
-	}
-
-	.custom-control-input {
-		z-index: 2;
-	}
-
-	.custom-control-label {
-		position: absolute;
-		z-index: 1;
-	}
-
-	.form-check-input {
-		margin-left: 0;
-		margin-top: 0;
-		position: absolute;
-		z-index: 1;
-	}
-
-	.form-check-label {
-		color: $cadmin-body-color;
-		display: inline;
-		font-weight: $cadmin-font-weight-normal;
-		padding-left: 0;
-		position: static;
-	}
-
-	&.active .card,
-	.custom-control-input:checked ~ .card,
 	.form-check-input:checked ~ .card {
-		box-shadow: $cadmin-form-check-card-checked-box-shadow;
-	}
-}
-
-.form-check-card {
-	&:hover {
-		.card {
-			box-shadow: $cadmin-form-check-card-checked-box-shadow;
-		}
-	}
-}
-
-.custom-control-input,
-.form-check-input {
-	&:hover {
-		~ .card {
-			box-shadow: $cadmin-form-check-card-checked-box-shadow;
-		}
+		@include clay-card-variant(
+			map-deep-get(
+				$cadmin-form-check-card,
+				custom-control,
+				custom-control-input,
+				checked,
+				card
+			)
+		);
 	}
 }
 

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/variables/_cards.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/variables/_cards.scss
@@ -1,20 +1,25 @@
 $cadmin-card-bg: $cadmin-white !default;
-$cadmin-card-border-color: rgba($cadmin-black, 0.125) !default;
+$cadmin-card-border-color: $cadmin-secondary-l2 !default;
+$cadmin-card-border-radius: $cadmin-border-radius-xl !default;
 $cadmin-card-border-style: solid !default;
-$cadmin-card-border-width: 0px !default;
-
-$cadmin-card-border-radius: $cadmin-border-radius !default;
-$cadmin-card-inner-border-radius: calc(
-	#{$cadmin-card-border-radius} - #{$cadmin-card-border-width}
-) !default;
-
-$cadmin-card-box-shadow: 0 1px 3px -1px rgba(0, 0, 0, 0.6) !default;
+$cadmin-card-border-width: $cadmin-border-width !default;
+$cadmin-card-box-shadow: null !default;
 $cadmin-card-color: null !default;
 $cadmin-card-height: null !default;
 $cadmin-card-margin-bottom: 24px !default;
-
 $cadmin-card-spacer-x: 20px !default;
 $cadmin-card-spacer-y: 12px !default;
+$cadmin-card-transition:
+	$cadmin-component-transition,
+	transform 0.15s ease-in-out !default;
+
+$cadmin-card-hover-box-shadow: unquote(
+	'0 0.25rem 0.75rem -0.25rem rgb(from #{$cadmin-black} r g b / 0.25)'
+) !default;
+
+$cadmin-card-inner-border-radius: calc(
+	#{$cadmin-card-border-radius} - #{$cadmin-card-border-width}
+) !default;
 
 $cadmin-card-cap-bg: rgba($cadmin-black, 0.03) !default;
 $cadmin-card-cap-color: null !default;
@@ -160,12 +165,15 @@ $card: map-deep-merge(
 		border-radius: clay-enable-rounded($cadmin-card-border-radius),
 		border-style: $cadmin-card-border-style,
 		border-width: $cadmin-card-border-width,
-		box-shadow: clay-enable-shadows($cadmin-card-box-shadow),
 		display: block,
 		height: $cadmin-card-height,
 		margin-bottom: $cadmin-card-margin-bottom,
 		min-width: 0px,
+		outline-color: transparent,
+		outline-style: solid,
+		outline-width: $cadmin-card-border-width,
 		position: relative,
+		transition: $cadmin-card-transition,
 		word-wrap: break-word,
 
 		aspect-ratio: (
@@ -193,6 +201,10 @@ $card: map-deep-merge(
 		hr: (
 			margin-left: 0px,
 			margin-right: 0px,
+		),
+
+		hover: (
+			box-shadow: clay-enable-shadows($cadmin-card-hover-box-shadow),
 		),
 	),
 	$card
@@ -371,8 +383,89 @@ $cadmin-checkbox-right-card-padding: $cadmin-checkbox-left-card-padding !default
 
 $cadmin-checkbox-position: 16px !default;
 
-$cadmin-form-check-card-checked-box-shadow: 0 0 0 2px
-	clay-lighten($cadmin-component-active-bg, 22.94) !default;
+$cadmin-form-check-card-checked-box-shadow: null !default;
+
+$cadmin-form-check-card: () !default;
+$cadmin-form-check-card: map-deep-merge(
+	(
+		margin-bottom: $cadmin-card-margin-bottom,
+		margin-top: 0px,
+		padding-left: 0px,
+		transition: $cadmin-card-transition,
+
+		hover: (
+			card: (
+				border-color: $cadmin-primary-l1,
+				box-shadow: $cadmin-form-check-card-checked-box-shadow,
+				outline-color: $cadmin-primary-l1,
+			),
+		),
+
+		active: (
+			card: (
+				border-color: $cadmin-primary,
+				box-shadow: $cadmin-form-check-card-checked-box-shadow,
+				outline-color: $cadmin-primary,
+			),
+		),
+
+		checked: (
+			card: (
+				border-color: $cadmin-primary,
+				box-shadow: $cadmin-form-check-card-checked-box-shadow,
+				outline-color: $cadmin-primary,
+			),
+		),
+
+		card: (
+			margin-bottom: 0px,
+		),
+
+		form-check-input: (
+			margin-left: 0px,
+			margin-top: 0px,
+			opacity: 0,
+			position: absolute,
+			z-index: 1,
+		),
+
+		form-check-label: (
+			color: $cadmin-body-color,
+			display: inline,
+			font-weight: $cadmin-font-weight-normal,
+			padding-left: 0px,
+			position: static,
+		),
+
+		custom-control: (
+			display: inline,
+			margin-right: 0px,
+			position: static,
+
+			label: (
+				font-weight: $cadmin-font-weight-normal,
+				padding-left: 0px,
+			),
+
+			custom-control-label: (
+				opacity: 0,
+				position: absolute,
+				z-index: 1,
+			),
+
+			custom-control-input: (
+				z-index: 2,
+
+				checked: (
+					card: (
+						box-shadow: $cadmin-form-check-card-checked-box-shadow,
+					),
+				),
+			),
+		),
+	),
+	$cadmin-form-check-card
+);
 
 // Card Interactive
 
@@ -416,8 +509,7 @@ $cadmin-card-interactive: () !default;
 $cadmin-card-interactive: map-deep-merge(
 	(
 		cursor: $cadmin-link-cursor,
-		outline: 0,
-		transition: $cadmin-component-transition,
+		transition: $cadmin-card-transition,
 
 		hover: (
 			background-color: #f7f8f9,
@@ -425,8 +517,12 @@ $cadmin-card-interactive: map-deep-merge(
 		),
 
 		focus: (
-			box-shadow: #{0 0 0 2px #fff,
-			0 0 0 4px #719aff},
+			border-color: $cadmin-primary-l1,
+			box-shadow: none,
+			outline-color: $cadmin-primary-l1,
+			outline-offset: 0,
+			outline-style: solid,
+			outline-width: $cadmin-card-border-width,
 		),
 
 		active: (
@@ -441,6 +537,10 @@ $cadmin-card-interactive: map-deep-merge(
 );
 
 // Card Interactive Primary
+
+$cadmin-card-interactive-primary-hover-box-shadow: unquote(
+	'#{$cadmin-card-hover-box-shadow}, 0px -2.5rem 0px -2.25rem #{$cadmin-primary} inset'
+) !default;
 
 $cadmin-card-interactive-primary-after-highlight: () !default;
 $cadmin-card-interactive-primary-after-highlight: map-deep-merge(
@@ -463,15 +563,19 @@ $cadmin-card-interactive-primary-after-highlight: map-deep-merge(
 $cadmin-card-interactive-primary: () !default;
 $cadmin-card-interactive-primary: map-deep-merge(
 	(
+		hover: (
+			box-shadow: $cadmin-card-interactive-primary-hover-box-shadow,
+		),
+
 		focus: (
-			background-color: $cadmin-gray-100,
+			box-shadow: $cadmin-card-interactive-primary-hover-box-shadow,
 		),
 
 		active: (
-			background-color: $cadmin-gray-200,
+			box-shadow: $cadmin-card-interactive-primary-hover-box-shadow,
 		),
 
-		after-highlight: $cadmin-card-interactive-primary-after-highlight,
+		after-highlight: null,
 	),
 	$cadmin-card-interactive-primary
 );
@@ -485,14 +589,8 @@ $cadmin-card-interactive-secondary: map-deep-merge(
 
 		hover: (
 			background-color: $cadmin-white,
-			border-color: transparent,
-			box-shadow: 0 0 0 2px #719aff,
 			color: $cadmin-gray-900,
-		),
-
-		focus: (
-			border-color: transparent,
-			box-shadow: 0 0 0 2px #719aff,
+			transform: translateY(-0.25rem),
 		),
 
 		active: (
@@ -507,6 +605,12 @@ $cadmin-card-interactive-secondary: map-deep-merge(
 $cadmin-card-type-asset: () !default;
 $cadmin-card-type-asset: map-deep-merge(
 	(
+		transition: $cadmin-card-transition,
+
+		hover: (
+			transform: translateY(-0.25rem),
+		),
+
 		aspect-ratio: (
 			border-color: $cadmin-gray-300,
 			border-style: solid,
@@ -811,6 +915,10 @@ $cadmin-template-card: () !default;
 $cadmin-template-card: map-deep-merge(
 	(
 		card-body: $cadmin-template-card-body,
+
+		hover: (
+			transform: translateY(-0.25rem),
+		),
 	),
 	$cadmin-template-card
 );

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/variables/_globals.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/variables/_globals.scss
@@ -440,6 +440,7 @@ $cadmin-border-width: 1px !default;
 $cadmin-border-radius: 4px !default; // 4px
 $cadmin-border-radius-lg: 6px !default; // 6px
 $cadmin-border-radius-sm: 3px !default; // 3px
+$cadmin-border-radius-xl: 16px !default; // 16px
 
 $cadmin-rounded-0-border-radius: 0px !default;
 $cadmin-rounded-border-radius: $cadmin-border-radius !default;

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/variables/_cards.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/variables/_cards.scss
@@ -9,6 +9,7 @@ $card-height: null !default;
 $card-margin-bottom: 1.5rem !default;
 $card-spacer-x: 1.25rem !default;
 $card-spacer-y: 0.75rem !default;
+$card-transition: null !default;
 
 $card-inner-border-radius: calc(
 	#{$card-border-radius} - #{$card-border-width}
@@ -182,6 +183,7 @@ $card: map-deep-merge(
 		margin-bottom: $card-margin-bottom,
 		min-width: 0rem,
 		position: relative,
+		transition: $card-transition,
 		word-wrap: break-word,
 
 		aspect-ratio: (
@@ -738,6 +740,8 @@ $card-interactive: map-deep-merge(
 
 // Card Interactive Primary
 
+$card-interactive-primary-hover-box-shadow: null !default;
+
 $card-interactive-primary-after-highlight: () !default;
 $card-interactive-primary-after-highlight: map-deep-merge(
 	(
@@ -759,6 +763,9 @@ $card-interactive-primary-after-highlight: map-deep-merge(
 $card-interactive-primary: () !default;
 $card-interactive-primary: map-deep-merge(
 	(
+		hover: (
+			box-shadow: $card-interactive-primary-hover-box-shadow,
+		),
 		focus: (
 			background-color: $gray-100,
 		),

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/variables/_globals.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/variables/_globals.scss
@@ -382,6 +382,7 @@ $border-width: 0.0625rem !default;
 
 $border-radius-lg: 0.3rem !default;
 $border-radius-sm: 0.2rem !default;
+$border-radius-xl: 1rem !default;
 $border-radius: 0.25rem !default;
 
 $rounded-0-border-radius: 0px !default;


### PR DESCRIPTION
Resending https://github.com/liferay-platform-experience/liferay-portal/pull/1935.

Ticket https://liferay.atlassian.net/browse/LPD-79840

## What is being adjusted

We need to reduce the visual gap between the current card and the revamped design, so we're shipping some CSS changes that can be applied to all existing card types without breaking their API or layouts.

## How it is being adjusted

- Define Card's `border` with `1px`;
- Increase of Card's `border-radius` to `16px`;
- Lift up the Card on hover, applying the proper shadow (* elevation doesn't apply to horizontal cards, nor disabled ones) ;
- For selectable, apply Cards (check/radio) outline for hover and active/selected states.

[Screencast from 2026-05-12 22-08-53.webm](https://github.com/user-attachments/assets/10f906a3-8458-4a5e-bc57-9160be9b71ef)

* Updated after design discussion