### PR TITLE
LPD-91046 Add table view to CMS file Item Selector

### DIFF
--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-drop-down/src/DropDownWithItems.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-drop-down/src/DropDownWithItems.tsx
@@ -199,6 +199,7 @@ export function ClayDropDownWithItems({
 	menuElementAttrs,
 	menuHeight,
 	menuWidth,
+	messages: _messages,
 	offsetFn,
 	onActiveChange,
 	onSearchValueChange = () => {},

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/openCMSFileSelectorModal.ts
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/openCMSFileSelectorModal.ts
@@ -158,6 +158,44 @@ const FDS_PROPS: Omit<
 
 			thumbnail: 'cards2',
 		},
+		{
+			contentRenderer: 'table',
+			label: Liferay.Language.get('table'),
+			name: 'table',
+			schema: {
+				fields: [
+					{
+						contentRenderer: 'cmsFilesTitleCellRenderer',
+						fieldName: 'embedded.title',
+						label: Liferay.Language.get('title'),
+						sortable: false,
+					},
+					{
+						fieldName: 'embedded.file.mimeType',
+						label: Liferay.Language.get('type'),
+						sortable: false,
+					},
+					{
+						fieldName: 'embedded.file.size',
+						label: Liferay.Language.get('size'),
+						sortable: false,
+					},
+					{
+						contentRenderer: 'dateTime',
+						fieldName: 'embedded.dateModified',
+						label: Liferay.Language.get('modified-date'),
+						sortable: false,
+					},
+					{
+						contentRenderer: 'dateTime',
+						fieldName: 'embedded.dateCreated',
+						label: Liferay.Language.get('create-date'),
+						sortable: false,
+					},
+				],
+			},
+			thumbnail: 'table',
+		},
 	],
 };
 

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/openCMSFileSelectorModal.ts
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/openCMSFileSelectorModal.ts
@@ -166,9 +166,9 @@ const FDS_PROPS: Omit<
 				fields: [
 					{
 						contentRenderer: 'cmsFilesTitleCellRenderer',
-						fieldName: 'embedded.title',
+						fieldName: 'title',
 						label: Liferay.Language.get('title'),
-						sortable: false,
+						sortable: true,
 					},
 					{
 						fieldName: 'embedded.file.mimeType',
@@ -182,15 +182,15 @@ const FDS_PROPS: Omit<
 					},
 					{
 						contentRenderer: 'dateTime',
-						fieldName: 'embedded.dateModified',
+						fieldName: 'dateModified',
 						label: Liferay.Language.get('modified-date'),
-						sortable: false,
+						sortable: true,
 					},
 					{
 						contentRenderer: 'dateTime',
-						fieldName: 'embedded.dateCreated',
+						fieldName: 'dateCreated',
 						label: Liferay.Language.get('create-date'),
-						sortable: false,
+						sortable: true,
 					},
 				],
 			},

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/test/openCMSFileSelectorModal.test.tsx
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/test/openCMSFileSelectorModal.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import '@testing-library/jest-dom';
+import {screen, within} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import openCMSFileSelectorModal from '../src/main/resources/META-INF/resources/item_selector/openCMSFileSelectorModal';
+
+jest.mock('frontend-js-web', () => ({
+	...(jest.requireActual('frontend-js-web') as any),
+	fetch: jest.fn(() =>
+		Promise.resolve({
+			json: () =>
+				Promise.resolve({
+					items: [{embedded: {id: 1, title: 'File'}, id: 1}],
+					lastPage: 1,
+					page: 1,
+					totalCount: 1,
+				}),
+			ok: true,
+		})
+	),
+}));
+
+describe('openCMSFileSelectorModal', () => {
+	beforeAll(() => {
+		Object.assign(Liferay.ThemeDisplay, {
+			isImpersonated: () => false,
+		});
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	afterAll(() => {
+		Object.assign(Liferay.ThemeDisplay, {
+			isImpersonated: undefined,
+		});
+	});
+
+	it('renders cards and table options in the view-toggle picker', async () => {
+		const user = userEvent.setup();
+
+		openCMSFileSelectorModal({
+			groupId: 123,
+			onSelect: jest.fn(),
+		});
+
+		const dialog = await screen.findByRole('dialog');
+
+		const viewToggle = await within(dialog).findByRole('combobox', {
+			name: 'x-view-selected',
+		});
+
+		await user.click(viewToggle);
+
+		const options = await screen.findAllByRole('option');
+
+		expect(options).toHaveLength(2);
+
+		expect(options[0]).toHaveTextContent('cards');
+
+		expect(options[1]).toHaveTextContent('table');
+	});
+});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91046

## What is being fixed

The CMS file picker variant of the Item Selector modal only offered the cards view, so users had no way to scan files in a denser format that exposes type, size, and dates at a glance.

## How it is being fixed

A second entry is added to the `views` array of the FDS props driving the CMS file selector: a `table` view that reuses the existing `cmsFilesTitleCellRenderer` for the title column and shows MIME type, size, modified date, and creation date. The new view sits alongside the existing cards view and is reachable through the modal's view-toggle picker. A Jest unit test covers that both options surface in the picker.

<img width="1855" height="806" alt="Screenshot 2026-05-20 at 19 05 02" src="https://github.com/user-attachments/assets/9fac1bce-4f15-471e-b843-425a75ba9269" />

Notes: sticker before title will be added in different task, with folders navigation. 
