### PR TITLE
LPD-91601 Support min and max in ClayDatePicker

### DIFF
--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-date-picker/docs/date-picker.mdx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-date-picker/docs/date-picker.mdx
@@ -143,6 +143,47 @@ export default function App() {
 }
 ```
 
+## Min and Max
+
+Use [`min`](#api-min) and [`max`](#api-max) to constrain the range of selectable dates. Both props are optional and may be supplied independently. They are strings formatted using the same [`dateFormat`](#api-dateFormat) (followed by a time portion when [`time`](#api-time) is `true`):
+
+- When `min` is provided, any date strictly before `min` is disabled.
+- When `max` is provided, any date strictly after `max` is disabled.
+- For date-time pickers, the hours and minutes are also constrained when the selected day equals `min` or `max`.
+- In range mode, both endpoints respect the bounds.
+- If `min >= max`, a warning is logged to the console and both bounds are ignored.
+
+Month and year navigation remain available across the full visible range; only the selection is constrained.
+
+```jsx preview
+import {Provider} from '@clayui/core';
+import DatePicker from '@clayui/date-picker';
+import React, {useState} from 'react';
+
+import '@clayui/css/lib/css/atlas.css';
+
+export default function App() {
+	const [value, setValue] = useState(null);
+
+	return (
+		<Provider spritemap="/public/icons.svg">
+			<div className="p-4">
+				<label htmlFor="datePickerMinMax">Min and Max</label>
+				<DatePicker
+					id="datePickerMinMax"
+					max="2030-12-31"
+					min="2025-01-01"
+					onChange={setValue}
+					placeholder="YYYY-MM-DD"
+					value={value}
+					years={{end: 2030, start: 2025}}
+				/>
+			</div>
+		</Provider>
+	);
+}
+```
+
 ## Internationalization
 
 To set internationalization of the component, you need to configure the props according to the language. Date Picker offers low level APIs to configure [`firstDayOfWeek`](#api-firstDayOfWeek), [`weekdaysShort`](#api-weekdaysShort), [`months`](#api-months), [`timezone`](#api-timezone) and [`dateFormat`](#api-dateFormat), you can follow the example below to set up a Date Picker for Russian.

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-date-picker/src/DayNumber.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-date-picker/src/DayNumber.tsx
@@ -63,7 +63,8 @@ function ClayDatePickerDayNumber({
 				// Out-of-range days use `aria-disabled` rather than the HTML
 				// `disabled` attribute so they remain focusable, which keeps
 				// the grid's arrow-key navigation continuous across them. The
-				// click and Space handlers no-op when `outOfRange` is true.
+				// click still propagates so the parent can short-circuit
+				// uniformly and surface the rejection to assistive tech.
 
 				aria-disabled={outOfRange ? true : undefined}
 				aria-label={setDate(date, {
@@ -85,13 +86,7 @@ function ClayDatePickerDayNumber({
 				)}
 				data-index={index}
 				disabled={disabled}
-				onClick={() => {
-					if (outOfRange) {
-						return;
-					}
-
-					onClick(date);
-				}}
+				onClick={() => onClick(date)}
 				onKeyDown={(event) => {
 
 					// When tabbing and selecting a DayNumber using
@@ -103,7 +98,7 @@ function ClayDatePickerDayNumber({
 					}
 				}}
 				onKeyUp={(event) => {
-					if (event.key === Keys.Spacebar && !outOfRange) {
+					if (event.key === Keys.Spacebar) {
 						onClick(date);
 					}
 				}}

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-date-picker/src/DayNumber.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-date-picker/src/DayNumber.tsx
@@ -16,6 +16,7 @@ type Props = {
 	index: number;
 	isFocused: boolean;
 	onClick: (date: Date) => void;
+	outOfRange?: boolean;
 	range?: boolean;
 };
 
@@ -26,6 +27,7 @@ function ClayDatePickerDayNumber({
 	index,
 	isFocused,
 	onClick,
+	outOfRange,
 	range,
 }: Props) {
 	const {date, nextMonth, previousMonth} = day;
@@ -57,6 +59,13 @@ function ClayDatePickerDayNumber({
 			role="gridcell"
 		>
 			<button
+
+				// Out-of-range days use `aria-disabled` rather than the HTML
+				// `disabled` attribute so they remain focusable, which keeps
+				// the grid's arrow-key navigation continuous across them. The
+				// click and Space handlers no-op when `outOfRange` is true.
+
+				aria-disabled={outOfRange ? true : undefined}
 				aria-label={setDate(date, {
 					hours: 12,
 					milliseconds: 0,
@@ -69,14 +78,20 @@ function ClayDatePickerDayNumber({
 						'active':
 							hasStartDateSelected ||
 							(range && hasEndDateSelected),
-						disabled,
+						'disabled': disabled || outOfRange,
 						'next-month-date': nextMonth,
 						'previous-month-date': previousMonth,
 					}
 				)}
 				data-index={index}
 				disabled={disabled}
-				onClick={() => onClick(date)}
+				onClick={() => {
+					if (outOfRange) {
+						return;
+					}
+
+					onClick(date);
+				}}
 				onKeyDown={(event) => {
 
 					// When tabbing and selecting a DayNumber using
@@ -88,7 +103,7 @@ function ClayDatePickerDayNumber({
 					}
 				}}
 				onKeyUp={(event) => {
-					if (event.key === Keys.Spacebar) {
+					if (event.key === Keys.Spacebar && !outOfRange) {
 						onClick(date);
 					}
 				}}

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-date-picker/src/Helpers.ts
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-date-picker/src/Helpers.ts
@@ -20,11 +20,51 @@ export type WeekDays = Array<IDay>;
 
 export type Month = Array<WeekDays>;
 
+export function addMonths(date: number | Date, months: number) {
+	date = clone(date);
+
+	date.setMonth(date.getMonth() + months);
+
+	return date;
+}
+
+export function clamp(date: Date, min?: Date, max?: Date) {
+	if (min && isBefore(date, min)) {
+		return min;
+	}
+
+	if (max && isAfter(date, max)) {
+		return max;
+	}
+
+	return date;
+}
+
 /**
  * Clone a date object.
  */
 export function clone(date: number | Date) {
 	return new Date(date instanceof Date ? date.getTime() : date);
+}
+
+export function isAfter(a: Date, b: Date) {
+	return a.getTime() > b.getTime();
+}
+
+export function isBefore(a: Date, b: Date) {
+	return a.getTime() < b.getTime();
+}
+
+export function isSameDay(a: Date, b: Date) {
+	return (
+		a.getFullYear() === b.getFullYear() &&
+		a.getMonth() === b.getMonth() &&
+		a.getDate() === b.getDate()
+	);
+}
+
+export function isValid(date: Date) {
+	return date instanceof Date && !isNaN(date.getTime());
 }
 
 export function range({end, start}: {end: number; start: number}) {
@@ -34,14 +74,6 @@ export function range({end, start}: {end: number; start: number}) {
 		},
 		(_v, k) => k + start
 	);
-}
-
-export function addMonths(date: number | Date, months: number) {
-	date = clone(date);
-
-	date.setMonth(date.getMonth() + months);
-
-	return date;
 }
 
 export function setDate(
@@ -66,10 +98,6 @@ export function setDate(
 
 		return acc;
 	}, date);
-}
-
-export function isValid(date: Date) {
-	return date instanceof Date && !isNaN(date.getTime());
 }
 
 export function setMonth(

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-date-picker/src/Helpers.ts
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-date-picker/src/Helpers.ts
@@ -30,14 +30,14 @@ export function addMonths(date: number | Date, months: number) {
 
 export function clamp(date: Date, min?: Date, max?: Date) {
 	if (min && isBefore(date, min)) {
-		return min;
+		return clone(min);
 	}
 
 	if (max && isAfter(date, max)) {
-		return max;
+		return clone(max);
 	}
 
-	return date;
+	return clone(date);
 }
 
 /**

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-date-picker/src/TimePicker.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-date-picker/src/TimePicker.tsx
@@ -6,7 +6,27 @@
 import ClayTimePicker, {Input} from '@clayui/time-picker';
 import React from 'react';
 
+type ConfigMaxMin = {
+	max: number;
+	min: number;
+};
+
+type ConfigAmpm = {
+	am: string;
+	pm: string;
+};
+
+type TimePickerConfig = {
+	ampm: ConfigAmpm;
+	hours: ConfigMaxMin;
+	minutes: ConfigMaxMin;
+};
+
 type Props = {
+	config?: {
+		use12Hours: TimePickerConfig;
+		use24Hours: TimePickerConfig;
+	};
 	currentTime: string;
 	disabled?: boolean;
 	onTimeChange: (
@@ -27,6 +47,7 @@ type Props = {
 const DEFAULT_VALUE = '--';
 
 function ClayDatePickerTimePicker({
+	config,
 	currentTime,
 	disabled,
 	onTimeChange,
@@ -70,6 +91,7 @@ function ClayDatePickerTimePicker({
 	return (
 		<div className="time-picker">
 			<ClayTimePicker
+				config={config}
 				disabled={disabled}
 				icon
 				onInputChange={handleOnChange}

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-date-picker/src/TimePicker.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-date-picker/src/TimePicker.tsx
@@ -11,13 +11,13 @@ type ConfigMaxMin = {
 	min: number;
 };
 
-type ConfigAmpm = {
+type ConfigAmPm = {
 	am: string;
 	pm: string;
 };
 
 type TimePickerConfig = {
-	ampm: ConfigAmpm;
+	ampm: ConfigAmPm;
 	hours: ConfigMaxMin;
 	minutes: ConfigMaxMin;
 };

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-date-picker/src/__tests__/IncrementalInteractions.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-date-picker/src/__tests__/IncrementalInteractions.tsx
@@ -800,4 +800,189 @@ describe('IncrementalInteractions', () => {
 
 		jest.useRealTimers();
 	});
+
+	describe('min/max', () => {
+		it('disables days before min in the calendar grid', () => {
+			const {getByLabelText} = render(
+				<DatePickerWithState
+					ariaLabels={ariaLabels}
+					defaultExpanded
+					min="2019-04-10"
+					spritemap={spritemap}
+				/>
+			);
+
+			const beforeMin = getByLabelText(
+				new Date('2019 04 09').toDateString()
+			);
+			const atMin = getByLabelText(new Date('2019 04 10').toDateString());
+			const afterMin = getByLabelText(
+				new Date('2019 04 11').toDateString()
+			);
+
+			expect(beforeMin).toBeDisabled();
+			expect(atMin).not.toBeDisabled();
+			expect(afterMin).not.toBeDisabled();
+		});
+
+		it('disables days after max in the calendar grid', () => {
+			const {getByLabelText} = render(
+				<DatePickerWithState
+					ariaLabels={ariaLabels}
+					defaultExpanded
+					max="2019-04-20"
+					spritemap={spritemap}
+				/>
+			);
+
+			const beforeMax = getByLabelText(
+				new Date('2019 04 19').toDateString()
+			);
+			const atMax = getByLabelText(new Date('2019 04 20').toDateString());
+			const afterMax = getByLabelText(
+				new Date('2019 04 21').toDateString()
+			);
+
+			expect(beforeMax).not.toBeDisabled();
+			expect(atMax).not.toBeDisabled();
+			expect(afterMax).toBeDisabled();
+		});
+
+		it('does not commit a click on a disabled day', () => {
+			const onChange = jest.fn();
+
+			const {getByLabelText} = render(
+				<ClayDatePicker
+					ariaLabels={ariaLabels}
+					defaultExpanded
+					defaultMonth={new Date(2019, 3, 18)}
+					min="2019-04-10"
+					onChange={onChange}
+					spritemap={spritemap}
+					years={{end: 2019, start: 2019}}
+				/>
+			);
+
+			fireEvent.click(
+				getByLabelText(new Date('2019 04 05').toDateString())
+			);
+
+			expect(onChange).not.toHaveBeenCalled();
+		});
+
+		it('does not commit out-of-range values typed into the input', () => {
+			const onChange = jest.fn();
+
+			const {getByLabelText} = render(
+				<ClayDatePicker
+					ariaLabels={ariaLabels}
+					defaultExpanded
+					defaultMonth={new Date(2019, 3, 18)}
+					min="2019-04-10"
+					onChange={onChange}
+					spritemap={spritemap}
+					years={{end: 2019, start: 2019}}
+				/>
+			);
+
+			const input: any = getByLabelText(ariaLabels.input);
+
+			fireEvent.change(input, {target: {value: '2019-04-05'}});
+
+			const dayNumber = getByLabelText(
+				new Date('2019 04 05').toDateString()
+			);
+
+			expect(dayNumber.classList).not.toContain('active');
+		});
+
+		it('warns and ignores both bounds when min >= max', () => {
+			const warnSpy = jest
+				.spyOn(console, 'warn')
+				.mockImplementation(() => {});
+
+			const {getByLabelText} = render(
+				<DatePickerWithState
+					ariaLabels={ariaLabels}
+					defaultExpanded
+					max="2019-04-10"
+					min="2019-04-20"
+					spritemap={spritemap}
+				/>
+			);
+
+			expect(warnSpy).toHaveBeenCalled();
+
+			const beforeMin = getByLabelText(
+				new Date('2019 04 05').toDateString()
+			);
+			const afterMax = getByLabelText(
+				new Date('2019 04 25').toDateString()
+			);
+
+			expect(beforeMin).not.toBeDisabled();
+			expect(afterMax).not.toBeDisabled();
+
+			warnSpy.mockRestore();
+		});
+
+		it('applies min/max to both endpoints in range mode', () => {
+			const {getByLabelText} = render(
+				<DatePickerWithState
+					ariaLabels={ariaLabels}
+					defaultExpanded
+					max="2019-04-20"
+					min="2019-04-10"
+					range
+					spritemap={spritemap}
+				/>
+			);
+
+			expect(
+				getByLabelText(new Date('2019 04 09').toDateString())
+			).toBeDisabled();
+			expect(
+				getByLabelText(new Date('2019 04 21').toDateString())
+			).toBeDisabled();
+		});
+
+		it('does not commit a time edit that falls outside min on the boundary day', () => {
+			const onChange = jest.fn();
+
+			const {getByTestId} = render(
+				<ClayDatePicker
+					ariaLabels={ariaLabels}
+					defaultExpanded
+					defaultMonth={new Date(2019, 3, 10, 12, 0)}
+					min="2019-04-10 10:00"
+					onChange={onChange}
+					spritemap={spritemap}
+					time
+					value="2019-04-10 12:00"
+					years={{end: 2019, start: 2019}}
+				/>
+			);
+
+			fireEvent.click(getByTestId('hours'));
+			fireEvent.keyDown(getByTestId('hours'), {key: 'ArrowDown'});
+
+			// Hours start at 12, arrow down loops via config min=10 (down from
+			// 12 → 11 → 10). Further presses are clamped/wrapped by config.
+
+			fireEvent.keyDown(getByTestId('hours'), {key: 'ArrowDown'});
+			fireEvent.keyDown(getByTestId('hours'), {key: 'ArrowDown'});
+
+			// `onChange` should not have been called with a value below 10:00.
+
+			const calls = onChange.mock.calls
+				.map((call: Array<string>) => call[0])
+				.filter(Boolean);
+
+			calls.forEach((value: string) => {
+				const [, hh] = value.split(' ');
+
+				expect(Number(hh!.split(':')[0])).toBeGreaterThanOrEqual(10);
+			});
+		});
+	});
 });

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-date-picker/src/__tests__/IncrementalInteractions.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-date-picker/src/__tests__/IncrementalInteractions.tsx
@@ -1018,11 +1018,11 @@ describe('IncrementalInteractions', () => {
 
 			const calls = onChange.mock.calls
 				.map((call: Array<string>) => call[0])
-				.filter(Boolean);
+				.filter((value): value is string => Boolean(value));
 
 			expect(calls.length).toBeGreaterThan(0);
 
-			calls.forEach((value: string) => {
+			calls.forEach((value) => {
 				const [, hh] = value.split(' ');
 
 				expect(Number(hh!.split(':')[0])).toBeGreaterThanOrEqual(10);

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-date-picker/src/__tests__/IncrementalInteractions.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-date-picker/src/__tests__/IncrementalInteractions.tsx
@@ -74,7 +74,7 @@ describe('IncrementalInteractions', () => {
 		fireEvent.change(input, {target: {value: '2019-04-10'}});
 
 		expect(input.value).toBe('2019-04-10');
-		expect(dayNumber.classList).toContain('active');
+		expect(dayNumber).toHaveClass('active');
 		expect(monthSelect.value).toBe('3');
 		expect(yearSelect.value).toBe('2019');
 		expect(document.body).toMatchSnapshot();
@@ -93,7 +93,7 @@ describe('IncrementalInteractions', () => {
 
 		fireEvent.click(getByTestId('date-button'), {});
 
-		expect(dropdown.classList).toContain('show');
+		expect(dropdown).toHaveClass('show');
 		expect(document.body).toMatchSnapshot();
 	});
 
@@ -111,7 +111,7 @@ describe('IncrementalInteractions', () => {
 
 		fireEvent.click(getByTestId('date-button'), {});
 
-		expect(dropdown.classList).not.toContain('show');
+		expect(dropdown).not.toHaveClass('show');
 		expect(document.body).toMatchSnapshot();
 	});
 
@@ -133,7 +133,7 @@ describe('IncrementalInteractions', () => {
 
 		userEvent.click(getByTestId('outsideElement'));
 
-		expect(dropdown.classList).not.toContain('show');
+		expect(dropdown).not.toHaveClass('show');
 		expect(document.body).toMatchSnapshot();
 	});
 
@@ -231,7 +231,7 @@ describe('IncrementalInteractions', () => {
 		expect(input.value).toBe(formatDate(currentDate, 'yyyy-MM-dd'));
 
 		const dayNumber = getByLabelText(currentDate.toDateString());
-		expect(dayNumber.classList).toContain('active');
+		expect(dayNumber).toHaveClass('active');
 	});
 
 	it('clicking on the next arrow button the content must be updated with the corresponding month', () => {
@@ -340,7 +340,7 @@ describe('IncrementalInteractions', () => {
 		expect(input.value).toBe('2019-04-28');
 		expect(yearSelect.value).toBe('2019');
 		expect(monthSelect.value).toBe('3');
-		expect(dayNumber.classList).toContain('active');
+		expect(dayNumber).toHaveClass('active');
 	});
 
 	it('clicking on the days number previous-month or next-month should change the date and the input value', () => {
@@ -524,8 +524,8 @@ describe('IncrementalInteractions', () => {
 
 			fireEvent.click(dayNumber);
 
-			expect(dayNumber.classList).toContain('active');
-			expect(endDate.classList).toContain('active');
+			expect(dayNumber).toHaveClass('active');
+			expect(endDate).toHaveClass('active');
 		});
 
 		it('clicking on the day later the start date sets the end date for the selected date', () => {
@@ -548,8 +548,8 @@ describe('IncrementalInteractions', () => {
 
 			fireEvent.click(dayNumber);
 
-			expect(startDate.classList).toContain('active');
-			expect(dayNumber.classList).toContain('active');
+			expect(startDate).toHaveClass('active');
+			expect(dayNumber).toHaveClass('active');
 		});
 
 		it.each(['2019 04 23', '2019 04 10', '2019 04 30'])(
@@ -574,16 +574,16 @@ describe('IncrementalInteractions', () => {
 
 				fireEvent.click(endDate);
 
-				expect(startDate.classList).toContain('active');
-				expect(endDate.classList).toContain('active');
+				expect(startDate).toHaveClass('active');
+				expect(endDate).toHaveClass('active');
 
 				const dayNumber = getByLabelText(new Date(date).toDateString());
 
 				fireEvent.click(dayNumber);
 
-				expect(dayNumber.classList).toContain('active');
-				expect(startDate.classList).not.toContain('active');
-				expect(endDate.classList).not.toContain('active');
+				expect(dayNumber).toHaveClass('active');
+				expect(startDate).not.toHaveClass('active');
+				expect(endDate).not.toHaveClass('active');
 			}
 		);
 	});
@@ -691,7 +691,7 @@ describe('IncrementalInteractions', () => {
 		expect(input.value).toBe(formatDate(currentDate, 'yyyy-MM-dd'));
 
 		const dayNumber = getByLabelText(currentDate.toDateString());
-		expect(dayNumber.classList).toContain('active');
+		expect(dayNumber).toHaveClass('active');
 	});
 
 	it('updates date state when resetting input value using the controlled mode', () => {
@@ -728,8 +728,8 @@ describe('IncrementalInteractions', () => {
 		const dayNumber = getByLabelText(new Date('2019 04 10').toDateString());
 		const endDate = getByLabelText(new Date('2019 04 15').toDateString());
 
-		expect(dayNumber.classList).toContain('active');
-		expect(endDate.classList).toContain('active');
+		expect(dayNumber).toHaveClass('active');
+		expect(endDate).toHaveClass('active');
 
 		fireEvent.click(resetButton);
 
@@ -740,9 +740,9 @@ describe('IncrementalInteractions', () => {
 		);
 
 		expect(input.value).toBe('');
-		expect(defaultDate.classList).toContain('active');
-		expect(dayNumber.classList).not.toContain('active');
-		expect(endDate.classList).not.toContain('active');
+		expect(defaultDate).toHaveClass('active');
+		expect(dayNumber).not.toHaveClass('active');
+		expect(endDate).not.toHaveClass('active');
 	});
 
 	it('clicking the dot button should set the current time when the button is clicked', () => {

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-date-picker/src/__tests__/IncrementalInteractions.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-date-picker/src/__tests__/IncrementalInteractions.tsx
@@ -1004,5 +1004,32 @@ describe('IncrementalInteractions', () => {
 				expect(Number(hh!.split(':')[0])).toBeGreaterThanOrEqual(10);
 			});
 		});
+
+		it('announces out-of-range rejections via a polite live region', () => {
+			const {container, getByLabelText} = render(
+				<ClayDatePicker
+					ariaLabels={{
+						...ariaLabels,
+						outOfRange: 'Out of range',
+					}}
+					defaultExpanded
+					defaultMonth={new Date(2019, 3, 18)}
+					min="2019-04-10"
+					spritemap={spritemap}
+					years={{end: 2019, start: 2019}}
+				/>
+			);
+
+			const liveRegion = container.querySelector('[aria-live="polite"]');
+
+			expect(liveRegion).not.toBeNull();
+			expect(liveRegion).toHaveTextContent('');
+
+			const input: any = getByLabelText(ariaLabels.input);
+
+			fireEvent.change(input, {target: {value: '2019-04-05'}});
+
+			expect(liveRegion).toHaveTextContent('Out of range');
+		});
 	});
 });

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-date-picker/src/__tests__/IncrementalInteractions.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-date-picker/src/__tests__/IncrementalInteractions.tsx
@@ -820,9 +820,9 @@ describe('IncrementalInteractions', () => {
 				new Date('2019 04 11').toDateString()
 			);
 
-			expect(beforeMin).toBeDisabled();
-			expect(atMin).not.toBeDisabled();
-			expect(afterMin).not.toBeDisabled();
+			expect(beforeMin).toHaveAttribute('aria-disabled', 'true');
+			expect(atMin).not.toHaveAttribute('aria-disabled');
+			expect(afterMin).not.toHaveAttribute('aria-disabled');
 		});
 
 		it('disables days after max in the calendar grid', () => {
@@ -843,9 +843,29 @@ describe('IncrementalInteractions', () => {
 				new Date('2019 04 21').toDateString()
 			);
 
-			expect(beforeMax).not.toBeDisabled();
-			expect(atMax).not.toBeDisabled();
-			expect(afterMax).toBeDisabled();
+			expect(beforeMax).not.toHaveAttribute('aria-disabled');
+			expect(atMax).not.toHaveAttribute('aria-disabled');
+			expect(afterMax).toHaveAttribute('aria-disabled', 'true');
+		});
+
+		it('keeps out-of-range days focusable so the grid can navigate over them', () => {
+			const {getByLabelText} = render(
+				<DatePickerWithState
+					ariaLabels={ariaLabels}
+					defaultExpanded
+					min="2019-04-10"
+					spritemap={spritemap}
+				/>
+			);
+
+			const beforeMin = getByLabelText(
+				new Date('2019 04 09').toDateString()
+			);
+
+			// Native HTML disabled would block focus entirely; aria-disabled
+			// keeps the button focusable for arrow-key grid navigation.
+
+			expect(beforeMin).not.toBeDisabled();
 		});
 
 		it('does not commit a click on a disabled day', () => {
@@ -920,8 +940,8 @@ describe('IncrementalInteractions', () => {
 				new Date('2019 04 25').toDateString()
 			);
 
-			expect(beforeMin).not.toBeDisabled();
-			expect(afterMax).not.toBeDisabled();
+			expect(beforeMin).not.toHaveAttribute('aria-disabled');
+			expect(afterMax).not.toHaveAttribute('aria-disabled');
 
 			warnSpy.mockRestore();
 		});
@@ -940,10 +960,10 @@ describe('IncrementalInteractions', () => {
 
 			expect(
 				getByLabelText(new Date('2019 04 09').toDateString())
-			).toBeDisabled();
+			).toHaveAttribute('aria-disabled', 'true');
 			expect(
 				getByLabelText(new Date('2019 04 21').toDateString())
-			).toBeDisabled();
+			).toHaveAttribute('aria-disabled', 'true');
 		});
 
 		it('does not commit a time edit that falls outside min on the boundary day', () => {

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-date-picker/src/__tests__/IncrementalInteractions.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-date-picker/src/__tests__/IncrementalInteractions.tsx
@@ -879,7 +879,7 @@ describe('IncrementalInteractions', () => {
 				/>
 			);
 
-			const input: any = getByLabelText(ariaLabels.input);
+			const input = getByLabelText(ariaLabels.input) as HTMLInputElement;
 			const dayNumber = getByLabelText(
 				new Date('2019 04 15').toDateString()
 			);
@@ -927,7 +927,7 @@ describe('IncrementalInteractions', () => {
 				/>
 			);
 
-			const input: any = getByLabelText(ariaLabels.input);
+			const input = getByLabelText(ariaLabels.input) as HTMLInputElement;
 
 			await userEvent.type(input, '2019-04-05');
 

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-date-picker/src/__tests__/IncrementalInteractions.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-date-picker/src/__tests__/IncrementalInteractions.tsx
@@ -865,10 +865,32 @@ describe('IncrementalInteractions', () => {
 			// Native HTML disabled would block focus entirely; aria-disabled
 			// keeps the button focusable for arrow-key grid navigation.
 
-			expect(beforeMin).not.toBeDisabled();
+			expect(beforeMin).toBeEnabled();
 		});
 
-		it('does not commit a click on a disabled day', () => {
+		it('selects a valid day inside the range', async () => {
+			const {getByLabelText} = render(
+				<DatePickerWithState
+					ariaLabels={ariaLabels}
+					defaultExpanded
+					max="2019-04-20"
+					min="2019-04-10"
+					spritemap={spritemap}
+				/>
+			);
+
+			const input: any = getByLabelText(ariaLabels.input);
+			const dayNumber = getByLabelText(
+				new Date('2019 04 15').toDateString()
+			);
+
+			await userEvent.click(dayNumber);
+
+			expect(input.value).toBe('2019-04-15');
+			expect(dayNumber).toHaveClass('active');
+		});
+
+		it('does not commit a click on a disabled day', async () => {
 			const onChange = jest.fn();
 
 			const {getByLabelText} = render(
@@ -883,14 +905,14 @@ describe('IncrementalInteractions', () => {
 				/>
 			);
 
-			fireEvent.click(
+			await userEvent.click(
 				getByLabelText(new Date('2019 04 05').toDateString())
 			);
 
 			expect(onChange).not.toHaveBeenCalled();
 		});
 
-		it('does not commit out-of-range values typed into the input', () => {
+		it('does not commit out-of-range values typed into the input', async () => {
 			const onChange = jest.fn();
 
 			const {getByLabelText} = render(
@@ -907,13 +929,13 @@ describe('IncrementalInteractions', () => {
 
 			const input: any = getByLabelText(ariaLabels.input);
 
-			fireEvent.change(input, {target: {value: '2019-04-05'}});
+			await userEvent.type(input, '2019-04-05');
 
 			const dayNumber = getByLabelText(
 				new Date('2019 04 05').toDateString()
 			);
 
-			expect(dayNumber.classList).not.toContain('active');
+			expect(dayNumber).not.toHaveClass('active');
 		});
 
 		it('warns and ignores both bounds when min >= max', () => {
@@ -966,7 +988,7 @@ describe('IncrementalInteractions', () => {
 			).toHaveAttribute('aria-disabled', 'true');
 		});
 
-		it('does not commit a time edit that falls outside min on the boundary day', () => {
+		it('does not commit a time edit that falls outside min on the boundary day', async () => {
 			const onChange = jest.fn();
 
 			const {getByTestId} = render(
@@ -983,20 +1005,22 @@ describe('IncrementalInteractions', () => {
 				/>
 			);
 
-			fireEvent.click(getByTestId('hours'));
-			fireEvent.keyDown(getByTestId('hours'), {key: 'ArrowDown'});
+			const hoursInput = getByTestId('hours');
+
+			await userEvent.click(hoursInput);
 
 			// Hours start at 12, arrow down loops via config min=10 (down from
 			// 12 → 11 → 10). Further presses are clamped/wrapped by config.
 
-			fireEvent.keyDown(getByTestId('hours'), {key: 'ArrowDown'});
-			fireEvent.keyDown(getByTestId('hours'), {key: 'ArrowDown'});
+			await userEvent.keyboard('{ArrowDown}{ArrowDown}{ArrowDown}');
 
 			// `onChange` should not have been called with a value below 10:00.
 
 			const calls = onChange.mock.calls
 				.map((call: Array<string>) => call[0])
 				.filter(Boolean);
+
+			expect(calls.length).toBeGreaterThan(0);
 
 			calls.forEach((value: string) => {
 				const [, hh] = value.split(' ');
@@ -1005,29 +1029,27 @@ describe('IncrementalInteractions', () => {
 			});
 		});
 
-		it('announces out-of-range rejections via a polite live region', () => {
+		it('announces out-of-range rejections via a polite live region', async () => {
 			const {container, getByLabelText} = render(
-				<ClayDatePicker
+				<DatePickerWithState
 					ariaLabels={{
 						...ariaLabels,
 						outOfRange: 'Out of range',
 					}}
 					defaultExpanded
-					defaultMonth={new Date(2019, 3, 18)}
 					min="2019-04-10"
 					spritemap={spritemap}
-					years={{end: 2019, start: 2019}}
 				/>
 			);
 
 			const liveRegion = container.querySelector('[aria-live="polite"]');
 
-			expect(liveRegion).not.toBeNull();
+			expect(liveRegion).toBeInTheDocument();
 			expect(liveRegion).toHaveTextContent('');
 
-			const input: any = getByLabelText(ariaLabels.input);
-
-			fireEvent.change(input, {target: {value: '2019-04-05'}});
+			await userEvent.click(
+				getByLabelText(new Date('2019 04 05').toDateString())
+			);
 
 			expect(liveRegion).toHaveTextContent('Out of range');
 		});

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-date-picker/src/__tests__/__snapshots__/BasicRendering.tsx.snap
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-date-picker/src/__tests__/__snapshots__/BasicRendering.tsx.snap
@@ -7,6 +7,11 @@ exports[`BasicRendering renders by default 1`] = `
       class="date-picker"
     >
       <div
