### PR TITLE
LPD-91066 Review stroke width of hover/selected states & corner-radius when cards have a width less than 190px

### DIFF
--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-drop-down/src/DropDownWithItems.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-drop-down/src/DropDownWithItems.tsx
@@ -199,6 +199,7 @@ export function ClayDropDownWithItems({
 	menuElementAttrs,
 	menuHeight,
 	menuWidth,
+	messages: _messages,
 	offsetFn,
 	onActiveChange,
 	onSearchValueChange = () => {},

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/_TabItem.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/_TabItem.scss
@@ -19,11 +19,10 @@ html#{$cadmin-selector} .cadmin .page-editor__fragments-widgets__tab {
 			}
 		}
 
-		.card {
-			aspect-ratio: 1;
-		}
+		.aspect-ratio {
+			background-color: $cadmin-light;
+			padding-bottom: 70%;
 
-		.card-item-first {
 			.card-type-asset-icon {
 				width: 32px;
 			}
@@ -31,14 +30,9 @@ html#{$cadmin-selector} .cadmin .page-editor__fragments-widgets__tab {
 			.lexicon-icon {
 				color: $cadmin-secondary;
 			}
-
-			background-color: $cadmin-light;
-			height: 70%;
 		}
 
 		.card-body {
-			height: 30%;
-
 			.card-title {
 				font-size: 12px;
 				width: 100%;
@@ -53,7 +47,19 @@ html#{$cadmin-selector} .cadmin .page-editor__fragments-widgets__tab {
 		&.disabled {
 			cursor: default;
 
-			.image-card .card-item-first {
+			.card-type-asset {
+				&:hover {
+					transform: none;
+
+					.card {
+						border-color: $cadmin-card-border-color;
+						outline-color: transparent;
+						box-shadow: none;
+					}
+				}
+			}
+
+			.image-card .aspect-ratio {
 				opacity: 0.5;
 			}
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/_TabItem.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/_TabItem.scss
@@ -53,8 +53,8 @@ html#{$cadmin-selector} .cadmin .page-editor__fragments-widgets__tab {
 
 					.card {
 						border-color: $cadmin-card-border-color;
-						outline-color: transparent;
 						box-shadow: none;
+						outline-color: transparent;
 					}
 				}
 			}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/_TabItem.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/_TabItem.scss
@@ -3,7 +3,6 @@
 html#{$cadmin-selector} .cadmin .page-editor__fragments-widgets__tab {
 	&-card-item {
 		cursor: grab;
-		transition: transform ease 0.3s;
 
 		&:focus-visible,
 		&--active {
@@ -15,39 +14,13 @@ html#{$cadmin-selector} .cadmin .page-editor__fragments-widgets__tab {
 		&:hover:not(.disabled),
 		&:focus-visible,
 		&--active {
-			box-shadow: 0 4px 8px fade_out($cadmin-gray-900, 0.9);
-			outline: none;
-			transform: translateY(-4px);
-
-			.card {
-				border-radius: 4px;
-				box-shadow: none;
-
-				&::after {
-					border-radius: 4px;
-					box-shadow: inset 0 0 0 2px $cadmin-primary-l1;
-					content: '';
-					height: 100%;
-					left: 0;
-					pointer-events: none;
-					position: absolute;
-					top: 0;
-					width: 100%;
-				}
-
-				.page-editor__fragments-widgets__tab__highlight-button {
-					opacity: 1;
-				}
+			.card .page-editor__fragments-widgets__tab__highlight-button {
+				opacity: 1;
 			}
-		}
-
-		.file-card .card {
-			background-color: $cadmin-light;
 		}
 
 		.card {
 			aspect-ratio: 1;
-			box-shadow: 0 0 0 1px $cadmin-gray-300;
 		}
 
 		.card-item-first {
@@ -59,11 +32,11 @@ html#{$cadmin-selector} .cadmin .page-editor__fragments-widgets__tab {
 				color: $cadmin-secondary;
 			}
 
+			background-color: $cadmin-light;
 			height: 70%;
 		}
 
 		.card-body {
-			background-color: $cadmin-white;
 			height: 30%;
 
 			.card-title {
@@ -85,8 +58,6 @@ html#{$cadmin-selector} .cadmin .page-editor__fragments-widgets__tab {
 			}
 
 			.card {
-				box-shadow: 0 0 0 1px $cadmin-gray-300;
-
 				.lexicon-icon {
 					color: $cadmin-secondary-l1;
 				}


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPD-91066

## What is being fixed

Page editor's fragments visualized as cards were customized by the module itself, leading to some style inconsistencies.

## How is it being fixed

Removing unnecessary module styles related to `.card`, that affects Clay ones.