### PR TITLE
LPD-90345 Adapt the documentation

### DIFF
--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/docs/resize-handle.mdx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/docs/resize-handle.mdx
@@ -24,11 +24,16 @@ export default function App() {
         className="border rounded d-flex overflow-hidden"
         style={{ height: 280 }}
       >
-        <div className="bg-light p-3 position-relative" style={{ width }}>
+        <div
+          className="bg-light p-3 position-relative"
+          id="resizable-region"
+          style={{ width }}
+        >
           <div className="text-secondary">Resizable region</div>
           <div className="text-weight-semi-bold">{width}px</div>
 
           <ResizeHandle
+            aria-controls="resizable-region"
             maxWidth={480}
             minWidth={240}
             onWidthChange={setWidth}
@@ -59,6 +64,7 @@ The component is fully controlled: it does not store the width internally. You m
 import { ResizeHandle } from "@clayui/core";
 
 <ResizeHandle
+  aria-controls="resizable-region"
   maxWidth={480}
   minWidth={240}
   onWidthChange={setWidth}
@@ -84,6 +90,9 @@ The `position` prop indicates which side of the screen the resized element is an
 
 - Renders with `role="separator"` and `aria-orientation="vertical"`.
 - Reflects the current width through `aria-valuenow`, with `aria-valuemin` / `aria-valuemax` matching the configured boundaries.
+- Sets `aria-valuetext` to the current width in pixels (for example, _"320px"_). Without it, screen readers fall back to announcing the value as a percentage of the `aria-valuemin` / `aria-valuemax` range, which is misleading because the underlying values are pixel measurements.
+- Provides a localized accessible name through `aria-label`, with a default per `position` (_"Resize left side"_ or _"Resize right side"_). Pass `aria-label` explicitly to override it with a more specific or translated string (for example, _"Resize navigation panel"_).
+- Requires `aria-controls` to be set to the `id` of the element being resized. The component cannot infer it because it does not know which element it resizes — it only emits the new width through `onWidthChange`, and the consumer is the one that applies it. Supplying `aria-controls` lets assistive technology identify the controlled region.
 - `tabIndex={0}` so the handle is reachable with the keyboard.
 
 ### Keyboard interaction
@@ -91,5 +100,3 @@ The `position` prop indicates which side of the screen the resized element is an
 - `Left` / `Right` — decrease or increase the width (mapping depends on `position`).
 - `Up` / `Down` — increase or decrease the width.
 - Holding a key accelerates the change after a few key repeats (1px per step, then 10px per step).
-
-When labeling the handle from a parent component, set `aria-label` on `ResizeHandle` directly so screen readers announce its purpose (for example, _"Resize navigation panel"_).

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/resize-handle/ResizeHandle.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/resize-handle/ResizeHandle.tsx
@@ -94,6 +94,7 @@ export function ResizeHandle({
 			aria-valuemax={maxWidth}
 			aria-valuemin={minWidth}
 			aria-valuenow={width}
+			aria-valuetext={`${width}px`}
 			className={classnames('c-horizontal-resizer', {
 				'c-horizontal-resizer-end':
 					document.dir === 'rtl' ? positionLeft : !positionLeft,

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/resize-handle/ResizeHandle.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/resize-handle/ResizeHandle.tsx
@@ -42,7 +42,7 @@ type Props = {
 	'width'?: number;
 } & Omit<
 	React.HTMLAttributes<HTMLDivElement>,
-	'aria-controls' | 'onKeyDown' | 'onKeyUp' | 'onPointerDown'
+	'aria-controls' | 'className' | 'onKeyDown' | 'onKeyUp' | 'onPointerDown'
 >;
 
 const DEFAULT_ARIA_LABELS: Record<Position, string> = {
@@ -95,12 +95,12 @@ export function ResizeHandle({
 			aria-valuemin={minWidth}
 			aria-valuenow={width}
 			aria-valuetext={`${width}px`}
+			{...otherProps}
+			aria-controls={ariaControls}
 			className={classnames('c-horizontal-resizer', {
 				'c-horizontal-resizer-end':
 					document.dir === 'rtl' ? positionLeft : !positionLeft,
 			})}
-			{...otherProps}
-			aria-controls={ariaControls}
 			onKeyDown={(event: React.KeyboardEvent<HTMLDivElement>) => {
 				const delta = keyDownCounter > 7 ? 10 : 1;
 

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/resize-handle/ResizeHandle.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/resize-handle/ResizeHandle.tsx
@@ -45,6 +45,11 @@ type Props = {
 	'aria-controls' | 'onKeyDown' | 'onKeyUp' | 'onPointerDown'
 >;
 
+const DEFAULT_ARIA_LABELS: Record<Position, string> = {
+	left: 'Resize left side',
+	right: 'Resize right side',
+};
+
 const MAIN_MOUSE_BUTTON = 0;
 
 let keyDownCounter = 0;
@@ -84,6 +89,7 @@ export function ResizeHandle({
 
 	return (
 		<div
+			aria-label={DEFAULT_ARIA_LABELS[position]}
 			aria-orientation="vertical"
 			aria-valuemax={maxWidth}
 			aria-valuemin={minWidth}

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/resize-handle/ResizeHandle.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/resize-handle/ResizeHandle.tsx
@@ -12,32 +12,37 @@ export type Position = 'left' | 'right';
 type Props = {
 
 	/**
+	 * ID of the element being resized.
+	 */
+	'aria-controls': string;
+
+	/**
 	 * The maximum width allowed.
 	 */
-	maxWidth: number;
+	'maxWidth': number;
 
 	/**
 	 * The minimum width allowed.
 	 */
-	minWidth: number;
+	'minWidth': number;
 
 	/**
 	 * Callback called every time the width changes (controlled).
 	 */
-	onWidthChange: (width: number) => void;
+	'onWidthChange': (width: number) => void;
 
 	/**
 	 * The side of the screen where the resized element is located.
 	 */
-	position: Position;
+	'position': Position;
 
 	/**
 	 * Property to set the current width (controlled).
 	 */
-	width?: number;
+	'width'?: number;
 } & Omit<
 	React.HTMLAttributes<HTMLDivElement>,
-	'onKeyDown' | 'onKeyUp' | 'onPointerDown'
+	'aria-controls' | 'onKeyDown' | 'onKeyUp' | 'onPointerDown'
 >;
 
 const MAIN_MOUSE_BUTTON = 0;
@@ -45,6 +50,7 @@ const MAIN_MOUSE_BUTTON = 0;
 let keyDownCounter = 0;
 
 export function ResizeHandle({
+	'aria-controls': ariaControls,
 	maxWidth,
 	minWidth,
 	onWidthChange,
@@ -87,6 +93,7 @@ export function ResizeHandle({
 					document.dir === 'rtl' ? positionLeft : !positionLeft,
 			})}
 			{...otherProps}
+			aria-controls={ariaControls}
 			onKeyDown={(event: React.KeyboardEvent<HTMLDivElement>) => {
 				const delta = keyDownCounter > 7 ? 10 : 1;
 

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/resize-handle/__tests__/ResizeHandle.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/resize-handle/__tests__/ResizeHandle.tsx
@@ -20,6 +20,7 @@ function renderComponent({
 }) {
 	return render(
 		<ResizeHandle
+			aria-controls="resizable-region"
 			data-testid="resizer"
 			maxWidth={600}
 			minWidth={200}

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/side-panel/SidePanel.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/side-panel/SidePanel.tsx
@@ -349,6 +349,7 @@ export function SidePanel({
 
 						{isResizable && (
 							<ResizeHandle
+								aria-controls={sidePanelRef.current?.id!}
 								maxWidth={sidePanelObservedMaxWidth}
 								minWidth={PANEL_WIDTH_MIN}
 								onWidthChange={setResizeWidth}

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/side-panel/SidePanel.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/side-panel/SidePanel.tsx
@@ -153,6 +153,7 @@ export function SidePanel({
 	displayType = 'light',
 	externalSidePanelRef,
 	fluid = false,
+	'id': externalId,
 	onOpenChange,
 	'open': externalOpen,
 	'panelWidth': externalPanelWidth,
@@ -247,10 +248,12 @@ export function SidePanel({
 		}
 	}, [closeOnEscape, open]);
 
+	const internalPanelId = useId();
 	const titleId = useId();
 
 	const offsetTop = useOffsetTop(containerRef);
 
+	const panelId = externalId ?? internalPanelId;
 	const panelWidth = isResizable
 		? Math.min(sidePanelObservedMaxWidth, resizeWidth)
 		: externalPanelWidth && Math.max(externalPanelWidth, PANEL_WIDTH_MIN);
@@ -336,6 +339,7 @@ export function SidePanel({
 					aria-labelledby={
 						!ariaLabelledby && !ariaLabel ? titleId : ariaLabelledby
 					}
+					id={panelId}
 					ref={sidePanelRef}
 					style={panelWidth ? {width: panelWidth} : undefined}
 					tabIndex={-1}
@@ -349,7 +353,7 @@ export function SidePanel({
 
 						{isResizable && (
 							<ResizeHandle
-								aria-controls={sidePanelRef.current?.id!}
+								aria-controls={panelId}
 								maxWidth={sidePanelObservedMaxWidth}
 								minWidth={PANEL_WIDTH_MIN}
 								onWidthChange={setResizeWidth}

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/side-panel/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/side-panel/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -9,7 +9,7 @@ exports[`SidePanel basic rendering render basic content 1`] = `
       class="c-slideout c-slideout-absolute c-slideout-push c-slideout-end"
     >
       <div
-        aria-labelledby="clay-id-1"
+        aria-labelledby="clay-id-2"
         class="sidebar sidebar-light"
         id="sidepanel"
         inert=""
@@ -29,7 +29,7 @@ exports[`SidePanel basic rendering render basic content 1`] = `
               >
                 <span
                   class="component-title"
-                  id="clay-id-1"
+                  id="clay-id-2"
                 >
                   Title
                 </span>
@@ -80,7 +80,7 @@ exports[`SidePanel basic rendering render component with open state 1`] = `
       class="c-slideout c-slideout-absolute c-slideout-push c-slideout-end"
     >
       <div
-        aria-labelledby="clay-id-2"
+        aria-labelledby="clay-id-4"
         class="sidebar sidebar-light c-slideout-show"
         id="sidepanel"
         tabindex="-1"
@@ -102,7 +102,7 @@ exports[`SidePanel basic rendering render component with open state 1`] = `
               >
                 <span
                   class="component-title"
-                  id="clay-id-2"
+                  id="clay-id-4"
                 >
                   Title
                 </span>
@@ -176,7 +176,7 @@ exports[`SidePanel basic rendering render with custom aria-label 1`] = `
               >
                 <span
                   class="component-title"
-                  id="clay-id-3"
+                  id="clay-id-6"
                 >
                   Title
                 </span>
@@ -227,7 +227,7 @@ exports[`SidePanel basic rendering render with custom width 1`] = `
       class="c-slideout c-slideout-absolute c-slideout-push c-slideout-end"
     >
       <div
-        aria-labelledby="clay-id-4"
+        aria-labelledby="clay-id-8"
         class="sidebar sidebar-light"
         id="sidepanel"
         inert=""
@@ -248,7 +248,7 @@ exports[`SidePanel basic rendering render with custom width 1`] = `
               >
                 <span
                   class="component-title"
-                  id="clay-id-4"
+                  id="clay-id-8"
                 >
                   Title
                 </span>
@@ -299,7 +299,7 @@ exports[`SidePanel basic rendering render with fluid width 1`] = `
       class="c-slideout c-slideout-absolute c-slideout-push c-slideout-end"
     >
       <div
-        aria-labelledby="clay-id-5"
+        aria-labelledby="clay-id-10"
         class="sidebar sidebar-light"
         id="sidepanel"
         inert=""
@@ -319,7 +319,7 @@ exports[`SidePanel basic rendering render with fluid width 1`] = `
               >
                 <span
                   class="component-title"
-                  id="clay-id-5"
+                  id="clay-id-10"
                 >
                   Title
                 </span>

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/stories/ResizeHandle.stories.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/stories/ResizeHandle.stories.tsx
@@ -36,7 +36,6 @@ export function ResizingLeft() {
 
 				<ResizeHandle
 					aria-controls={id}
-					aria-label="Resize region"
 					maxWidth={MAX_WIDTH}
 					minWidth={MIN_WIDTH}
 					onWidthChange={setWidth}

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/stories/ResizeHandle.stories.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/stories/ResizeHandle.stories.tsx
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import {useId} from '@clayui/shared';
 import React, {useState} from 'react';
 
 import {ResizeHandle} from '../src/resize-handle';
@@ -17,18 +18,24 @@ export default {
 
 export function ResizingLeft() {
 	const [width, setWidth] = useState(320);
+	const id = useId();
 
 	return (
 		<div
 			className="border d-flex overflow-hidden rounded"
 			style={{height: 280}}
 		>
-			<div className="bg-light p-3 position-relative" style={{width}}>
+			<div
+				className="bg-light p-3 position-relative"
+				id={id}
+				style={{width}}
+			>
 				<div className="text-secondary">Resizable region</div>
 
 				<div className="text-weight-semi-bold">{width}px</div>
 
 				<ResizeHandle
+					aria-controls={id}
 					aria-label="Resize region"
 					maxWidth={MAX_WIDTH}
 					minWidth={MIN_WIDTH}
@@ -49,6 +56,7 @@ export function ResizingLeft() {
 
 export function ResizingRight() {
 	const [width, setWidth] = useState(320);
+	const id = useId();
 
 	return (
 		<div
@@ -61,13 +69,17 @@ export function ResizingRight() {
 				<div className="text-weight-semi-bold">Fills the rest</div>
 			</div>
 
-			<div className="bg-light p-3 position-relative" style={{width}}>
+			<div
+				className="bg-light p-3 position-relative"
+				id={id}
+				style={{width}}
+			>
 				<div className="text-secondary">Resizable region</div>
 
 				<div className="text-weight-semi-bold">{width}px</div>
 
 				<ResizeHandle
-					aria-label="Resize region"
+					aria-controls={id}
 					maxWidth={MAX_WIDTH}
 					minWidth={MIN_WIDTH}
 					onWidthChange={setWidth}

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_resizer.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_resizer.scss
@@ -23,13 +23,24 @@ $c-horizontal-resizer: map-merge(
 
 		hover: (
 			before: (
-				background-color: $primary-l0,
+				background-color: $primary,
+			),
+		),
+
+		active: (
+			before: (
+				background-color: $primary-d2,
 			),
 		),
 
 		focus: (
+			box-shadow: $component-focus-inset-box-shadow,
+			outline: 0,
+
 			before: (
-				background-color: $primary-l0,
+				background-color: $primary,
+				bottom: 0.25rem,
+				top: 0.25rem,
 			),
 		),
 	),

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/components/_focus-ring.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/components/_focus-ring.scss
@@ -53,7 +53,9 @@ $cadmin-focus-ring-animation-to-box-shadow:
 			box-shadow: $cadmin-focus-ring-animation-to-box-shadow;
 		}
 
-		:focus-visible:not(.toggle-switch-check):not(.custom-control-input),
+		:focus-visible:not(.c-horizontal-resizer):not(.toggle-switch-check):not(
+				.custom-control-input
+			),
 		.focus {
 			position: relative;
 			z-index: 1;

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/components/_resizer.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/components/_resizer.scss
@@ -11,6 +11,16 @@
 		);
 	}
 
+	&:active::before {
+		@include clay-css(
+			map-deep-get($cadmin-c-horizontal-resizer, active, before)
+		);
+	}
+
+	&:focus-visible {
+		@include clay-css(map-get($cadmin-c-horizontal-resizer, focus));
+	}
+
 	&:focus-visible::before {
 		@include clay-css(
 			map-deep-get($cadmin-c-horizontal-resizer, focus, before)

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/variables/_resizer.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/variables/_resizer.scss
@@ -22,13 +22,24 @@ $cadmin-c-horizontal-resizer: map-merge(
 
 		hover: (
 			before: (
-				background-color: $cadmin-primary-l0,
+				background-color: $cadmin-primary,
+			),
+		),
+
+		active: (
+			before: (
+				background-color: $cadmin-primary-d2,
 			),
 		),
 
 		focus: (
+			box-shadow: $cadmin-component-focus-inset-box-shadow,
+			outline: 0,
+
 			before: (
-				background-color: $cadmin-primary-l0,
+				background-color: $cadmin-primary,
+				bottom: 0.25rem,
+				top: 0.25rem,
 			),
 		),
 	),

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/components/_focus-ring.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/components/_focus-ring.scss
@@ -46,7 +46,9 @@ $focus-ring-animation-to-box-shadow:
 		box-shadow: $focus-ring-animation-to-box-shadow;
 	}
 
-	:focus-visible:not(.toggle-switch-check):not(.custom-control-input),
+	:focus-visible:not(.c-horizontal-resizer):not(.toggle-switch-check):not(
+			.custom-control-input
+		),
 	.focus {
 		position: relative;
 		z-index: 1;

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/components/_resizer.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/components/_resizer.scss
@@ -9,6 +9,14 @@
 		@include clay-css(map-deep-get($c-horizontal-resizer, hover, before));
 	}
 
+	&:active::before {
+		@include clay-css(map-deep-get($c-horizontal-resizer, active, before));
+	}
+
+	&:focus-visible {
+		@include clay-css(map-get($c-horizontal-resizer, focus));
+	}
+
 	&:focus-visible::before {
 		@include clay-css(map-deep-get($c-horizontal-resizer, focus, before));
 	}

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/variables/_resizer.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/variables/_resizer.scss
@@ -23,13 +23,24 @@ $c-horizontal-resizer: map-merge(
 
 		hover: (
 			before: (
-				background-color: $primary-l0,
+				background-color: $primary,
+			),
+		),
+
+		active: (
+			before: (
+				background-color: $primary-d2,
 			),
 		),
 
 		focus: (
+			box-shadow: $component-focus-inset-box-shadow,
+			outline: 0,
+
 			before: (
-				background-color: $primary-l0,
+				background-color: $primary,
+				bottom: 0.25rem,
+				top: 0.25rem,
 			),
 		),
 	),

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/ContentEditorPreview.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/ContentEditorPreview.tsx
@@ -59,6 +59,7 @@ export default function ContentEditorPreview({
 
 	const localizationLanguageId = useLocalizationLanguageId(defaultLanguageId);
 
+	const previewId = useId();
 	const previewWidthMax = useObservedMaxWidth(previewRef);
 	const previewWidth = Math.min(previewWidthMax, resizeWidth!);
 	const titleId = useId();
@@ -121,6 +122,7 @@ export default function ContentEditorPreview({
 				resizing,
 				visible: isVisible,
 			})}
+			id={previewId}
 			onTransitionEnd={({propertyName}) => {
 				if (isVisible && propertyName === 'visibility') {
 					previewRef.current?.focus();
@@ -150,6 +152,7 @@ export default function ContentEditorPreview({
 			) : null}
 
 			<ResizeHandle
+				aria-controls={previewId}
 				maxWidth={previewWidthMax}
 				minWidth={PREVIEW_WIDTH_MIN}
 				onWidthChange={(width: number) => {


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPD-90344

Hey team!

I'm sending this PR with improvements to accessibility and visual feedback for the ResizeHandle component. Below is a summary of the changes:

**Styles applied across the three variants (base, atlas-custom-properties, cadmin):**
- New `:active` style (using $primary-d2).
- New `:focus-visible` with inset box-shadow + outline: 0.
- Stronger `hover` and `focus` colors ($primary-l0 → $primary).

**Accessibility:**
- `aria-controls` is now a required prop. The component cannot infer which element is being resized; it only emits the new width through onWidthChange, and applying that value is the consumer's responsibility. Therefore, the consumer must provide the id of the controlled element.
- Default `aria-label` based on position ("Resize left side" / "Resize right side"). Consumers can override it to localize or customize it according to the context.
- Default `aria-valuetext` in pixels (e.g. "320px"). Without this attribute, screen readers announced the value as a percentage calculated from the `aria-valuemin`/`aria-valuemax` range, which was misleading since the underlying values are pixel measurements.

cc @marcoscv-work @drakonux