+        aria-atomic="true"
+        aria-live="polite"
+        class="sr-only"
+      />
+      <div
         class="input-group"
       >
         <div
@@ -832,15 +837,19 @@ exports[`BasicRendering renders by default 1`] = `
 
 exports[`BasicRendering renders date picker with dropdown open 1`] = `
 <body>
-  <div
-    aria-hidden="true"
-    data-aria-hidden="true"
-  >
+  <div>
     <div
       class="date-picker"
     >
       <div
+        aria-atomic="true"
+        aria-live="polite"
+        class="sr-only"
+      />
+      <div
+        aria-hidden="true"
         class="input-group"
+        data-aria-hidden="true"
         style=""
       >
         <div
@@ -1675,6 +1684,11 @@ exports[`BasicRendering renders date picker with native picker 1`] = `
       class="date-picker"
     >
       <div
+        aria-atomic="true"
+        aria-live="polite"
+        class="sr-only"
+      />
+      <div
         class="input-group"
       >
         <div
@@ -1700,15 +1714,19 @@ exports[`BasicRendering renders date picker with native picker 1`] = `
 
 exports[`BasicRendering renders date picker with time 1`] = `
 <body>
-  <div
-    aria-hidden="true"
-    data-aria-hidden="true"
-  >
+  <div>
     <div
       class="date-picker"
     >
       <div
+        aria-atomic="true"
+        aria-live="polite"
+        class="sr-only"
+      />
+      <div
+        aria-hidden="true"
         class="input-group"
+        data-aria-hidden="true"
         style=""
       >
         <div
@@ -2681,15 +2699,19 @@ exports[`BasicRendering renders date picker with time 1`] = `
 
 exports[`BasicRendering renders the date picker with years range 1`] = `
 <body>
-  <div
-    aria-hidden="true"
-    data-aria-hidden="true"
-  >
+  <div>
     <div
       class="date-picker"
     >
       <div
+        aria-atomic="true"
+        aria-live="polite"
+        class="sr-only"
+      />
+      <div
+        aria-hidden="true"
         class="input-group"
+        data-aria-hidden="true"
         style=""
       >
         <div

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-date-picker/src/__tests__/__snapshots__/IncrementalInteractions.tsx.snap
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-date-picker/src/__tests__/__snapshots__/IncrementalInteractions.tsx.snap
@@ -2,15 +2,19 @@
 
 exports[`IncrementalInteractions clicking a month on the selector should change the content to the corresponding month 1`] = `
 <body>
