### PR TITLE
LPD-91067 Selected state of Cards not applying the primary stroke correctly

### DIFF
--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_cards.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_cards.scss
@@ -439,6 +439,8 @@ $form-check-card: map-deep-merge(
 		),
 
 		disabled: (
+			transform: none,
+
 			card: (
 				box-shadow: none,
 				border-color: $card-border-color,

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas/variables/_cards.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas/variables/_cards.scss
@@ -126,6 +126,8 @@ $form-check-card: map-deep-merge(
 		),
 
 		disabled: (
+			transform: none,
+
 			card: (
 				box-shadow: none,
 				border-color: $card-border-color,

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/variables/_cards.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/variables/_cards.scss
@@ -418,6 +418,8 @@ $cadmin-form-check-card: map-deep-merge(
 		),
 
 		disabled: (
+			transform: none,
+
 			card: (
 				box-shadow: none,
 				border-color: $cadmin-card-border-color,

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/mixins/_cards.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/mixins/_cards.scss
@@ -2033,6 +2033,8 @@
 			@if ($_disabled) {
 				&.disabled,
 				&:has(.custom-control-input:disabled) {
+					@include clay-css($_disabled);
+
 					$_card: map-get($_disabled, card);
 
 					@if ($_card) {

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/mixins/_cards.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/mixins/_cards.scss
@@ -2002,7 +2002,8 @@
 			$_checked: map-get($map, checked);
 
 			@if ($_checked) {
-				&.checked {
+				&.checked,
+				&:has(.custom-control-input:checked) {
 					$_card: map-get($_checked, card);
 
 					@if ($_card) {
@@ -2030,7 +2031,8 @@
 			$_disabled: map-get($map, disabled);
 
 			@if ($_disabled) {
-				&.disabled {
+				&.disabled,
+				&:has(.custom-control-input:disabled) {
 					$_card: map-get($_disabled, card);
 
 					@if ($_card) {

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/variables/_cards.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/variables/_cards.scss
@@ -407,6 +407,8 @@ $form-check-card: map-deep-merge(
 		),
 
 		disabled: (
+			transform: none,
+
 			card: (
 				box-shadow: none,
 				border-color: $card-border-color,


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPD-91067

## What is being fixed

The selected (and disabled) state styling on revamped Cards wasn't applying the `$primary` stroke in cases where the card is rendered as plain HTML markup with a `.custom-control-input` checkbox/radio inside — instead of having the `.checked` class toggled by JS or set by the Clay component.

## How is it being fixed

In `modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/mixins/_cards.scss`, the checked/disabled selectors are extended with a `:has()` fallback: `&.checked, &:has(.custom-control-input:checked)` (and the same pattern for `:disabled`). This lets the styles kick in from the input's native state, so HTML-only usages get the correct selected/disabled appearance.