### PR TITLE
LPD-90764 Vocabulary selector (single selection)

### DIFF
--- a/modules/apps/asset/asset-categories-admin-web/package.json
+++ b/modules/apps/asset/asset-categories-admin-web/package.json
@@ -1,5 +1,6 @@
 {
 	"dependencies": {
+		"@liferay/frontend-js-item-selector-web": "*",
 		"asset-taglib": "*",
 		"frontend-js-components-web": "*",
 		"frontend-js-web": "*",

--- a/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/display/context/AssetCategoriesDisplayContext.java
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/display/context/AssetCategoriesDisplayContext.java
@@ -697,11 +697,6 @@ public class AssetCategoriesDisplayContext {
 
 		long scopeGroupId = _themeDisplay.getScopeGroupId();
 
-		Group scopeGroup = _themeDisplay.getScopeGroup();
-
-		String siteName = scopeGroup.getDescriptiveName(
-			_themeDisplay.getLocale());
-
 		return DropdownItemListBuilder.add(
 			dropdownItem -> {
 				dropdownItem.putData("action", "deleteVocabularies");
@@ -710,7 +705,6 @@ public class AssetCategoriesDisplayContext {
 				dropdownItem.putData(
 					"deleteVocabulariesURL", deleteVocabulariesURL.toString());
 				dropdownItem.putData("redirectURL", getDefaultRedirect());
-				dropdownItem.putData("siteName", siteName);
 				dropdownItem.setIcon("trash");
 				dropdownItem.setLabel(
 					LanguageUtil.get(_httpServletRequest, "delete"));

--- a/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/display/context/AssetCategoriesDisplayContext.java
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/display/context/AssetCategoriesDisplayContext.java
@@ -9,7 +9,6 @@ import com.liferay.asset.categories.admin.web.constants.AssetCategoriesAdminPort
 import com.liferay.asset.categories.admin.web.internal.configuration.AssetCategoriesAdminWebConfiguration;
 import com.liferay.asset.categories.admin.web.internal.constants.AssetCategoriesAdminDisplayStyleKeys;
 import com.liferay.asset.categories.admin.web.internal.constants.AssetCategoriesAdminWebKeys;
-import com.liferay.asset.categories.admin.web.internal.item.selector.AssetVocabularyItemSelectorCriterion;
 import com.liferay.asset.categories.admin.web.internal.util.AssetCategoryTreePathComparator;
 import com.liferay.asset.categories.configuration.AssetCategoriesCompanyConfiguration;
 import com.liferay.asset.entry.rel.service.AssetEntryAssetCategoryRelLocalServiceUtil;
@@ -39,7 +38,6 @@ import com.liferay.frontend.taglib.clay.servlet.taglib.util.LabelItemListBuilder
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.VerticalNavItemList;
 import com.liferay.item.selector.ItemSelector;
 import com.liferay.item.selector.criteria.InfoItemItemSelectorReturnType;
-import com.liferay.item.selector.criteria.UUIDItemSelectorReturnType;
 import com.liferay.item.selector.criteria.info.item.criterion.InfoItemItemSelectorCriterion;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -687,7 +685,9 @@ public class AssetCategoriesDisplayContext {
 		return _assetVocabularies;
 	}
 
-	public List<DropdownItem> getVocabulariesDropdownItems() {
+	public List<DropdownItem> getVocabulariesDropdownItems()
+		throws PortalException {
+
 		LiferayPortletURL deleteVocabulariesURL =
 			(LiferayPortletURL)_renderResponse.createResourceURL();
 
@@ -695,31 +695,22 @@ public class AssetCategoriesDisplayContext {
 		deleteVocabulariesURL.setResourceID(
 			"/asset_categories_admin/delete_asset_vocabularies");
 
-		ItemSelector itemSelector =
-			(ItemSelector)_httpServletRequest.getAttribute(
-				ItemSelector.class.getName());
+		long scopeGroupId = _themeDisplay.getScopeGroupId();
 
-		AssetVocabularyItemSelectorCriterion
-			assetVocabularyItemSelectorCriterion =
-				new AssetVocabularyItemSelectorCriterion();
+		Group scopeGroup = _themeDisplay.getScopeGroup();
 
-		assetVocabularyItemSelectorCriterion.setDesiredItemSelectorReturnTypes(
-			new UUIDItemSelectorReturnType());
+		String siteName = scopeGroup.getDescriptiveName(
+			_themeDisplay.getLocale());
 
 		return DropdownItemListBuilder.add(
 			dropdownItem -> {
 				dropdownItem.putData("action", "deleteVocabularies");
 				dropdownItem.putData(
+					"currentSiteId", String.valueOf(scopeGroupId));
+				dropdownItem.putData(
 					"deleteVocabulariesURL", deleteVocabulariesURL.toString());
 				dropdownItem.putData("redirectURL", getDefaultRedirect());
-				dropdownItem.putData(
-					"viewVocabulariesURL",
-					String.valueOf(
-						itemSelector.getItemSelectorURL(
-							RequestBackedPortletURLFactoryUtil.create(
-								_httpServletRequest),
-							_renderResponse.getNamespace() + "selectVocabulary",
-							assetVocabularyItemSelectorCriterion)));
+				dropdownItem.putData("siteName", siteName);
 				dropdownItem.setIcon("trash");
 				dropdownItem.setLabel(
 					LanguageUtil.get(_httpServletRequest, "delete"));

--- a/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/js/ActionsComponentPropsTransformer.js
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/js/ActionsComponentPropsTransformer.js
@@ -3,67 +3,135 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openSelectionModal, openToast} from 'frontend-js-components-web';
+import {openItemSelectorModal} from '@liferay/frontend-js-item-selector-web';
+import {openToast} from 'frontend-js-components-web';
 import {fetch, navigate, objectToFormData} from 'frontend-js-web';
 
 import openDeleteVocabularyModal from './openDeleteVocabularyModal';
 
+const HEADLESS_TAXONOMY_VOCABULARIES_BASE =
+	'/o/headless-admin-taxonomy/v1.0/sites';
+
+function buildVocabulariesURL(currentSiteId) {
+	const url = new URL(
+		`${HEADLESS_TAXONOMY_VOCABULARIES_BASE}/${String(
+			currentSiteId
+		)}/taxonomy-vocabularies`,
+		window.location.origin
+	);
+
+	url.searchParams.set(
+		'filter',
+		`visibilityType eq 0 and siteId eq ${String(currentSiteId)}`
+	);
+
+	return url.toString();
+}
+
 const ACTIONS = {
 	deleteVocabularies(itemData, portletNamespace) {
-		openSelectionModal({
-			buttonAddLabel: Liferay.Language.get('delete'),
-			multiple: true,
-			onSelect: (selectedItems) => {
-				if (selectedItems.length) {
-					openDeleteVocabularyModal({
-						multiple: true,
-						onDelete: () => {
-							fetch(itemData.deleteVocabulariesURL, {
-								body: objectToFormData({
-									[`${portletNamespace}rowIds`]: selectedItems
-										.map((item) => {
-											const selectedValue = JSON.parse(
-												item.value
-											);
+		const TitleCell = ({itemData: vocabulary}) =>
+			`${vocabulary.name} (${itemData.siteName})`;
 
-											return selectedValue.vocabularyId;
-										})
-										.join(','),
-								}),
-								method: 'POST',
-							})
-								.then((response) => {
-									if (response.ok) {
-										return response.json();
-									}
-									else {
-										showErorMessage();
-									}
-								})
-								.then((data) => {
-									if (data.success) {
-										navigate(itemData.redirectURL);
-
-										openToast({
-											message: Liferay.Language.get(
-												'your-request-completed-successfully'
-											),
-											type: 'success',
-										});
-									}
-									else {
-										showErorMessage(data.errorMessage);
-									}
-								})
-								.catch(() => {
-									showErorMessage();
-								});
+		openItemSelectorModal({
+			apiURL: buildVocabulariesURL(itemData.currentSiteId),
+			confirmButtonLabel: Liferay.Language.get('delete'),
+			fdsProps: {
+				configInURLBehavior: 'OFF',
+				customRenderers: {
+					tableCell: [
+						{
+							component: TitleCell,
+							name: 'titleWithScope',
+							type: 'internal',
 						},
-					});
-				}
+					],
+				},
+				id: 'assetCategoriesAdminVocabularyDeleteFDS',
+				pagination: {
+					deltas: [{label: 20}, {label: 50}],
+					initialDelta: 20,
+				},
+				views: [
+					{
+						contentRenderer: 'table',
+						label: '',
+						name: 'list',
+						schema: {
+							fields: [
+								{
+									contentRenderer: 'titleWithScope',
+									fieldName: 'name',
+									label: Liferay.Language.get('title'),
+								},
+								{
+									fieldName: 'creator.name',
+									label: Liferay.Language.get('user'),
+								},
+								{
+									contentRenderer: 'dateTime',
+									fieldName: 'dateModified',
+									label: Liferay.Language.get(
+										'modified-date'
+									),
+									sortable: true,
+								},
+							],
+						},
+					},
+				],
 			},
+			itemTypeLabel: Liferay.Language.get('vocabulary'),
+			items: [],
+			locator: {id: 'id', label: 'name', value: 'id'},
+			multiSelect: true,
+			onItemsChange: (selected) => {
+				if (!selected.length) {
+					return;
+				}
+
+				openDeleteVocabularyModal({
+					multiple: true,
+					onDelete: () => {
+						fetch(itemData.deleteVocabulariesURL, {
+							body: objectToFormData({
+								[`${portletNamespace}rowIds`]: selected
+									.map((vocabulary) => vocabulary.id)
+									.join(','),
+							}),
+							method: 'POST',
+						})
+							.then((response) => {
+								if (response.ok) {
+									return response.json();
+								}
+								else {
+									showErorMessage();
+								}
+							})
+							.then((data) => {
+								if (data.success) {
+									navigate(itemData.redirectURL);
+
+									openToast({
+										message: Liferay.Language.get(
+											'your-request-completed-successfully'
+										),
+										type: 'success',
+									});
+								}
+								else {
+									showErorMessage(data.errorMessage);
+								}
+							})
+							.catch(() => {
+								showErorMessage();
+							});
+					},
+				});
+			},
+			size: 'lg',
 			title: Liferay.Language.get('delete-vocabulary'),
-			url: itemData.viewVocabulariesURL,
 		});
 	},
 };

--- a/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/js/ActionsComponentPropsTransformer.js
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/js/ActionsComponentPropsTransformer.js
@@ -30,23 +30,11 @@ function buildVocabulariesURL(currentSiteId) {
 
 const ACTIONS = {
 	deleteVocabularies(itemData, portletNamespace) {
-		const TitleCell = ({itemData: vocabulary}) =>
-			`${vocabulary.name} (${itemData.siteName})`;
-
 		openItemSelectorModal({
 			apiURL: buildVocabulariesURL(itemData.currentSiteId),
 			confirmButtonLabel: Liferay.Language.get('delete'),
 			fdsProps: {
 				configInURLBehavior: 'OFF',
-				customRenderers: {
-					tableCell: [
-						{
-							component: TitleCell,
-							name: 'titleWithScope',
-							type: 'internal',
-						},
-					],
-				},
 				id: 'assetCategoriesAdminVocabularyDeleteFDS',
 				pagination: {
 					deltas: [{label: 20}, {label: 50}],
@@ -60,7 +48,6 @@ const ACTIONS = {
 						schema: {
 							fields: [
 								{
-									contentRenderer: 'titleWithScope',
 									fieldName: 'name',
 									label: Liferay.Language.get('title'),
 								},

--- a/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/js/ActionsComponentPropsTransformer.js
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/js/ActionsComponentPropsTransformer.js
@@ -12,6 +12,8 @@ import openDeleteVocabularyModal from './openDeleteVocabularyModal';
 const HEADLESS_TAXONOMY_VOCABULARIES_BASE =
 	'/o/headless-admin-taxonomy/v1.0/sites';
 
+const VISIBILITY_TYPE_PUBLIC = 0;
+
 function buildVocabulariesURL(currentSiteId) {
 	const url = new URL(
 		`${HEADLESS_TAXONOMY_VOCABULARIES_BASE}/${String(
@@ -22,7 +24,9 @@ function buildVocabulariesURL(currentSiteId) {
 
 	url.searchParams.set(
 		'filter',
-		`visibilityType eq 0 and siteId eq ${String(currentSiteId)}`
+		`visibilityType eq ${VISIBILITY_TYPE_PUBLIC} and siteId eq ${String(
+			currentSiteId
+		)}`
 	);
 
 	return url.toString();

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/ItemSelectorModal.tsx
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/ItemSelectorModal.tsx
@@ -76,6 +76,11 @@ export interface IItemSelectorModalProps<T> {
 	breadcrumbsLabel?: boolean;
 
 	/**
+	 * Label for the footer confirmation button. Defaults to "Select".
+	 */
+	confirmButtonLabel?: string;
+
+	/**
 	 * Label shown in the footer as "{label} Selected" when
 	 * 'allowEmptySelection' is true and no items are selected.
 	 */
@@ -151,6 +156,12 @@ export interface IItemSelectorModalProps<T> {
 	open: boolean;
 
 	/**
+	 * Modal size. Defaults to "full-screen" to preserve the file-picker
+	 * layout; pass a smaller value (e.g. "lg") for compact list pickers.
+	 */
+	size?: React.ComponentProps<typeof ClayModal>['size'];
+
+	/**
 	 * Represents the title of a modal. takes precedence over itemTypeLabel.
 	 */
 	title?: string;
@@ -162,6 +173,7 @@ function ItemSelectorModal<T extends Record<string, any>>({
 	apiURL,
 	breadcrumbs,
 	breadcrumbsLabel = true,
+	confirmButtonLabel,
 	emptySelectionLabel,
 	fdsProps,
 	filesUploaderComponent: FilesUploaderComponent,
@@ -180,6 +192,7 @@ function ItemSelectorModal<T extends Record<string, any>>({
 	onItemsChange,
 	onOpenChange,
 	open,
+	size = 'full-screen',
 	title,
 }: IItemSelectorModalProps<T>) {
 	const [selectedItems, setSelectedItems] = useState(externalItems);
@@ -230,7 +243,7 @@ function ItemSelectorModal<T extends Record<string, any>>({
 	}
 
 	return (
-		<ClayModal observer={observer} size="full-screen">
+		<ClayModal observer={observer} size={size}>
 			<ClayModal.Header
 				closeButtonAriaLabel={Liferay.Language.get('close')}
 			>
@@ -379,7 +392,8 @@ function ItemSelectorModal<T extends Record<string, any>>({
 									onOpenChange(false);
 								}}
 							>
-								{Liferay.Language.get('select')}
+								{confirmButtonLabel ??
+									Liferay.Language.get('select')}
 							</ClayButton>
 						</ClayButton.Group>
 					}

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/fetchAllPages.ts
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/fetchAllPages.ts
@@ -1,0 +1,55 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {DEFAULT_FETCH_HEADERS} from '@liferay/frontend-data-set-web';
+import {fetch} from 'frontend-js-web';
+
+const PAGE_SIZE = 100;
+
+export interface IPage<T> {
+	items?: T[];
+	lastPage?: number;
+	page?: number;
+	totalCount?: number;
+}
+
+export default async function fetchAllPages<T>(
+	baseURL: string,
+	signal?: AbortSignal
+): Promise<T[]> {
+	const items: T[] = [];
+
+	let page = 1;
+	let lastPage = 1;
+
+	do {
+		const url = new URL(baseURL, window.location.origin);
+
+		url.searchParams.set('page', String(page));
+		url.searchParams.set('pageSize', String(PAGE_SIZE));
+
+		const response = await fetch(url.toString(), {
+			headers: DEFAULT_FETCH_HEADERS,
+			signal,
+		});
+
+		if (!response.ok) {
+			throw new Error(
+				`Request to ${url.pathname} failed: ${response.status}`
+			);
+		}
+
+		const json = (await response.json()) as IPage<T>;
+
+		if (Array.isArray(json.items)) {
+			items.push(...json.items);
+		}
+
+		lastPage = json.lastPage ?? 1;
+		page += 1;
+	} while (page <= lastPage);
+
+	return items;
+}

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/useTaxonomyCategoryTreeNodes.ts
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/useTaxonomyCategoryTreeNodes.ts
@@ -3,17 +3,15 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {DEFAULT_FETCH_HEADERS} from '@liferay/frontend-data-set-web';
-import {fetch} from 'frontend-js-web';
 import {useEffect, useMemo, useState} from 'react';
+
+import fetchAllPages from './fetchAllPages';
 
 // The vocabulary-scoped endpoint is used (not /sites/{id}/taxonomy-categories)
 // because the site path filters out categories of global vocabularies, while
 // this path returns the full set regardless of the requesting site.
 
 const HEADLESS_TAXONOMY_BASE = '/o/headless-admin-taxonomy/v1.0';
-
-const PAGE_SIZE = 100;
 
 export interface ITaxonomyCategory {
 	availableLanguages?: string[];
@@ -39,52 +37,6 @@ export interface ITaxonomyCategoryTreeNode {
 	name: string;
 	raw: ITaxonomyCategory;
 	vocabularyId: string;
-}
-
-interface IPage<T> {
-	items?: T[];
-	lastPage?: number;
-	page?: number;
-	totalCount?: number;
-}
-
-async function fetchAllPages<T>(
-	baseURL: string,
-	signal: AbortSignal
-): Promise<T[]> {
-	const items: T[] = [];
-
-	let page = 1;
-	let lastPage = 1;
-
-	do {
-		const url = new URL(baseURL, window.location.origin);
-
-		url.searchParams.set('page', String(page));
-		url.searchParams.set('pageSize', String(PAGE_SIZE));
-
-		const response = await fetch(url.toString(), {
-			headers: DEFAULT_FETCH_HEADERS,
-			signal,
-		});
-
-		if (!response.ok) {
-			throw new Error(
-				`Request to ${url.pathname} failed: ${response.status}`
-			);
-		}
-
-		const json = (await response.json()) as IPage<T>;
-
-		if (Array.isArray(json.items)) {
-			items.push(...json.items);
-		}
-
-		lastPage = json.lastPage ?? 1;
-		page += 1;
-	} while (page <= lastPage);
-
-	return items;
 }
 
 function buildTree(

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/odata/entity/v1_0/VocabularyEntityModel.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/odata/entity/v1_0/VocabularyEntityModel.java
@@ -8,6 +8,7 @@ package com.liferay.headless.admin.taxonomy.internal.odata.entity.v1_0;
 import com.liferay.headless.common.spi.odata.entity.EntityFieldsMapFactory;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.odata.entity.CollectionEntityField;
 import com.liferay.portal.odata.entity.DateTimeEntityField;
 import com.liferay.portal.odata.entity.EntityField;
 import com.liferay.portal.odata.entity.EntityModel;
@@ -24,6 +25,8 @@ public class VocabularyEntityModel implements EntityModel {
 
 	public VocabularyEntityModel() {
 		_entityFieldsMap = EntityFieldsMapFactory.create(
+			new CollectionEntityField(
+				new IntegerEntityField("assetLibraries", locale -> "groupIds")),
 			new DateTimeEntityField(
 				"dateCreated",
 				locale -> Field.getSortableFieldName(Field.CREATE_DATE),
@@ -33,12 +36,13 @@ public class VocabularyEntityModel implements EntityModel {
 				locale -> Field.getSortableFieldName(Field.MODIFIED_DATE),
 				locale -> Field.MODIFIED_DATE),
 			new IdEntityField(
-				"assetLibraries", locale -> "groupIds", String::valueOf),
-			new IdEntityField(
 				"assetTypes", locale -> "classNameIds", String::valueOf),
 			new IntegerEntityField(
 				"numberOfTaxonomyCategories",
 				locale -> Field.getSortableFieldName("categoriesCount")),
+			new IntegerEntityField("siteId", locale -> Field.GROUP_ID),
+			new IntegerEntityField(
+				"visibilityType", locale -> Field.VISIBILITY_TYPE),
 			new StringEntityField(
 				"externalReferenceCode", locale -> "externalReferenceCode"),
 			new StringEntityField(

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyVocabularyResourceTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyVocabularyResourceTest.java
@@ -304,7 +304,10 @@ public class TaxonomyVocabularyResourceTest
 
 	@Override
 	protected String[] getIgnoredEntityFieldNames() {
-		return new String[] {"dateCreated", "dateModified"};
+		return new String[] {
+			"assetLibraries", "dateCreated", "dateModified", "siteId",
+			"visibilityType"
+		};
 	}
 
 	@Override

--- a/modules/apps/site-navigation/site-navigation-admin-web/package.json
+++ b/modules/apps/site-navigation/site-navigation-admin-web/package.json
@@ -10,6 +10,7 @@
 		"@clayui/layout": "^3.163.0",
 		"@clayui/loading-indicator": "^3.163.0",
 		"@clayui/modal": "^3.163.0",
+		"@liferay/frontend-js-item-selector-web": "*",
 		"@liferay/frontend-js-react-web": "*",
 		"@liferay/layout-js-components-web": "*",
 		"classnames": "2.3.1",

--- a/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/js/site_navigation_menu_editor/utils/decorateAddSiteNavigationMenuItemOptions.js
+++ b/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/js/site_navigation_menu_editor/utils/decorateAddSiteNavigationMenuItemOptions.js
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import {openItemSelectorModal} from '@liferay/frontend-js-item-selector-web';
 import {openModal, openSelectionModal} from 'frontend-js-components-web';
 import {
 	COOKIE_TYPES,
@@ -11,6 +12,38 @@ import {
 	objectToFormData,
 	sessionStorage,
 } from 'frontend-js-web';
+
+const ASSET_VOCABULARY_TYPE = 'asset_vocabulary';
+
+const HEADLESS_TAXONOMY_VOCABULARIES_BASE =
+	'/o/headless-admin-taxonomy/v1.0/sites';
+
+function buildVocabulariesURL(currentSiteId) {
+	const url = new URL(
+		`${HEADLESS_TAXONOMY_VOCABULARIES_BASE}/${String(
+			currentSiteId
+		)}/taxonomy-vocabularies`,
+		window.location.origin
+	);
+
+	url.searchParams.set('filter', 'visibilityType eq 0');
+
+	return url.toString();
+}
+
+function getVocabularyScopeName(vocabulary, companyGroupId) {
+	const assetLibrary = vocabulary.assetLibraries?.[0];
+
+	if (!assetLibrary) {
+		return '';
+	}
+
+	if (String(assetLibrary.id) === String(companyGroupId)) {
+		return Liferay.Language.get('global');
+	}
+
+	return assetLibrary.name;
+}
 
 export default function decorateAddSiteNavigationMenuItemOptions({
 	addSiteNavigationMenuItemOptions,
@@ -30,6 +63,18 @@ export default function decorateAddSiteNavigationMenuItemOptions({
 		parentSiteNavigationMenuItemId,
 	}) => {
 		const useSmallerModal = shouldUseSmallerModal(data.type);
+
+		if (data.type === ASSET_VOCABULARY_TYPE && data.itemSelector) {
+			openAssetVocabularyPicker({
+				data,
+				onItemAdd,
+				order,
+				parentSiteNavigationMenuItemId,
+				portletNamespace,
+			});
+
+			return;
+		}
 
 		if (data.itemSelector) {
 			openSelectionModal({
@@ -172,6 +217,113 @@ function getNamespacedInfoItems(
 	};
 
 	return Liferay.Util.ns(portletNamespace, infoItems);
+}
+
+function openAssetVocabularyPicker({
+	data,
+	onItemAdd,
+	order,
+	parentSiteNavigationMenuItemId,
+	portletNamespace,
+}) {
+	const companyGroupId = Liferay.ThemeDisplay.getCompanyGroupId();
+	const currentSiteId = Liferay.ThemeDisplay.getScopeGroupId();
+
+	const TitleCell = ({itemData: vocabulary}) => {
+		const scopeName = getVocabularyScopeName(vocabulary, companyGroupId);
+
+		if (!scopeName) {
+			return vocabulary.name;
+		}
+
+		return `${vocabulary.name} (${scopeName})`;
+	};
+
+	openItemSelectorModal({
+		apiURL: buildVocabulariesURL(currentSiteId),
+		fdsProps: {
+			configInURLBehavior: 'OFF',
+			customRenderers: {
+				tableCell: [
+					{
+						component: TitleCell,
+						name: 'titleWithScope',
+						type: 'internal',
+					},
+				],
+			},
+			id: 'addSiteNavigationMenuVocabularyFDS',
+			pagination: {
+				deltas: [{label: 20}, {label: 50}],
+				initialDelta: 20,
+			},
+			views: [
+				{
+					contentRenderer: 'table',
+					label: '',
+					name: 'list',
+					schema: {
+						fields: [
+							{
+								contentRenderer: 'titleWithScope',
+								fieldName: 'name',
+								label: Liferay.Language.get('title'),
+							},
+							{
+								fieldName: 'creator.name',
+								label: Liferay.Language.get('user'),
+							},
+							{
+								contentRenderer: 'dateTime',
+								fieldName: 'dateModified',
+								label: Liferay.Language.get('modified-date'),
+								sortable: true,
+							},
+						],
+					},
+				},
+			],
+		},
+		itemTypeLabel: Liferay.Language.get('vocabulary'),
+		items: [],
+		locator: {id: 'id', label: 'name', value: 'id'},
+		multiSelect: true,
+		onItemsChange: (selected) => {
+			if (!selected.length) {
+				return;
+			}
+
+			const addItemURL = createPortletURL(data.addItemURL, {
+				order,
+				parentSiteNavigationMenuItemId,
+			});
+
+			const items = selected.map((vocabulary) => ({
+				externalReferenceCode: vocabulary.externalReferenceCode,
+				groupId:
+					vocabulary.siteId ??
+					vocabulary.assetLibraries?.[0]?.id ??
+					currentSiteId,
+				title: vocabulary.name,
+			}));
+
+			fetch(addItemURL, {
+				body: objectToFormData(
+					Liferay.Util.ns(portletNamespace, {
+						items: JSON.stringify(items),
+						siteNavigationMenuId: data.siteNavigationMenuId,
+					})
+				),
+				method: 'POST',
+			}).then(() => {
+				onItemAdd();
+
+				window.location.reload();
+			});
+		},
+		size: 'lg',
+		title: data.addTitle,
+	});
 }
 
 const SMALLER_MODAL_TYPES = [

--- a/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/js/site_navigation_menu_editor/utils/decorateAddSiteNavigationMenuItemOptions.js
+++ b/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/js/site_navigation_menu_editor/utils/decorateAddSiteNavigationMenuItemOptions.js
@@ -51,10 +51,7 @@ function getVocabularyScopeName(vocabulary, companyGroupId) {
 		return assetLibrary.name;
 	}
 
-	if (
-		vocabulary.siteId !== undefined &&
-		String(vocabulary.siteId) === String(companyGroupId)
-	) {
+	if (String(vocabulary.siteId) === String(companyGroupId)) {
 		return Liferay.Language.get('global');
 	}
 

--- a/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/js/site_navigation_menu_editor/utils/decorateAddSiteNavigationMenuItemOptions.js
+++ b/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/js/site_navigation_menu_editor/utils/decorateAddSiteNavigationMenuItemOptions.js
@@ -15,6 +15,7 @@ import {
 	fetch,
 	objectToFormData,
 	sessionStorage,
+	sub,
 } from 'frontend-js-web';
 
 const ASSET_VOCABULARY_TYPE = 'asset_vocabulary';
@@ -249,7 +250,11 @@ function openAssetVocabularyPicker({
 			return vocabulary.name;
 		}
 
-		return `${vocabulary.name} (${scopeName})`;
+		return sub(
+			Liferay.Language.get('x-group-x'),
+			vocabulary.name,
+			scopeName
+		);
 	};
 
 	openItemSelectorModal({

--- a/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/js/site_navigation_menu_editor/utils/decorateAddSiteNavigationMenuItemOptions.js
+++ b/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/js/site_navigation_menu_editor/utils/decorateAddSiteNavigationMenuItemOptions.js
@@ -22,6 +22,8 @@ const ASSET_VOCABULARY_TYPE = 'asset_vocabulary';
 const HEADLESS_TAXONOMY_VOCABULARIES_BASE =
 	'/o/headless-admin-taxonomy/v1.0/sites';
 
+const VISIBILITY_TYPE_PUBLIC = 0;
+
 function buildVocabulariesURL(currentSiteId) {
 	const url = new URL(
 		`${HEADLESS_TAXONOMY_VOCABULARIES_BASE}/${String(
@@ -30,7 +32,10 @@ function buildVocabulariesURL(currentSiteId) {
 		window.location.origin
 	);
 
-	url.searchParams.set('filter', 'visibilityType eq 0');
+	url.searchParams.set(
+		'filter',
+		`visibilityType eq ${VISIBILITY_TYPE_PUBLIC}`
+	);
 
 	return url.toString();
 }

--- a/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/js/site_navigation_menu_editor/utils/decorateAddSiteNavigationMenuItemOptions.js
+++ b/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/js/site_navigation_menu_editor/utils/decorateAddSiteNavigationMenuItemOptions.js
@@ -4,7 +4,11 @@
  */
 
 import {openItemSelectorModal} from '@liferay/frontend-js-item-selector-web';
-import {openModal, openSelectionModal} from 'frontend-js-components-web';
+import {
+	openModal,
+	openSelectionModal,
+	openToast,
+} from 'frontend-js-components-web';
 import {
 	COOKIE_TYPES,
 	createPortletURL,
@@ -34,15 +38,22 @@ function buildVocabulariesURL(currentSiteId) {
 function getVocabularyScopeName(vocabulary, companyGroupId) {
 	const assetLibrary = vocabulary.assetLibraries?.[0];
 
-	if (!assetLibrary) {
-		return '';
+	if (assetLibrary) {
+		if (String(assetLibrary.id) === String(companyGroupId)) {
+			return Liferay.Language.get('global');
+		}
+
+		return assetLibrary.name;
 	}
 
-	if (String(assetLibrary.id) === String(companyGroupId)) {
+	if (
+		vocabulary.siteId !== undefined &&
+		String(vocabulary.siteId) === String(companyGroupId)
+	) {
 		return Liferay.Language.get('global');
 	}
 
-	return assetLibrary.name;
+	return '';
 }
 
 export default function decorateAddSiteNavigationMenuItemOptions({
@@ -315,11 +326,24 @@ function openAssetVocabularyPicker({
 					})
 				),
 				method: 'POST',
-			}).then(() => {
-				onItemAdd();
+			})
+				.then((response) => {
+					if (!response.ok) {
+						throw new Error();
+					}
 
-				window.location.reload();
-			});
+					onItemAdd();
+
+					window.location.reload();
+				})
+				.catch(() => {
+					openToast({
+						message: Liferay.Language.get(
+							'an-unexpected-error-occurred'
+						),
+						type: 'danger',
+					});
+				});
 		},
 		size: 'lg',
 		title: data.addTitle,

--- a/modules/apps/site-navigation/site-navigation-menu-item-asset-vocabulary/build.gradle
+++ b/modules/apps/site-navigation/site-navigation-menu-item-asset-vocabulary/build.gradle
@@ -9,6 +9,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:asset:asset-display-page-api")
 	compileOnly project(":apps:asset:asset-vocabulary-item-selector-api")
+	compileOnly project(":apps:depot:depot-api")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-react")

--- a/modules/apps/site-navigation/site-navigation-menu-item-asset-vocabulary/package.json
+++ b/modules/apps/site-navigation/site-navigation-menu-item-asset-vocabulary/package.json
@@ -5,6 +5,7 @@
 		"@clayui/form": "^3.163.0",
 		"@clayui/icon": "^3.163.0",
 		"@clayui/label": "^3.163.0",
+		"@liferay/frontend-js-item-selector-web": "*",
 		"classnames": "2.3.1",
 		"frontend-js-components-web": "*",
 		"frontend-js-web": "*",

--- a/modules/apps/site-navigation/site-navigation-menu-item-asset-vocabulary/src/main/java/com/liferay/site/navigation/menu/item/asset/vocabulary/internal/display/context/AssetVocabularySiteNavigationMenuTypeDisplayContext.java
+++ b/modules/apps/site-navigation/site-navigation-menu-item-asset-vocabulary/src/main/java/com/liferay/site/navigation/menu/item/asset/vocabulary/internal/display/context/AssetVocabularySiteNavigationMenuTypeDisplayContext.java
@@ -7,18 +7,20 @@ package com.liferay.site.navigation.menu.item.asset.vocabulary.internal.display.
 
 import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalServiceUtil;
-import com.liferay.asset.vocabulary.item.selector.AssetVocabularyItemSelectorCriterion;
-import com.liferay.asset.vocabulary.item.selector.AssetVocabularyItemSelectorReturnType;
-import com.liferay.item.selector.ItemSelector;
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalServiceUtil;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.LiferayPortletURL;
-import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactory;
-import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactoryUtil;
-import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.portlet.url.builder.ResourceURLBuilder;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -40,6 +42,7 @@ import jakarta.portlet.PortletResponse;
 
 import jakarta.servlet.http.HttpServletRequest;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -48,11 +51,10 @@ import java.util.Map;
 public class AssetVocabularySiteNavigationMenuTypeDisplayContext {
 
 	public AssetVocabularySiteNavigationMenuTypeDisplayContext(
-		HttpServletRequest httpServletRequest, ItemSelector itemSelector,
+		HttpServletRequest httpServletRequest,
 		SiteNavigationMenuItem siteNavigationMenuItem) {
 
 		_httpServletRequest = httpServletRequest;
-		_itemSelector = itemSelector;
 		_siteNavigationMenuItem = siteNavigationMenuItem;
 
 		_liferayPortletResponse = PortalUtil.getLiferayPortletResponse(
@@ -208,37 +210,33 @@ public class AssetVocabularySiteNavigationMenuTypeDisplayContext {
 		).build();
 	}
 
-	private Map<String, Object> _getChooseAssetVocabularyButtonContext() {
+	private Map<String, Object> _getChooseAssetVocabularyButtonContext()
+		throws Exception {
+
+		long companyGroupId = _themeDisplay.getCompanyGroupId();
+		long scopeGroupId = _themeDisplay.getScopeGroupId();
+
+		Group companyGroup = GroupLocalServiceUtil.fetchGroup(companyGroupId);
+		Group scopeGroup = _themeDisplay.getScopeGroup();
+
+		String companyExternalReferenceCode;
+
+		if (companyGroup == null) {
+			companyExternalReferenceCode = StringPool.BLANK;
+		}
+		else {
+			companyExternalReferenceCode = GetterUtil.getString(
+				companyGroup.getExternalReferenceCode());
+		}
+
 		return HashMapBuilder.<String, Object>put(
-			"assetVocabularySelectorURL",
-			() -> {
-				AssetVocabularyItemSelectorCriterion
-					assetVocabularyItemSelectorCriterion =
-						new AssetVocabularyItemSelectorCriterion();
-
-				assetVocabularyItemSelectorCriterion.
-					setDesiredItemSelectorReturnTypes(
-						new AssetVocabularyItemSelectorReturnType());
-				assetVocabularyItemSelectorCriterion.
-					setIncludeAncestorSiteAndDepotGroupIds(true);
-				assetVocabularyItemSelectorCriterion.
-					setIncludeInternalVocabularies(false);
-
-				RequestBackedPortletURLFactory requestBackedPortletURLFactory =
-					RequestBackedPortletURLFactoryUtil.create(
-						_httpServletRequest);
-
-				return PortletURLBuilder.create(
-					_itemSelector.getItemSelectorURL(
-						requestBackedPortletURLFactory,
-						_liferayPortletResponse.getNamespace() +
-							"selectAssetVocabulary",
-						assetVocabularyItemSelectorCriterion)
-				).buildString();
-			}
+			"assetLibraries", _getConnectedAssetLibrariesJSONArray(scopeGroupId)
 		).put(
-			"eventName",
-			_liferayPortletResponse.getNamespace() + "selectAssetVocabulary"
+			"companyExternalReferenceCode", companyExternalReferenceCode
+		).put(
+			"companyGroupId", String.valueOf(companyGroupId)
+		).put(
+			"currentSiteId", String.valueOf(scopeGroupId)
 		).put(
 			"getAssetVocabularyDetailsURL",
 			() -> {
@@ -253,12 +251,61 @@ public class AssetVocabularySiteNavigationMenuTypeDisplayContext {
 
 				return itemDetailsURL.toString();
 			}
+		).put(
+			"siteExternalReferenceCode",
+			GetterUtil.getString(scopeGroup.getExternalReferenceCode())
+		).put(
+			"siteName", scopeGroup.getDescriptiveName(_themeDisplay.getLocale())
 		).build();
 	}
 
+	private JSONArray _getConnectedAssetLibrariesJSONArray(long scopeGroupId) {
+		JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
+
+		try {
+			List<DepotEntry> depotEntries =
+				DepotEntryLocalServiceUtil.getGroupConnectedDepotEntries(
+					scopeGroupId, DepotConstants.TYPE_ANY, QueryUtil.ALL_POS,
+					QueryUtil.ALL_POS);
+
+			for (DepotEntry depotEntry : depotEntries) {
+				Group depotGroup = GroupLocalServiceUtil.fetchGroup(
+					depotEntry.getGroupId());
+
+				if (depotGroup == null) {
+					continue;
+				}
+
+				jsonArray.put(
+					JSONUtil.put(
+						"externalReferenceCode",
+						GetterUtil.getString(
+							depotGroup.getExternalReferenceCode())
+					).put(
+						"id", String.valueOf(depotGroup.getGroupId())
+					).put(
+						"name",
+						depotGroup.getDescriptiveName(_themeDisplay.getLocale())
+					));
+			}
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Unable to enumerate connected asset libraries for group " +
+						scopeGroupId,
+					exception);
+			}
+		}
+
+		return jsonArray;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		AssetVocabularySiteNavigationMenuTypeDisplayContext.class);
+
 	private final AssetVocabulary _assetVocabulary;
 	private final HttpServletRequest _httpServletRequest;
-	private final ItemSelector _itemSelector;
 	private final LiferayPortletResponse _liferayPortletResponse;
 	private final SiteNavigationMenuItem _siteNavigationMenuItem;
 	private final ThemeDisplay _themeDisplay;

--- a/modules/apps/site-navigation/site-navigation-menu-item-asset-vocabulary/src/main/java/com/liferay/site/navigation/menu/item/asset/vocabulary/internal/type/AssetVocabularySiteNavigationMenuItemType.java
+++ b/modules/apps/site-navigation/site-navigation-menu-item-asset-vocabulary/src/main/java/com/liferay/site/navigation/menu/item/asset/vocabulary/internal/type/AssetVocabularySiteNavigationMenuItemType.java
@@ -552,7 +552,7 @@ public class AssetVocabularySiteNavigationMenuItemType
 			AssetVocabularySiteNavigationMenuTypeConstants.
 				ASSET_VOCABULARY_SITE_NAVIGATION_MENU_TYPE_DISPLAY_CONTEXT,
 			new AssetVocabularySiteNavigationMenuTypeDisplayContext(
-				httpServletRequest, _itemSelector, siteNavigationMenuItem));
+				httpServletRequest, siteNavigationMenuItem));
 
 		_jspRenderer.renderJSP(
 			_servletContext, httpServletRequest, httpServletResponse,

--- a/modules/apps/site-navigation/site-navigation-menu-item-asset-vocabulary/src/main/resources/META-INF/resources/js/index.js
+++ b/modules/apps/site-navigation/site-navigation-menu-item-asset-vocabulary/src/main/resources/META-INF/resources/js/index.js
@@ -8,14 +8,58 @@ import {ClayButtonWithIcon} from '@clayui/button';
 import ClayForm, {ClayCheckbox, ClayInput} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import ClayLabel from '@clayui/label';
+import {openItemSelectorModal} from '@liferay/frontend-js-item-selector-web';
 import classNames from 'classnames';
-import {
-	TranslationAdminSelector,
-	openSelectionModal,
-} from 'frontend-js-components-web';
+import {TranslationAdminSelector} from 'frontend-js-components-web';
 import {fetch, objectToFormData} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useEffect, useRef, useState} from 'react';
+
+const HEADLESS_TAXONOMY_VOCABULARIES_BASE =
+	'/o/headless-admin-taxonomy/v1.0/sites';
+
+function buildVocabulariesURL(currentSiteId) {
+	const url = new URL(
+		`${HEADLESS_TAXONOMY_VOCABULARIES_BASE}/${String(
+			currentSiteId
+		)}/taxonomy-vocabularies`,
+		window.location.origin
+	);
+
+	url.searchParams.set('filter', 'visibilityType eq 0');
+
+	return url.toString();
+}
+
+function resolveScope(vocabulary, context) {
+	if (vocabulary.assetLibraryKey) {
+		const assetLibrary = context.assetLibrariesByKey.get(
+			vocabulary.assetLibraryKey
+		);
+
+		return {
+			scopeExternalReferenceCode:
+				assetLibrary?.externalReferenceCode ??
+				vocabulary.assetLibraryKey,
+			scopeName: assetLibrary?.name ?? vocabulary.assetLibraryKey,
+		};
+	}
+
+	if (
+		vocabulary.siteId !== undefined &&
+		String(vocabulary.siteId) === context.companyGroupId
+	) {
+		return {
+			scopeExternalReferenceCode: context.companyExternalReferenceCode,
+			scopeName: Liferay.Language.get('global'),
+		};
+	}
+
+	return {
+		scopeExternalReferenceCode: context.siteExternalReferenceCode,
+		scopeName: context.siteName,
+	};
+}
 
 function AssetVocabularyContextualSidebar({
 	assetVocabulary,
@@ -48,9 +92,13 @@ function AssetVocabularyContextualSidebar({
 	const nameRef = useRef(null);
 
 	const {
-		assetVocabularySelectorURL,
-		eventName,
+		assetLibraries,
+		companyExternalReferenceCode,
+		companyGroupId,
+		currentSiteId,
 		getAssetVocabularyDetailsURL,
+		siteExternalReferenceCode,
+		siteName: chooseAssetVocabularySiteName,
 	} = chooseAssetVocabularyProps;
 
 	useEffect(() => {
@@ -104,59 +152,113 @@ function AssetVocabularyContextualSidebar({
 		};
 	}, [assetVocabulary.title, customName, defaultLanguageId, translations]);
 
-	const openChooseItemModal = () =>
-		openSelectionModal({
-			onSelect: (selectedItem) => {
-				if (selectedItem) {
-					let item = {
-						...selectedItem,
-					};
+	const openChooseItemModal = () => {
+		const scopeContext = {
+			assetLibrariesByKey: new Map(
+				(assetLibraries || []).map((assetLibrary) => [
+					assetLibrary.externalReferenceCode,
+					assetLibrary,
+				])
+			),
+			companyExternalReferenceCode,
+			companyGroupId: String(companyGroupId),
+			siteExternalReferenceCode,
+			siteName: chooseAssetVocabularySiteName,
+		};
 
-					let value;
+		const TitleCell = ({itemData}) => {
+			const {scopeName} = resolveScope(itemData, scopeContext);
 
-					if (typeof selectedItem.value === 'string') {
-						try {
-							value = JSON.parse(selectedItem.value);
-						}
-						catch (error) {}
-					}
-					else if (
-						selectedItem.value &&
-						typeof selectedItem.value === 'object'
-					) {
-						value = selectedItem.value;
-					}
+			return `${itemData.name} (${scopeName})`;
+		};
 
-					if (value) {
-						delete item.value;
-						item = {...value};
-					}
-
-					setSelectedVocabulary({
-						...item,
-						externalReferenceCode: item.externalReferenceCode,
-					});
-
-					const namespacedItem = Liferay.Util.ns(namespace, item);
-
-					fetch(getAssetVocabularyDetailsURL, {
-						body: objectToFormData(namespacedItem),
-						method: 'POST',
-					})
-						.then((response) => response.json())
-						.then((jsonResponse) => {
-							setNumberOfCategories(
-								jsonResponse.numberOfCategories
-							);
-							setSiteName(jsonResponse.siteName);
-						})
-						.catch(() => {});
-				}
+		openItemSelectorModal({
+			apiURL: buildVocabulariesURL(currentSiteId),
+			fdsProps: {
+				configInURLBehavior: 'OFF',
+				customRenderers: {
+					tableCell: [
+						{
+							component: TitleCell,
+							name: 'titleWithScope',
+							type: 'internal',
+						},
+					],
+				},
+				id: 'siteNavVocabularySelectorFDS',
+				pagination: {
+					deltas: [{label: 20}, {label: 50}],
+					initialDelta: 20,
+				},
+				views: [
+					{
+						contentRenderer: 'table',
+						label: '',
+						name: 'list',
+						schema: {
+							fields: [
+								{
+									contentRenderer: 'titleWithScope',
+									fieldName: 'name',
+									label: Liferay.Language.get('title'),
+								},
+								{
+									fieldName: 'creator.name',
+									label: Liferay.Language.get('user'),
+								},
+								{
+									contentRenderer: 'dateTime',
+									fieldName: 'dateModified',
+									label: Liferay.Language.get(
+										'modified-date'
+									),
+									sortable: true,
+								},
+							],
+						},
+					},
+				],
 			},
-			selectEventName: eventName,
+			itemTypeLabel: Liferay.Language.get('vocabulary'),
+			items: [],
+			locator: {id: 'id', label: 'name', value: 'id'},
+			multiSelect: false,
+			onItemsChange: (selected) => {
+				const [vocabulary] = selected;
+
+				if (!vocabulary) {
+					return;
+				}
+
+				const {scopeExternalReferenceCode} = resolveScope(
+					vocabulary,
+					scopeContext
+				);
+
+				const item = {
+					externalReferenceCode: vocabulary.externalReferenceCode,
+					scopeExternalReferenceCode,
+					title: vocabulary.name,
+					type: 'AssetVocabulary',
+				};
+
+				setSelectedVocabulary(item);
+
+				fetch(getAssetVocabularyDetailsURL, {
+					body: objectToFormData(Liferay.Util.ns(namespace, item)),
+					method: 'POST',
+				})
+					.then((response) => response.json())
+					.then((jsonResponse) => {
+						setNumberOfCategories(jsonResponse.numberOfCategories);
+						setSiteName(jsonResponse.siteName);
+					})
+					.catch(() => {});
+			},
+			size: 'lg',
 			title: Liferay.Language.get('select-vocabulary'),
-			url: assetVocabularySelectorURL,
 		});
+	};
 
 	return (
 		<>
@@ -375,9 +477,19 @@ AssetVocabularyContextualSidebar.propTypes = {
 		type: PropTypes.string,
 	}).isRequired,
 	chooseAssetVocabularyProps: PropTypes.shape({
-		assetVocabularySelectorURL: PropTypes.string,
-		eventName: PropTypes.string,
+		assetLibraries: PropTypes.arrayOf(
+			PropTypes.shape({
+				externalReferenceCode: PropTypes.string,
+				id: PropTypes.string,
+				name: PropTypes.string,
+			})
+		),
+		companyExternalReferenceCode: PropTypes.string,
+		companyGroupId: PropTypes.string,
+		currentSiteId: PropTypes.string,
 		getAssetVocabularyDetailsURL: PropTypes.string,
+		siteExternalReferenceCode: PropTypes.string,
+		siteName: PropTypes.string,
 	}).isRequired,
 	defaultLanguageId: PropTypes.string.isRequired,
 	locales: PropTypes.array.isRequired,

--- a/modules/apps/site-navigation/site-navigation-menu-item-asset-vocabulary/src/main/resources/META-INF/resources/js/index.js
+++ b/modules/apps/site-navigation/site-navigation-menu-item-asset-vocabulary/src/main/resources/META-INF/resources/js/index.js
@@ -18,6 +18,8 @@ import React, {useEffect, useRef, useState} from 'react';
 const HEADLESS_TAXONOMY_VOCABULARIES_BASE =
 	'/o/headless-admin-taxonomy/v1.0/sites';
 
+const VISIBILITY_TYPE_PUBLIC = 0;
+
 function buildVocabulariesURL(currentSiteId) {
 	const url = new URL(
 		`${HEADLESS_TAXONOMY_VOCABULARIES_BASE}/${String(
@@ -26,7 +28,10 @@ function buildVocabulariesURL(currentSiteId) {
 		window.location.origin
 	);
 
-	url.searchParams.set('filter', 'visibilityType eq 0');
+	url.searchParams.set(
+		'filter',
+		`visibilityType eq ${VISIBILITY_TYPE_PUBLIC}`
+	);
 
 	return url.toString();
 }

--- a/modules/apps/site-navigation/site-navigation-menu-item-asset-vocabulary/src/main/resources/META-INF/resources/js/index.js
+++ b/modules/apps/site-navigation/site-navigation-menu-item-asset-vocabulary/src/main/resources/META-INF/resources/js/index.js
@@ -11,7 +11,7 @@ import ClayLabel from '@clayui/label';
 import {openItemSelectorModal} from '@liferay/frontend-js-item-selector-web';
 import classNames from 'classnames';
 import {TranslationAdminSelector} from 'frontend-js-components-web';
-import {fetch, objectToFormData} from 'frontend-js-web';
+import {fetch, objectToFormData, sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useEffect, useRef, useState} from 'react';
 
@@ -171,7 +171,11 @@ function AssetVocabularyContextualSidebar({
 		const TitleCell = ({itemData}) => {
 			const {scopeName} = resolveScope(itemData, scopeContext);
 
-			return `${itemData.name} (${scopeName})`;
+			return sub(
+				Liferay.Language.get('x-group-x'),
+				itemData.name,
+				scopeName
+			);
 		};
 
 		openItemSelectorModal({

--- a/modules/apps/site-navigation/site-navigation-menu-item-asset-vocabulary/src/main/resources/META-INF/resources/js/index.js
+++ b/modules/apps/site-navigation/site-navigation-menu-item-asset-vocabulary/src/main/resources/META-INF/resources/js/index.js
@@ -50,10 +50,7 @@ function resolveScope(vocabulary, context) {
 		};
 	}
 
-	if (
-		vocabulary.siteId !== undefined &&
-		String(vocabulary.siteId) === context.companyGroupId
-	) {
+	if (String(vocabulary.siteId) === context.companyGroupId) {
 		return {
 			scopeExternalReferenceCode: context.companyExternalReferenceCode,
 			scopeName: Liferay.Language.get('global'),

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/recycleBin.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/recycleBin.spec.ts
@@ -313,7 +313,7 @@ test(
 		await test.step('Login as CMS Administrator', async () => {
 			const user = await addCMSAdministrator(apiHelpers);
 
-			await performUserSwitch(page, user.alternateName);
+			await performUserSwitchViaApi(page, user.alternateName);
 		});
 
 		await test.step('Delete all the contents so they can go into the Recycle Bin', async () => {

--- a/modules/test/playwright/tests/site-navigation-admin-web/main/pages/NavigationMenusPage.ts
+++ b/modules/test/playwright/tests/site-navigation-admin-web/main/pages/NavigationMenusPage.ts
@@ -47,7 +47,7 @@ export class NavigationMenusPage {
 	readonly sidebarBody: Locator;
 	readonly sidebarSaveButton: Locator;
 	readonly urlModal: FrameLocator;
-	readonly vocabulariesModal: FrameLocator;
+	readonly vocabulariesModal: Locator;
 
 	readonly globalMenuPage: GlobalMenuPage;
 	readonly productMenuPage: ProductMenuPage;
@@ -136,9 +136,11 @@ export class NavigationMenusPage {
 			name: 'Save',
 		});
 		this.urlModal = page.frameLocator('iframe[title="Add URL"]');
-		this.vocabulariesModal = page.frameLocator(
-			'iframe[title="Select Vocabularies"]'
-		);
+		this.vocabulariesModal = page
+			.getByRole('dialog', {
+				name: 'Select Vocabulary',
+			})
+			.or(page.getByRole('dialog', {name: 'Select Vocabularies'}));
 
 		this.globalMenuPage = new GlobalMenuPage(this.page);
 		this.productMenuPage = new ProductMenuPage(this.page);
@@ -522,7 +524,7 @@ export class NavigationMenusPage {
 			trigger: this.addMenuItemButton,
 		});
 
-		await this.vocabulariesModal.getByPlaceholder('Search').waitFor();
+		await this.vocabulariesModal.waitFor();
 	}
 
 	async translateName(itemName: string, useCustomName = false) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90764

## What is being fixed

The asset vocabulary selector flows (site navigation menu sidebar, add menu item, and Asset Categories Admin bulk-delete) still rendered through the legacy JSP-based `asset-vocabulary-item-selector-web` iframe. The parent story LPD-87722 (epic LPD-83235) replaces those with the new React Item Selector from `frontend-js-item-selector-web`.

## How it is being fixed

The three vocabulary picker flows now mount the generic `ItemSelectorModal` from `frontend-js-item-selector-web` and let FDS drive the fetch via `apiURL`, with two new filterable fields registered on `VocabularyEntityModel` — `visibilityType` and `siteId` — so internal vocabularies and out-of-scope rows are excluded server-side. The Asset Categories Admin bulk-delete flow narrows to the current site via `siteId eq <currentSiteId>` to match the legacy "current site owner only" constraint; the site navigation pickers stay broader (site + ancestors + connected depots) and decorate the title with the owner's scope name (site, asset library, or Global) so users can disambiguate vocabularies that share a name. Each picker shows Title, User, and Modified Date columns, with FDS's built-in `dateTime` renderer and `sortable: true` on the date column. Two narrow additions to `ItemSelectorModal` — `confirmButtonLabel` and `size` — keep the delete flow's `"Delete"` button label and let the modal open at `lg` instead of full-screen.