-  <div
-    aria-hidden="true"
-    data-aria-hidden="true"
-  >
+  <div>
     <div
       class="date-picker"
     >
       <div
+        aria-atomic="true"
+        aria-live="polite"
+        class="sr-only"
+      />
+      <div
+        aria-hidden="true"
         class="input-group"
+        data-aria-hidden="true"
         style=""
       >
         <div
@@ -843,6 +847,11 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
       class="date-picker"
     >
       <div
+        aria-atomic="true"
+        aria-live="polite"
+        class="sr-only"
+      />
+      <div
         class="input-group"
         style=""
       >
@@ -1667,15 +1676,19 @@ exports[`IncrementalInteractions clicking on the date icon should close the drop
 
 exports[`IncrementalInteractions clicking on the date icon should open the dropdown 1`] = `
 <body>
-  <div
-    aria-hidden="true"
-    data-aria-hidden="true"
-  >
+  <div>
     <div
       class="date-picker"
     >
       <div
+        aria-atomic="true"
+        aria-live="polite"
+        class="sr-only"
+      />
+      <div
+        aria-hidden="true"
         class="input-group"
+        data-aria-hidden="true"
         style=""
       >
         <div
@@ -2505,15 +2518,19 @@ exports[`IncrementalInteractions clicking on the date icon should open the dropd
 
 exports[`IncrementalInteractions clicking on the year selector should switch to the year of the corresponding month selected 1`] = `
 <body>
-  <div
-    aria-hidden="true"
-    data-aria-hidden="true"
-  >
+  <div>
     <div
       class="date-picker"
     >
       <div
+        aria-atomic="true"
+        aria-live="polite"
+        class="sr-only"
+      />
+      <div
+        aria-hidden="true"
         class="input-group"
+        data-aria-hidden="true"
         style=""
       >
         <div
@@ -3361,6 +3378,11 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
       class="date-picker"
     >
       <div
+        aria-atomic="true"
+        aria-live="polite"
+        class="sr-only"
+      />
+      <div
         class="input-group"
         style=""
       >
@@ -4190,15 +4212,19 @@ exports[`IncrementalInteractions clicking outside the dropdown should close the 
 
 exports[`IncrementalInteractions date entered in the input element should reflect on the date picker 1`] = `
 <body>
-  <div
-    aria-hidden="true"
-    data-aria-hidden="true"
-  >
+  <div>
     <div
       class="date-picker"
     >
       <div
+        aria-atomic="true"
+        aria-live="polite"
+        class="sr-only"
+      />
+      <div
+        aria-hidden="true"
         class="input-group"
+        data-aria-hidden="true"
         style=""
       >
         <div

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-date-picker/src/__tests__/__snapshots__/Internationalization.tsx.snap
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-date-picker/src/__tests__/__snapshots__/Internationalization.tsx.snap
@@ -2,15 +2,19 @@
 
 exports[`Internationalization FirstDayOfWeek first day of the week should start on Friday 1`] = `
 <body>
-  <div
-    aria-hidden="true"
-    data-aria-hidden="true"
-  >
+  <div>
     <div
       class="date-picker"
     >
       <div
+        aria-atomic="true"
+        aria-live="polite"
+        class="sr-only"
+      />
+      <div
+        aria-hidden="true"
         class="input-group"
+        data-aria-hidden="true"
         style=""
       >
         <div
@@ -839,15 +843,19 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
 
 exports[`Internationalization FirstDayOfWeek first day of the week should start on Monday 1`] = `
 <body>
-  <div
-    aria-hidden="true"
-    data-aria-hidden="true"
-  >
+  <div>
     <div
       class="date-picker"
     >
       <div
+        aria-atomic="true"
+        aria-live="polite"
+        class="sr-only"
+      />
+      <div
+        aria-hidden="true"
         class="input-group"
+        data-aria-hidden="true"
         style=""
       >
         <div
@@ -1676,15 +1684,19 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
 
 exports[`Internationalization FirstDayOfWeek first day of the week should start on Saturday 1`] = `
 <body>
-  <div
-    aria-hidden="true"
-    data-aria-hidden="true"
-  >
+  <div>
     <div
       class="date-picker"
     >
       <div
+        aria-atomic="true"
+        aria-live="polite"
+        class="sr-only"
+      />
+      <div
+        aria-hidden="true"
         class="input-group"
+        data-aria-hidden="true"
         style=""
       >
         <div
@@ -2513,15 +2525,19 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
 
 exports[`Internationalization FirstDayOfWeek first day of the week should start on Sunday 1`] = `
 <body>
-  <div
-    aria-hidden="true"
-    data-aria-hidden="true"
-  >
+  <div>
     <div
       class="date-picker"
     >
       <div
+        aria-atomic="true"
+        aria-live="polite"
+        class="sr-only"
+      />
+      <div
+        aria-hidden="true"
         class="input-group"
+        data-aria-hidden="true"
         style=""
       >
         <div
@@ -3350,15 +3366,19 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
 
 exports[`Internationalization FirstDayOfWeek first day of the week should start on Thursday 1`] = `
 <body>
-  <div
-    aria-hidden="true"
-    data-aria-hidden="true"
-  >
+  <div>
     <div
       class="date-picker"
     >
       <div
+        aria-atomic="true"
+        aria-live="polite"
+        class="sr-only"
+      />
+      <div
+        aria-hidden="true"
         class="input-group"
+        data-aria-hidden="true"
         style=""
       >
         <div
@@ -4187,15 +4207,19 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
 
 exports[`Internationalization FirstDayOfWeek first day of the week should start on Tuesday 1`] = `
 <body>
-  <div
-    aria-hidden="true"
-    data-aria-hidden="true"
-  >
+  <div>
     <div
       class="date-picker"
     >
       <div
+        aria-atomic="true"
+        aria-live="polite"
+        class="sr-only"
+      />
+      <div
+        aria-hidden="true"
         class="input-group"
+        data-aria-hidden="true"
         style=""
       >
         <div
@@ -5128,15 +5152,19 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
 
 exports[`Internationalization FirstDayOfWeek first day of the week should start on Wednesday 1`] = `
 <body>
-  <div
-    aria-hidden="true"
-    data-aria-hidden="true"
-  >
+  <div>
     <div
       class="date-picker"
     >
       <div
+        aria-atomic="true"
+        aria-live="polite"
+        class="sr-only"
+      />
+      <div
+        aria-hidden="true"
         class="input-group"
+        data-aria-hidden="true"
         style=""
       >
         <div
@@ -5965,15 +5993,19 @@ exports[`Internationalization FirstDayOfWeek first day of the week should start 
 
 exports[`Internationalization renders the date picker in russian 1`] = `
 <body>
-  <div
-    aria-hidden="true"
-    data-aria-hidden="true"
-  >
+  <div>
     <div
       class="date-picker"
     >
       <div
+        aria-atomic="true"
+        aria-live="polite"
+        class="sr-only"
+      />
+      <div
+        aria-hidden="true"
         class="input-group"
+        data-aria-hidden="true"
         style=""
       >
         <div

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-date-picker/src/index.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-date-picker/src/index.tsx
@@ -623,6 +623,8 @@ const DatePicker = React.forwardRef<HTMLInputElement, IProps>(
 		 */
 		const handleDayClicked = (date: Date) => {
 			if (isDayDisabled(date)) {
+				announceOutOfRange();
+
 				return;
 			}
 
@@ -785,6 +787,8 @@ const DatePicker = React.forwardRef<HTMLInputElement, IProps>(
 			const currentDateTime = getDefaultMonth();
 
 			if (isDayDisabled(currentDateTime)) {
+				announceOutOfRange();
+
 				return;
 			}
 

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-date-picker/src/index.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-date-picker/src/index.tsx
@@ -20,7 +20,11 @@ import DateNavigation from './DateNavigation';
 import DayNumber from './DayNumber';
 import DaysTable from './DaysTable';
 import {
+	clamp,
 	formatDate,
+	isAfter,
+	isBefore,
+	isSameDay,
 	isValid,
 	parseDate,
 	range as createRange,
@@ -128,6 +132,23 @@ interface IProps
 	 * Name of the input.
 	 */
 	inputName?: string;
+
+	/**
+	 * The latest date that can be selected, formatted using `dateFormat` (and
+	 * `dateFormat` followed by a time when `time` is `true`). Dates after `max`
+	 * are disabled in the calendar; when `time` is `true`, the time picker is
+	 * also constrained on the boundary day. If `min >= max`, a warning is
+	 * logged and both bounds are ignored.
+	 */
+	max?: string;
+
+	/**
+	 * The earliest date that can be selected, formatted using `dateFormat`
+	 * (and `dateFormat` followed by a time when `time` is `true`). Dates
+	 * before `min` are disabled in the calendar; when `time` is `true`, the
+	 * time picker is also constrained on the boundary day.
+	 */
+	min?: string;
 
 	/**
 	 * The names of the months.
@@ -263,6 +284,8 @@ const DatePicker = React.forwardRef<HTMLInputElement, IProps>(
 			initialExpanded = false,
 			initialMonth,
 			inputName,
+			max,
+			min,
 			months = [
 				'January',
 				'February',
@@ -299,9 +322,89 @@ const DatePicker = React.forwardRef<HTMLInputElement, IProps>(
 		}: IProps,
 		ref
 	) => {
+		const [parsedMin, parsedMax] = useMemo<
+			readonly [Date | undefined, Date | undefined]
+		>(() => {
+			const parseBound = (value?: string) => {
+				if (!value) {
+					return undefined;
+				}
+
+				const parsed = parseDate(
+					value,
+					time
+						? `${dateFormat} ${
+								use12Hours ? TIME_FORMAT_12H : TIME_FORMAT
+							}`
+						: dateFormat,
+					NEW_DATE
+				);
+
+				return isValid(parsed) ? parsed : undefined;
+			};
+
+			const minDate = parseBound(min);
+			const maxDate = parseBound(max);
+
+			if (minDate && maxDate && !isBefore(minDate, maxDate)) {
+
+				// eslint-disable-next-line no-console
+				console.warn(
+					'ClayDatePicker: `min` must be earlier than `max`. Both bounds will be ignored.'
+				);
+
+				return [undefined, undefined] as const;
+			}
+
+			return [minDate, maxDate] as const;
+		}, [min, max, dateFormat, time, use12Hours]);
+
+		const isDayDisabled = useCallback(
+			(date: Date) => {
+				if (
+					parsedMin &&
+					isBefore(date, parsedMin) &&
+					!isSameDay(date, parsedMin)
+				) {
+					return true;
+				}
+
+				if (
+					parsedMax &&
+					isAfter(date, parsedMax) &&
+					!isSameDay(date, parsedMax)
+				) {
+					return true;
+				}
+
+				return false;
+			},
+			[parsedMin, parsedMax]
+		);
+
+		const isDateTimeOutOfRange = useCallback(
+			(date: Date) => {
+				if (parsedMin && isBefore(date, parsedMin)) {
+					return true;
+				}
+
+				if (parsedMax && isAfter(date, parsedMax)) {
+					return true;
+				}
+
+				return false;
+			},
+			[parsedMin, parsedMax]
+		);
+
 		const getDefaultMonth = useCallback(
-			() => defaultMonth ?? initialMonth ?? new Date(),
-			[defaultMonth, initialMonth]
+			() =>
+				clamp(
+					defaultMonth ?? initialMonth ?? new Date(),
+					parsedMin,
+					parsedMax
+				),
+			[defaultMonth, initialMonth, parsedMin, parsedMax]
 		);
 
 		const [internalValue, setValue, isUncontrolled] = useControlledState({
@@ -428,6 +531,50 @@ const DatePicker = React.forwardRef<HTMLInputElement, IProps>(
 			}
 		};
 
+		const timePickerConfig = useMemo(() => {
+			if (!time || use12Hours || (!parsedMin && !parsedMax)) {
+				return undefined;
+			}
+
+			const [day] = daysSelected;
+
+			let hoursMin = 0;
+			let hoursMax = 23;
+			let minutesMin = 0;
+			let minutesMax = 59;
+
+			const currentHours = Number(currentTime.split(':')[0]);
+
+			if (parsedMin && isSameDay(day, parsedMin)) {
+				hoursMin = parsedMin.getHours();
+
+				if (currentHours === hoursMin) {
+					minutesMin = parsedMin.getMinutes();
+				}
+			}
+
+			if (parsedMax && isSameDay(day, parsedMax)) {
+				hoursMax = parsedMax.getHours();
+
+				if (currentHours === hoursMax) {
+					minutesMax = parsedMax.getMinutes();
+				}
+			}
+
+			return {
+				use12Hours: {
+					ampm: {am: 'AM', pm: 'PM'},
+					hours: {max: 12, min: 1},
+					minutes: {max: 59, min: 0},
+				},
+				use24Hours: {
+					ampm: {am: 'AM', pm: 'PM'},
+					hours: {max: hoursMax, min: hoursMin},
+					minutes: {max: minutesMax, min: minutesMin},
+				},
+			};
+		}, [time, use12Hours, daysSelected, currentTime, parsedMin, parsedMax]);
+
 		const memoizedYears = useMemo<Array<ISelectOption>>(
 			() =>
 				createRange(years).map((elem) => {
@@ -454,6 +601,10 @@ const DatePicker = React.forwardRef<HTMLInputElement, IProps>(
 		 * Handles the click on element of the day
 		 */
 		const handleDayClicked = (date: Date) => {
+			if (isDayDisabled(date)) {
+				return;
+			}
+
 			const [startDate, endDate] = daysSelected;
 
 			let newDaysSelected: [Date, Date];
@@ -525,6 +676,34 @@ const DatePicker = React.forwardRef<HTMLInputElement, IProps>(
 					if (days) {
 						const [startDate, endDate] = days;
 
+						const referenceStart = time
+							? startDate!
+							: setDate(startDate!, {
+									hours: 12,
+									milliseconds: 0,
+									minutes: 0,
+									seconds: 0,
+								});
+						const referenceEnd = time
+							? endDate!
+							: setDate(endDate!, {
+									hours: 12,
+									milliseconds: 0,
+									minutes: 0,
+									seconds: 0,
+								});
+
+						const startOutOfRange = time
+							? isDateTimeOutOfRange(referenceStart)
+							: isDayDisabled(referenceStart);
+						const endOutOfRange = time
+							? isDateTimeOutOfRange(referenceEnd)
+							: isDayDisabled(referenceEnd);
+
+						if (startOutOfRange || endOutOfRange) {
+							return;
+						}
+
 						if (time) {
 							setCurrentTime(
 								startDate!.getHours(),
@@ -545,7 +724,15 @@ const DatePicker = React.forwardRef<HTMLInputElement, IProps>(
 					}
 				}
 			},
-			[dateFormat, use12Hours, time, years, yearsCheck]
+			[
+				dateFormat,
+				use12Hours,
+				time,
+				years,
+				yearsCheck,
+				isDayDisabled,
+				isDateTimeOutOfRange,
+			]
 		);
 
 		/**
@@ -572,6 +759,10 @@ const DatePicker = React.forwardRef<HTMLInputElement, IProps>(
 		 */
 		const handleDotClicked = () => {
 			const currentDateTime = getDefaultMonth();
+
+			if (isDayDisabled(currentDateTime)) {
+				return;
+			}
 
 			const [, endDate] = daysSelected;
 
@@ -620,6 +811,35 @@ const DatePicker = React.forwardRef<HTMLInputElement, IProps>(
 
 			if (minutes === '--' && typeof hours === 'number') {
 				minutes = 0;
+			}
+
+			// In 12-hour mode the AM/PM toggle can't be disabled, so the user
+			// can land on a side that is fully outside [min, max] even with the
+			// hour/minute config locked down. Validate the combined date+time
+			// here and refuse to commit when out of range. This also catches
+			// invalid combinations typed into the 24-hour input.
+
+			if (
+				typeof hours === 'number' &&
+				typeof minutes === 'number' &&
+				(parsedMin || parsedMax)
+			) {
+				let hours24 = hours;
+
+				if (use12Hours) {
+					if (ampm === 'PM' && hours < 12) {
+						hours24 = hours + 12;
+					}
+					else if (ampm === 'AM' && hours === 12) {
+						hours24 = 0;
+					}
+				}
+
+				const dateTimeSelected = setDate(day, {hours: hours24, minutes});
+
+				if (isDateTimeOutOfRange(dateTimeSelected)) {
+					return;
+				}
 			}
 
 			if (internalValue) {
@@ -770,7 +990,10 @@ const DatePicker = React.forwardRef<HTMLInputElement, IProps>(
 											<DayNumber
 												day={day}
 												daysSelected={daysSelected}
-												disabled={disabled}
+												disabled={
+													disabled ||
+													isDayDisabled(day.date)
+												}
 												index={key}
 												isFocused={calendarNavigation.isFocused(
 													day
@@ -787,6 +1010,7 @@ const DatePicker = React.forwardRef<HTMLInputElement, IProps>(
 									<div className="date-picker-calendar-footer">
 										{time && (
 											<TimePicker
+												config={timePickerConfig}
 												currentTime={currentTime}
 												disabled={disabled}
 												onTimeChange={handleTimeChange}

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-date-picker/src/index.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-date-picker/src/index.tsx
@@ -835,7 +835,10 @@ const DatePicker = React.forwardRef<HTMLInputElement, IProps>(
 					}
 				}
 
-				const dateTimeSelected = setDate(day, {hours: hours24, minutes});
+				const dateTimeSelected = setDate(day, {
+					hours: hours24,
+					minutes,
+				});
 
 				if (isDateTimeOutOfRange(dateTimeSelected)) {
 					return;
@@ -990,16 +993,16 @@ const DatePicker = React.forwardRef<HTMLInputElement, IProps>(
 											<DayNumber
 												day={day}
 												daysSelected={daysSelected}
-												disabled={
-													disabled ||
-													isDayDisabled(day.date)
-												}
+												disabled={disabled}
 												index={key}
 												isFocused={calendarNavigation.isFocused(
 													day
 												)}
 												key={key}
 												onClick={handleDayClicked}
+												outOfRange={isDayDisabled(
+													day.date
+												)}
 												range={range}
 											/>
 										)}

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-date-picker/src/index.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-date-picker/src/index.tsx
@@ -269,6 +269,8 @@ const DatePicker = React.forwardRef<HTMLInputElement, IProps>(
 					'Use the calendar to choose a Date. Current selection {0}',
 				dialog: 'Choose date',
 				openCalendar: 'Open Calendar Picker',
+				outOfRange:
+					'The entered value is outside the allowed range and was not applied',
 				selectMonth: 'Select a month',
 				selectYear: 'Select a year',
 			},
@@ -511,6 +513,25 @@ const DatePicker = React.forwardRef<HTMLInputElement, IProps>(
 		const triggerElementRef = useRef<HTMLDivElement | null>(null);
 
 		/**
+		 * Polite live region used to notify assistive technology when an
+		 * input or time edit is silently rejected because it falls outside
+		 * `[min, max]`. Clearing before assigning forces the announcement to
+		 * fire even when the same message would otherwise repeat.
+		 */
+		const liveRegionRef = useRef<HTMLDivElement | null>(null);
+
+		const announceOutOfRange = useCallback(() => {
+			const node = liveRegionRef.current;
+
+			if (!node || !ariaLabels.outOfRange) {
+				return;
+			}
+
+			node.textContent = '';
+			node.textContent = ariaLabels.outOfRange;
+		}, [ariaLabels.outOfRange]);
+
+		/**
 		 * Handles the change of the current month of the Date Picker
 		 * content and takes care of updating the weeks.
 		 */
@@ -701,6 +722,8 @@ const DatePicker = React.forwardRef<HTMLInputElement, IProps>(
 							: isDayDisabled(referenceEnd);
 
 						if (startOutOfRange || endOutOfRange) {
+							announceOutOfRange();
+
 							return;
 						}
 
@@ -732,6 +755,7 @@ const DatePicker = React.forwardRef<HTMLInputElement, IProps>(
 				yearsCheck,
 				isDayDisabled,
 				isDateTimeOutOfRange,
+				announceOutOfRange,
 			]
 		);
 
@@ -841,6 +865,8 @@ const DatePicker = React.forwardRef<HTMLInputElement, IProps>(
 				});
 
 				if (isDateTimeOutOfRange(dateTimeSelected)) {
+					announceOutOfRange();
+
 					return;
 				}
 			}
@@ -897,6 +923,13 @@ const DatePicker = React.forwardRef<HTMLInputElement, IProps>(
 		return (
 			<FocusScope arrowKeysUpDown={false}>
 				<div className="date-picker">
+					<div
+						aria-atomic="true"
+						aria-live="polite"
+						className="sr-only"
+						ref={liveRegionRef}
+					/>
+
 					<ClayInput.Group ref={triggerElementRef}>
 						<ClayInput.GroupItem className="input-group-item-focusable">
 							<InputDate

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-date-picker/src/types.ts
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-date-picker/src/types.ts
@@ -22,6 +22,7 @@ export interface IAriaLabels {
 	dialog?: string;
 	input?: string;
 	openCalendar?: string;
+	outOfRange?: string;
 	selectMonth: string;
 	selectYear: string;
 }

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-date-picker/stories/DatePicker.stories.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-date-picker/stories/DatePicker.stories.tsx
@@ -283,3 +283,41 @@ export function InDropdownMenu() {
 		</>
 	);
 }
+export function MinMax() {
+	const today = new Date();
+	const format = (date: Date) =>
+		`${date.getFullYear()}-${String(date.getMonth() + 1).padStart(
+			2,
+			'0'
+		)}-${String(date.getDate()).padStart(2, '0')}`;
+
+	const min = new Date(today);
+	min.setDate(today.getDate() - 5);
+
+	const max = new Date(today);
+	max.setDate(today.getDate() + 5);
+
+	return (
+		<>
+			<ClayDatePickerWithState
+				max={format(max)}
+				min={format(min)}
+				placeholder="YYYY-MM-DD"
+				years={{
+					end: today.getFullYear() + 1,
+					start: today.getFullYear() - 1,
+				}}
+			/>
+			<ClayDatePickerWithState
+				max={`${format(max)} 18:00`}
+				min={`${format(min)} 09:00`}
+				placeholder="YYYY-MM-DD HH:mm"
+				time
+				years={{
+					end: today.getFullYear() + 1,
+					start: today.getFullYear() - 1,
+				}}
+			/>
+		</>
+	);
+}


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPD-91601

## Goal

ClayDatePicker has no API to constrain the selectable date range to a window. Consumers that need a bounded picker (e.g. start-end pickers, validity-period inputs) have to validate after the fact and roll back invalid selections themselves, which is awkward and produces visible flicker.
Also, there is no visual nor assistive technology clue to know if a day is not available in the range.
    
## Technical details

- Adds opt-in `min` and `max` props formatted using the same `dateFormat` as `value`.
- Days outside the range are flagged in the calendar grid through `aria-disabled` (rather than the native HTML `disabled` attribute) so the grid's arrow-key navigation stays continuous, the click handler short-circuits, and the disabled visual class is preserved.
- When `time` is enabled, the boundary day's hours and minutes are constrained via `ClayTimePicker`'s `config`; the 12-hour AM/PM toggle cannot be locked, so `handleTimeChange` rejects out-of-range edits post-hoc.
- Typed input that falls outside the range and rejected time edits are announced through a polite `aria-live` region so screen reader users are not left wondering whether their entry was accepted.
- When `min >= max`, a console warning is logged and both bounds are ignored.

## UI

https://github.com/user-attachments/assets/3fb33164-3d93-46b0-90cb-2a92e4374b3c

