### PR TITLE
LPD-39987 Wire KeyboardArrowsIndicator into Clay components

### DIFF
--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-autocomplete/src/Autocomplete.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-autocomplete/src/Autocomplete.tsx
@@ -143,14 +143,6 @@ export interface IProps<T>
 	items?: Array<T> | null;
 
 	/**
-	 * Localized `aria-label` for the keyboard arrows indicator. Defaults
-	 * to the indicator's built-in English string when omitted. Pass a
-	 * translated value (e.g. via `Liferay.Language.get`) when the host
-	 * page needs i18n.
-	 */
-	keyboardArrowsIndicatorLabel?: string;
-
-	/**
 	 * The current state of Autocomplete current loading. Determines whether the
 	 * loading indicator should be shown or not.
 	 */
@@ -267,7 +259,6 @@ function AutocompleteInner<T extends Item>(
 		estimateSize,
 		filterKey,
 		items: externalItems,
-		keyboardArrowsIndicatorLabel,
 		loadingState,
 		menuTrigger = 'input',
 		messages: externalMessages,
@@ -812,7 +803,6 @@ function AutocompleteInner<T extends Item>(
 					<KeyboardArrowsIndicator
 						anchorRef={inputElementRef}
 						direction="vertical"
-						label={keyboardArrowsIndicatorLabel}
 					/>
 				</ClayPortal>
 			)}

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-autocomplete/src/Autocomplete.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-autocomplete/src/Autocomplete.tsx
@@ -4,6 +4,7 @@
  */
 
 import {
+	KeyboardArrowsIndicator,
 	__NOT_PUBLIC_COLLECTION,
 	__NOT_PUBLIC_LIVE_ANNOUNCER,
 } from '@clayui/core';
@@ -11,6 +12,7 @@ import DropDown from '@clayui/drop-down';
 import {ClayInput as Input} from '@clayui/form';
 import LoadingIndicator from '@clayui/loading-indicator';
 import {
+	ClayPortal,
 	InternalDispatch,
 	Keys,
 	Overlay,
@@ -116,6 +118,15 @@ export interface IProps<T>
 	direction?: 'bottom' | 'top';
 
 	/**
+	 * Flag to render the `KeyboardArrowsIndicator` alongside the Autocomplete
+	 * input, hinting that up and down arrow keys can be used to navigate
+	 * the suggestions list. The indicator floats to the right of the input
+	 * and flips to the left when it would overflow the viewport. It is
+	 * only rendered while the suggestions panel is open.
+	 */
+	displayKeyboardArrowsIndicator?: boolean;
+
+	/**
 	 * The estimated height of an item that is used by the virtualizer.
 	 */
 	estimateSize?: number;
@@ -130,6 +141,14 @@ export interface IProps<T>
 	 * Property to render content with dynamic data.
 	 */
 	items?: Array<T> | null;
+
+	/**
+	 * Localized `aria-label` for the keyboard arrows indicator. Defaults
+	 * to the indicator's built-in English string when omitted. Pass a
+	 * translated value (e.g. via `Liferay.Language.get`) when the host
+	 * page needs i18n.
+	 */
+	keyboardArrowsIndicatorLabel?: string;
 
 	/**
 	 * The current state of Autocomplete current loading. Determines whether the
@@ -244,9 +263,11 @@ function AutocompleteInner<T extends Item>(
 		defaultItems,
 		defaultValue,
 		direction = 'bottom',
+		displayKeyboardArrowsIndicator = false,
 		estimateSize,
 		filterKey,
 		items: externalItems,
+		keyboardArrowsIndicatorLabel,
 		loadingState,
 		menuTrigger = 'input',
 		messages: externalMessages,
@@ -784,6 +805,16 @@ function AutocompleteInner<T extends Item>(
 						<InfiniteScrollFeedback />
 					</div>
 				</Overlay>
+			)}
+
+			{active && displayKeyboardArrowsIndicator && (
+				<ClayPortal>
+					<KeyboardArrowsIndicator
+						anchorRef={inputElementRef}
+						direction="vertical"
+						label={keyboardArrowsIndicatorLabel}
+					/>
+				</ClayPortal>
 			)}
 
 			{isLoading && (

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-autocomplete/src/__tests__/IncrementalInteractions.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-autocomplete/src/__tests__/IncrementalInteractions.tsx
@@ -860,4 +860,76 @@ describe('Autocomplete incremental interactions', () => {
 			});
 		});
 	});
+
+	describe('keyboard arrows indicator', () => {
+		it('does not render the indicator by default', () => {
+			const {getByRole} = render(
+				<ClayAutocomplete messages={messages}>
+					{['one', 'two', 'three'].map((item) => (
+						<ClayAutocomplete.Item key={item}>
+							{item}
+						</ClayAutocomplete.Item>
+					))}
+				</ClayAutocomplete>
+			);
+
+			userEvent.type(getByRole('combobox'), 'o');
+
+			expect(
+				document.body.querySelector('.clay-keyboard-arrows-indicator')
+			).not.toBeInTheDocument();
+		});
+
+		it('renders the floating indicator alongside the input when enabled', () => {
+			const {getByRole} = render(
+				<ClayAutocomplete
+					displayKeyboardArrowsIndicator
+					messages={messages}
+				>
+					{['one', 'two', 'three'].map((item) => (
+						<ClayAutocomplete.Item key={item}>
+							{item}
+						</ClayAutocomplete.Item>
+					))}
+				</ClayAutocomplete>
+			);
+
+			userEvent.type(getByRole('combobox'), 'o');
+
+			const indicator = document.body.querySelector(
+				'.clay-keyboard-arrows-indicator'
+			);
+
+			expect(indicator).toBeInTheDocument();
+			expect(indicator).toHaveClass('clay-keyboard-arrows-vertical');
+			expect(indicator).toHaveClass(
+				'clay-keyboard-arrows-indicator-floating'
+			);
+		});
+
+		it('uses the localized label on the indicator', () => {
+			const {getByRole} = render(
+				<ClayAutocomplete
+					displayKeyboardArrowsIndicator
+					keyboardArrowsIndicatorLabel="Use up and down to navigate suggestions"
+					messages={messages}
+				>
+					{['one', 'two', 'three'].map((item) => (
+						<ClayAutocomplete.Item key={item}>
+							{item}
+						</ClayAutocomplete.Item>
+					))}
+				</ClayAutocomplete>
+			);
+
+			userEvent.type(getByRole('combobox'), 'o');
+
+			expect(
+				document.body.querySelector('.clay-keyboard-arrows-indicator')
+			).toHaveAttribute(
+				'aria-label',
+				'Use up and down to navigate suggestions'
+			);
+		});
+	});
 });

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-autocomplete/src/__tests__/IncrementalInteractions.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-autocomplete/src/__tests__/IncrementalInteractions.tsx
@@ -906,30 +906,5 @@ describe('Autocomplete incremental interactions', () => {
 				'clay-keyboard-arrows-indicator-floating'
 			);
 		});
-
-		it('uses the localized label on the indicator', () => {
-			const {getByRole} = render(
-				<ClayAutocomplete
-					displayKeyboardArrowsIndicator
-					keyboardArrowsIndicatorLabel="Use up and down to navigate suggestions"
-					messages={messages}
-				>
-					{['one', 'two', 'three'].map((item) => (
-						<ClayAutocomplete.Item key={item}>
-							{item}
-						</ClayAutocomplete.Item>
-					))}
-				</ClayAutocomplete>
-			);
-
-			userEvent.type(getByRole('combobox'), 'o');
-
-			expect(
-				document.body.querySelector('.clay-keyboard-arrows-indicator')
-			).toHaveAttribute(
-				'aria-label',
-				'Use up and down to navigate suggestions'
-			);
-		});
 	});
 });

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-autocomplete/src/__tests__/IncrementalInteractions.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-autocomplete/src/__tests__/IncrementalInteractions.tsx
@@ -862,7 +862,7 @@ describe('Autocomplete incremental interactions', () => {
 	});
 
 	describe('keyboard arrows indicator', () => {
-		it('does not render the indicator by default', () => {
+		it('does not render the indicator by default', async () => {
 			const {getByRole} = render(
 				<ClayAutocomplete messages={messages}>
 					{['one', 'two', 'three'].map((item) => (
@@ -873,14 +873,14 @@ describe('Autocomplete incremental interactions', () => {
 				</ClayAutocomplete>
 			);
 
-			userEvent.type(getByRole('combobox'), 'o');
+			await userEvent.type(getByRole('combobox'), 'o');
 
 			expect(
 				document.body.querySelector('.clay-keyboard-arrows-indicator')
 			).not.toBeInTheDocument();
 		});
 
-		it('renders the floating indicator alongside the input when enabled', () => {
+		it('renders the floating indicator alongside the input when enabled', async () => {
 			const {getByRole} = render(
 				<ClayAutocomplete
 					displayKeyboardArrowsIndicator
@@ -894,7 +894,7 @@ describe('Autocomplete incremental interactions', () => {
 				</ClayAutocomplete>
 			);
 
-			userEvent.type(getByRole('combobox'), 'o');
+			await userEvent.type(getByRole('combobox'), 'o');
 
 			const indicator = document.body.querySelector(
 				'.clay-keyboard-arrows-indicator'

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-autocomplete/stories/Autocomplete.stories.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-autocomplete/stories/Autocomplete.stories.tsx
@@ -732,3 +732,36 @@ export function InfiniteScroll() {
 		</div>
 	);
 }
+export function KeyboardArrowsIndicator() {
+	return (
+		<div className="row">
+			<div className="col-md-5">
+				<div className="sheet">
+					<div className="form-group">
+						<label
+							htmlFor="clay-autocomplete-1"
+							id="clay-autocomplete-label-1"
+						>
+							Numbers (one-five)
+						</label>
+
+						<ClayAutocomplete
+							defaultActive
+							displayKeyboardArrowsIndicator
+							keyboardArrowsIndicatorLabel="Use up and down arrow keys to navigate suggestions"
+							placeholder="Enter a number from One to Five"
+						>
+							{['one', 'two', 'three', 'four', 'five'].map(
+								(item) => (
+									<ClayAutocomplete.Item key={item}>
+										{item}
+									</ClayAutocomplete.Item>
+								)
+							)}
+						</ClayAutocomplete>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-autocomplete/stories/Autocomplete.stories.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-autocomplete/stories/Autocomplete.stories.tsx
@@ -748,7 +748,6 @@ export function KeyboardArrowsIndicator() {
 						<ClayAutocomplete
 							defaultActive
 							displayKeyboardArrowsIndicator
-							keyboardArrowsIndicatorLabel="Use up and down arrow keys to navigate suggestions"
 							placeholder="Enter a number from One to Five"
 						>
 							{['one', 'two', 'three', 'four', 'five'].map(

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/icon-selector/IconSelector.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/icon-selector/IconSelector.tsx
@@ -7,6 +7,7 @@ import Button, {ClayButtonWithIcon} from '@clayui/button';
 import {ClayInput} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import {
+	ClayPortal,
 	FOCUSABLE_ELEMENTS,
 	InternalDispatch,
 	Keys,
@@ -21,6 +22,7 @@ import {
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 
 import {FocusMenu} from '../focus-trap';
+import {KeyboardArrowsIndicator} from '../keyboard-arrows-indicator';
 
 enum alignPosition {
 	bottomLeft = 5,
@@ -48,6 +50,23 @@ export type Props = {
 	 * Direction the menu will render relative to the trigger.
 	 */
 	direction?: 'bottom' | 'top';
+
+	/**
+	 * Flag to render the `KeyboardArrowsIndicator` alongside the icon
+	 * panel, hinting that up and down arrow keys can be used to step
+	 * through the icons. The indicator floats to the right of the panel
+	 * and flips to the left when it would overflow the viewport. It is
+	 * only rendered while the icon panel is open.
+	 */
+	displayKeyboardArrowsIndicator?: boolean;
+
+	/**
+	 * Localized `aria-label` for the keyboard arrows indicator. Defaults
+	 * to the indicator's built-in English string when omitted. Pass a
+	 * translated value (e.g. via `Liferay.Language.get`) when the host
+	 * page needs i18n.
+	 */
+	keyboardArrowsIndicatorLabel?: string;
 
 	/**
 	 * Messages for the Icon Selector.
@@ -116,6 +135,8 @@ export function IconSelector({
 	defaultActive,
 	defaultSelectedIcon,
 	direction = 'bottom',
+	displayKeyboardArrowsIndicator = false,
+	keyboardArrowsIndicatorLabel,
 	messages = defaultMessages,
 	selectedIcon: externalSelectedIcon,
 	onIconChange,
@@ -426,6 +447,16 @@ export function IconSelector({
 						</FocusMenu>
 					</div>
 				</Overlay>
+			)}
+
+			{active && displayKeyboardArrowsIndicator && (
+				<ClayPortal>
+					<KeyboardArrowsIndicator
+						anchorRef={menuRef}
+						direction="vertical"
+						label={keyboardArrowsIndicatorLabel}
+					/>
+				</ClayPortal>
 			)}
 		</>
 	);

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/icon-selector/IconSelector.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/icon-selector/IconSelector.tsx
@@ -61,14 +61,6 @@ export type Props = {
 	displayKeyboardArrowsIndicator?: boolean;
 
 	/**
-	 * Localized `aria-label` for the keyboard arrows indicator. Defaults
-	 * to the indicator's built-in English string when omitted. Pass a
-	 * translated value (e.g. via `Liferay.Language.get`) when the host
-	 * page needs i18n.
-	 */
-	keyboardArrowsIndicatorLabel?: string;
-
-	/**
 	 * Messages for the Icon Selector.
 	 */
 	messages?: {
@@ -136,7 +128,6 @@ export function IconSelector({
 	defaultSelectedIcon,
 	direction = 'bottom',
 	displayKeyboardArrowsIndicator = false,
-	keyboardArrowsIndicatorLabel,
 	messages = defaultMessages,
 	selectedIcon: externalSelectedIcon,
 	onIconChange,
@@ -454,7 +445,6 @@ export function IconSelector({
 					<KeyboardArrowsIndicator
 						anchorRef={menuRef}
 						direction="vertical"
-						label={keyboardArrowsIndicatorLabel}
 					/>
 				</ClayPortal>
 			)}

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/icon-selector/__tests__/IconSelector.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/icon-selector/__tests__/IconSelector.tsx
@@ -1,0 +1,78 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {cleanup, render} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+import '@testing-library/jest-dom';
+
+import {IconSelector} from '../';
+
+// `IconSelector` fetches the spritemap on mount to extract the available icon
+// names. The indicator does not depend on that fetch, so a no-op stub keeps
+// jsdom happy without affecting what these tests assert.
+
+beforeAll(() => {
+	(global as any).fetch = jest.fn(() =>
+		Promise.resolve({
+			text: () => Promise.resolve('<svg></svg>'),
+		})
+	);
+});
+
+describe('IconSelector keyboard arrows indicator', () => {
+	afterEach(cleanup);
+
+	it('does not render the indicator by default', () => {
+		const {getByRole} = render(<IconSelector spritemap="/foo/bar.svg" />);
+
+		userEvent.click(getByRole('button'));
+
+		expect(
+			document.body.querySelector('.clay-keyboard-arrows-indicator')
+		).not.toBeInTheDocument();
+	});
+
+	it('renders the floating indicator with direction "vertical" when enabled', () => {
+		const {getByRole} = render(
+			<IconSelector
+				displayKeyboardArrowsIndicator
+				spritemap="/foo/bar.svg"
+			/>
+		);
+
+		userEvent.click(getByRole('button'));
+
+		const indicator = document.body.querySelector(
+			'.clay-keyboard-arrows-indicator'
+		);
+
+		expect(indicator).toBeInTheDocument();
+		expect(indicator).toHaveClass('clay-keyboard-arrows-vertical');
+		expect(indicator).toHaveClass(
+			'clay-keyboard-arrows-indicator-floating'
+		);
+	});
+
+	it('uses the localized label on the indicator', () => {
+		const {getByRole} = render(
+			<IconSelector
+				displayKeyboardArrowsIndicator
+				keyboardArrowsIndicatorLabel="Use up and down arrow keys to step through the icons"
+				spritemap="/foo/bar.svg"
+			/>
+		);
+
+		userEvent.click(getByRole('button'));
+
+		expect(
+			document.body.querySelector('.clay-keyboard-arrows-indicator')
+		).toHaveAttribute(
+			'aria-label',
+			'Use up and down arrow keys to step through the icons'
+		);
+	});
+});

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/icon-selector/__tests__/IconSelector.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/icon-selector/__tests__/IconSelector.tsx
@@ -26,17 +26,17 @@ beforeAll(() => {
 describe('IconSelector keyboard arrows indicator', () => {
 	afterEach(cleanup);
 
-	it('does not render the indicator by default', () => {
+	it('does not render the indicator by default', async () => {
 		const {getByRole} = render(<IconSelector spritemap="/foo/bar.svg" />);
 
-		userEvent.click(getByRole('button'));
+		await userEvent.click(getByRole('button'));
 
 		expect(
 			document.body.querySelector('.clay-keyboard-arrows-indicator')
 		).not.toBeInTheDocument();
 	});
 
-	it('renders the floating indicator with direction "vertical" when enabled', () => {
+	it('renders the floating indicator with direction "vertical" when enabled', async () => {
 		const {getByRole} = render(
 			<IconSelector
 				displayKeyboardArrowsIndicator
@@ -44,7 +44,7 @@ describe('IconSelector keyboard arrows indicator', () => {
 			/>
 		);
 
-		userEvent.click(getByRole('button'));
+		await userEvent.click(getByRole('button'));
 
 		const indicator = document.body.querySelector(
 			'.clay-keyboard-arrows-indicator'

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/icon-selector/__tests__/IconSelector.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/icon-selector/__tests__/IconSelector.tsx
@@ -56,23 +56,4 @@ describe('IconSelector keyboard arrows indicator', () => {
 			'clay-keyboard-arrows-indicator-floating'
 		);
 	});
-
-	it('uses the localized label on the indicator', () => {
-		const {getByRole} = render(
-			<IconSelector
-				displayKeyboardArrowsIndicator
-				keyboardArrowsIndicatorLabel="Use up and down arrow keys to step through the icons"
-				spritemap="/foo/bar.svg"
-			/>
-		);
-
-		userEvent.click(getByRole('button'));
-
-		expect(
-			document.body.querySelector('.clay-keyboard-arrows-indicator')
-		).toHaveAttribute(
-			'aria-label',
-			'Use up and down arrow keys to step through the icons'
-		);
-	});
 });

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/keyboard-arrows-indicator/KeyboardArrowsIndicator.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/keyboard-arrows-indicator/KeyboardArrowsIndicator.tsx
@@ -4,12 +4,24 @@
  */
 
 import ClayIcon from '@clayui/icon';
+import {observeRect, useOverlayPosition} from '@clayui/shared';
 import classNames from 'classnames';
-import React from 'react';
+import React, {useEffect, useRef, useState} from 'react';
+
+import type {AlignPoints} from '@clayui/shared';
 
 export type Direction = 'all' | 'horizontal' | 'vertical';
 
+export type Placement = 'center' | 'tooltip';
+
 export type Props = {
+
+	/**
+	 * When provided, the indicator positions itself relative to the
+	 * referenced element. See `placement` for the supported anchoring
+	 * modes. When omitted, the indicator renders in normal flow.
+	 */
+	anchorRef?: React.RefObject<HTMLElement>;
 
 	/**
 	 * Optional `class` for the root element.
@@ -33,6 +45,16 @@ export type Props = {
 	label?: string;
 
 	/**
+	 * How the indicator is positioned relative to `anchorRef`. `tooltip`
+	 * (default) places it alongside the anchor with a directional arrow
+	 * that flips to fit the viewport. `center` overlays the indicator on
+	 * the anchor's center with no arrow — useful for narrow interactive
+	 * elements such as a resize handle, where the indicator should mark
+	 * the surface itself rather than point at it.
+	 */
+	placement?: Placement;
+
+	/**
 	 * Path to the Clay icon spritemap. Optional when `ClayIconSpriteContext`
 	 * is provided by an ancestor `Provider`.
 	 */
@@ -45,13 +67,133 @@ const DEFAULT_LABELS: Record<Direction, string> = {
 	vertical: 'Use up and down arrow keys to navigate',
 };
 
+// `alignmentPosition: 2` is `RightCenter` — anchor's center-right aligns
+// to the indicator's center-left. `autoBestAlign` flips to `LeftCenter`
+// when the indicator would overflow on the right; `dom-align` negates
+// the horizontal offset internally during that flip, so a single
+// `getOffset` value drives both sides. The default 4px gap from the
+// shared offset map is too tight for triggers that render a focus ring
+// around their bounding box, so the offset is widened.
+
+const TOOLTIP_ALIGNMENT_POSITION = 2;
+
+const TOOLTIP_OFFSET = 12;
+
+// `['cc', 'cc']` aligns the indicator's center to the anchor's center
+// for the overlay-style placement used by narrow interactive elements
+// like the resize handle. `dom-align` accepts arbitrary point strings
+// at runtime, but the shared `AlignPoints` type only enumerates the
+// entries in `ALIGN_MAP`, so the array is cast at the call site.
+
+const CENTER_ALIGNMENT_POINTS = ['cc', 'cc'] as const;
+
+const NO_OFFSET: [number, number] = [0, 0];
+
+function getTooltipOffset(): [number, number] {
+	return [TOOLTIP_OFFSET, 0];
+}
+
+function getCenterOffset(): [number, number] {
+	return NO_OFFSET;
+}
+
 export function KeyboardArrowsIndicator({
+	anchorRef,
 	className,
 	direction,
 	label,
+	placement = 'tooltip',
 	spritemap,
 	...otherProps
 }: Props) {
+	const indicatorRef = useRef<HTMLDivElement>(null);
+	const fallbackTriggerRef = useRef<HTMLDivElement>(null);
+
+	const [flipped, setFlipped] = useState(false);
+	const [hasFocusWithin, setHasFocusWithin] = useState(false);
+
+	const isTooltip = placement === 'tooltip';
+
+	useOverlayPosition(
+		{
+			alignmentByViewport: isTooltip,
+			alignmentPosition: isTooltip
+				? TOOLTIP_ALIGNMENT_POSITION
+				: (CENTER_ALIGNMENT_POINTS as unknown as AlignPoints),
+			autoBestAlign: isTooltip,
+			getOffset: isTooltip ? getTooltipOffset : getCenterOffset,
+			isOpen: !!anchorRef,
+			ref: indicatorRef,
+			triggerRef: anchorRef ?? fallbackTriggerRef,
+		},
+		[anchorRef, isTooltip]
+	);
+
+	// `useOverlayPosition` does not expose which side `autoBestAlign`
+	// resolved to, and `getOffset` is only called with the initial
+	// points, so the resolved alignment cannot be read from there.
+	// Compare bounding rects after each alignment pass — observed via
+	// `observeRect` — to toggle the flipped modifier class so the
+	// tooltip arrow renders on the side facing the anchor. Skipped for
+	// the centered placement, which has no arrow to flip.
+
+	useEffect(() => {
+		if (!isTooltip || !anchorRef?.current || !indicatorRef.current) {
+			return;
+		}
+
+		const anchor = anchorRef.current;
+		const indicator = indicatorRef.current;
+
+		function update() {
+			const anchorRect = anchor.getBoundingClientRect();
+			const indicatorRect = indicator.getBoundingClientRect();
+			const isFlipped =
+				indicatorRect.left + indicatorRect.width / 2 <
+				anchorRect.left + anchorRect.width / 2;
+
+			setFlipped((previous) =>
+				previous === isFlipped ? previous : isFlipped
+			);
+		}
+
+		update();
+
+		return observeRect(indicator, update);
+	}, [anchorRef, isTooltip]);
+
+	// Toggle the indicator's visibility based on focus-within of the
+	// anchor element. Anchors that contain the focusable interaction
+	// surface (the input, the trigger, the nav, the open panel) cover
+	// the keyboard-engagement signal cleanly through `contains()` —
+	// including for popups whose menus get portaled, as long as the
+	// consumer points `anchorRef` at the focus-receiving element. CSS
+	// hides the indicator with `visibility: hidden` so the screen-reader
+	// description stays out of the accessibility tree until the user
+	// engages the component with the keyboard.
+
+	useEffect(() => {
+		if (!anchorRef?.current) {
+			return;
+		}
+
+		const anchor = anchorRef.current;
+
+		function update() {
+			setHasFocusWithin(anchor.contains(document.activeElement));
+		}
+
+		update();
+
+		document.addEventListener('focusin', update);
+		document.addEventListener('focusout', update);
+
+		return () => {
+			document.removeEventListener('focusin', update);
+			document.removeEventListener('focusout', update);
+		};
+	}, [anchorRef]);
+
 	return (
 		<div
 			{...otherProps}
@@ -59,8 +201,20 @@ export function KeyboardArrowsIndicator({
 			className={classNames(
 				'clay-keyboard-arrows-indicator',
 				`clay-keyboard-arrows-${direction}`,
+				{
+					'clay-keyboard-arrows-indicator-floating': !!anchorRef,
+					'clay-keyboard-arrows-indicator-floating-centered':
+						!!anchorRef && !isTooltip,
+					'clay-keyboard-arrows-indicator-floating-flipped':
+						!!anchorRef && isTooltip && flipped,
+					'clay-keyboard-arrows-indicator-floating-hidden':
+						!!anchorRef && !hasFocusWithin,
+					'clay-keyboard-arrows-indicator-floating-tooltip':
+						!!anchorRef && isTooltip,
+				},
 				className
 			)}
+			ref={indicatorRef}
 			role="img"
 		>
 			<ClayIcon spritemap={spritemap} symbol="arrows-all" />

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/keyboard-arrows-indicator/KeyboardArrowsIndicator.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/keyboard-arrows-indicator/KeyboardArrowsIndicator.tsx
@@ -8,11 +8,11 @@ import {observeRect, useOverlayPosition} from '@clayui/shared';
 import classNames from 'classnames';
 import React, {useEffect, useRef, useState} from 'react';
 
-import type {AlignPoints} from '@clayui/shared';
-
 export type Direction = 'all' | 'horizontal' | 'vertical';
 
-export type Placement = 'center' | 'tooltip';
+export type Placement = 'center' | 'tooltip' | 'tooltip-top';
+
+type Offset = [number, number];
 
 export type Props = {
 
@@ -40,10 +40,12 @@ export type Props = {
 	/**
 	 * How the indicator is positioned relative to `anchorRef`. `tooltip`
 	 * (default) places it alongside the anchor with a directional arrow
-	 * that flips to fit the viewport. `center` overlays the indicator on
-	 * the anchor's center with no arrow — useful for narrow interactive
-	 * elements such as a resize handle, where the indicator should mark
-	 * the surface itself rather than point at it.
+	 * at the vertical center, flipping to fit the viewport. `tooltip-top`
+	 * uses the same arrow but anchors near the anchor's top edge — useful
+	 * for tall containers like a vertical navigation, where a centered
+	 * tooltip would sit far from the items the user is reading. `center`
+	 * overlays the indicator on the anchor's center with no arrow —
+	 * useful for narrow interactive elements such as a resize handle.
 	 */
 	placement?: Placement;
 
@@ -54,34 +56,27 @@ export type Props = {
 	spritemap?: string;
 } & Omit<React.HTMLAttributes<HTMLDivElement>, 'aria-hidden' | 'role'>;
 
-// `alignmentPosition: 2` is `RightCenter` — anchor's center-right aligns
-// to the indicator's center-left. `autoBestAlign` flips to `LeftCenter`
-// when the indicator would overflow on the right; `dom-align` negates
-// the horizontal offset internally during that flip, so a single
-// `getOffset` value drives both sides. The default 4px gap from the
-// shared offset map is too tight for triggers that render a focus ring
-// around their bounding box, so the offset is widened.
+// `RightCenter` (2) anchors the indicator's center-left to the anchor's
+// center-right; `RightTop` (8) anchors the indicator's top-left to the
+// anchor's top-right. `autoBestAlign` flips horizontally when overflow
+// would push the indicator off-screen — `dom-align` negates the
+// horizontal offset internally during that flip, so a single
+// `getOffset` value drives both sides.
 
 const TOOLTIP_ALIGNMENT_POSITION = 2;
 
-const TOOLTIP_OFFSET = 12;
+const TOOLTIP_TOP_ALIGNMENT_POSITION = 8;
 
-// `['cc', 'cc']` aligns the indicator's center to the anchor's center
-// for the overlay-style placement used by narrow interactive elements
-// like the resize handle. `dom-align` accepts arbitrary point strings
-// at runtime, but the shared `AlignPoints` type only enumerates the
-// entries in `ALIGN_MAP`, so the array is cast at the call site.
+function getTooltipOffset(): Offset {
 
-const CENTER_ALIGNMENT_POINTS = ['cc', 'cc'] as const;
+	// The default 4px gap from the shared offset map is too tight for
+	// triggers that render a focus ring around their bounding box.
 
-const NO_OFFSET: [number, number] = [0, 0];
-
-function getTooltipOffset(): [number, number] {
-	return [TOOLTIP_OFFSET, 0];
+	return [12, 0];
 }
 
-function getCenterOffset(): [number, number] {
-	return NO_OFFSET;
+function getCenterOffset(): Offset {
+	return [0, 0];
 }
 
 export function KeyboardArrowsIndicator({
@@ -98,21 +93,24 @@ export function KeyboardArrowsIndicator({
 	const [flipped, setFlipped] = useState(false);
 	const [hasFocusWithin, setHasFocusWithin] = useState(false);
 
-	const isTooltip = placement === 'tooltip';
+	const isTooltip = placement === 'tooltip' || placement === 'tooltip-top';
+	const isCenter = placement === 'center';
 
 	useOverlayPosition(
 		{
 			alignmentByViewport: isTooltip,
 			alignmentPosition: isTooltip
-				? TOOLTIP_ALIGNMENT_POSITION
-				: (CENTER_ALIGNMENT_POINTS as unknown as AlignPoints),
+				? placement === 'tooltip-top'
+					? TOOLTIP_TOP_ALIGNMENT_POSITION
+					: TOOLTIP_ALIGNMENT_POSITION
+				: ['cc', 'cc'],
 			autoBestAlign: isTooltip,
 			getOffset: isTooltip ? getTooltipOffset : getCenterOffset,
 			isOpen: !!anchorRef,
 			ref: indicatorRef,
 			triggerRef: anchorRef ?? fallbackTriggerRef,
 		},
-		[anchorRef, isTooltip]
+		[anchorRef, placement]
 	);
 
 	// `useOverlayPosition` does not expose which side `autoBestAlign`
@@ -189,7 +187,7 @@ export function KeyboardArrowsIndicator({
 				{
 					'clay-keyboard-arrows-indicator-floating': !!anchorRef,
 					'clay-keyboard-arrows-indicator-floating-centered':
-						!!anchorRef && !isTooltip,
+						!!anchorRef && isCenter,
 					'clay-keyboard-arrows-indicator-floating-flipped':
 						!!anchorRef && isTooltip && flipped,
 					'clay-keyboard-arrows-indicator-floating-hidden':

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/keyboard-arrows-indicator/KeyboardArrowsIndicator.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/keyboard-arrows-indicator/KeyboardArrowsIndicator.tsx
@@ -38,13 +38,6 @@ export type Props = {
 	direction: Direction;
 
 	/**
-	 * Localized label announced by assistive technology. Defaults to an
-	 * English phrase derived from `direction`; pass an explicit string to
-	 * localize (e.g. via Liferay's `Liferay.Language.get`).
-	 */
-	label?: string;
-
-	/**
 	 * How the indicator is positioned relative to `anchorRef`. `tooltip`
 	 * (default) places it alongside the anchor with a directional arrow
 	 * that flips to fit the viewport. `center` overlays the indicator on
@@ -59,13 +52,7 @@ export type Props = {
 	 * is provided by an ancestor `Provider`.
 	 */
 	spritemap?: string;
-} & Omit<React.HTMLAttributes<HTMLDivElement>, 'aria-label' | 'role'>;
-
-const DEFAULT_LABELS: Record<Direction, string> = {
-	all: 'Use arrow keys to navigate',
-	horizontal: 'Use left and right arrow keys to navigate',
-	vertical: 'Use up and down arrow keys to navigate',
-};
+} & Omit<React.HTMLAttributes<HTMLDivElement>, 'aria-hidden' | 'role'>;
 
 // `alignmentPosition: 2` is `RightCenter` — anchor's center-right aligns
 // to the indicator's center-left. `autoBestAlign` flips to `LeftCenter`
@@ -101,7 +88,6 @@ export function KeyboardArrowsIndicator({
 	anchorRef,
 	className,
 	direction,
-	label,
 	placement = 'tooltip',
 	spritemap,
 	...otherProps
@@ -197,7 +183,7 @@ export function KeyboardArrowsIndicator({
 	return (
 		<div
 			{...otherProps}
-			aria-label={label ?? DEFAULT_LABELS[direction]}
+			aria-hidden="true"
 			className={classNames(
 				'clay-keyboard-arrows-indicator',
 				`clay-keyboard-arrows-${direction}`,
@@ -215,7 +201,6 @@ export function KeyboardArrowsIndicator({
 				className
 			)}
 			ref={indicatorRef}
-			role="img"
 		>
 			<ClayIcon spritemap={spritemap} symbol="arrows-all" />
 		</div>

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/keyboard-arrows-indicator/KeyboardArrowsIndicator.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/keyboard-arrows-indicator/KeyboardArrowsIndicator.tsx
@@ -149,14 +149,13 @@ export function KeyboardArrowsIndicator({
 	}, [anchorRef, isTooltip]);
 
 	// Toggle the indicator's visibility based on focus-within of the
-	// anchor element. Anchors that contain the focusable interaction
-	// surface (the input, the trigger, the nav, the open panel) cover
-	// the keyboard-engagement signal cleanly through `contains()` —
-	// including for popups whose menus get portaled, as long as the
-	// consumer points `anchorRef` at the focus-receiving element. CSS
-	// hides the indicator with `visibility: hidden` so the screen-reader
-	// description stays out of the accessibility tree until the user
-	// engages the component with the keyboard.
+	// anchor element. Listeners attach to the anchor itself, not the
+	// document — `focusin`/`focusout` bubble from descendants up to the
+	// anchor, so they fire as long as focus crosses the anchor's
+	// subtree. This stays encapsulated and survives consumers like
+	// Table's `FocusWithinProvider` that call `event.stopPropagation()`
+	// at the React root, which would otherwise stop a document-level
+	// listener from ever seeing the event.
 
 	useEffect(() => {
 		if (!anchorRef?.current) {
@@ -171,12 +170,12 @@ export function KeyboardArrowsIndicator({
 
 		update();
 
-		document.addEventListener('focusin', update);
-		document.addEventListener('focusout', update);
+		anchor.addEventListener('focusin', update);
+		anchor.addEventListener('focusout', update);
 
 		return () => {
-			document.removeEventListener('focusin', update);
-			document.removeEventListener('focusout', update);
+			anchor.removeEventListener('focusin', update);
+			anchor.removeEventListener('focusout', update);
 		};
 	}, [anchorRef]);
 

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/keyboard-arrows-indicator/__tests__/KeyboardArrowsIndicator.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/keyboard-arrows-indicator/__tests__/KeyboardArrowsIndicator.tsx
@@ -37,42 +37,16 @@ describe('KeyboardArrowsIndicator', () => {
 		}
 	);
 
-	it.each([
-		['all', 'Use arrow keys to navigate'],
-		['horizontal', 'Use left and right arrow keys to navigate'],
-		['vertical', 'Use up and down arrow keys to navigate'],
-	] as const)(
-		'sets the default aria-label for direction "%s"',
-		(direction, expected) => {
-			const {container} = render(
-				<KeyboardArrowsIndicator direction={direction} />
-			);
-
-			expect(
-				container.querySelector('.clay-keyboard-arrows-indicator')
-			).toHaveAttribute('aria-label', expected);
-		}
-	);
-
-	it('honors a custom label override', () => {
-		const {container} = render(
-			<KeyboardArrowsIndicator
-				direction="all"
-				label="Press the arrow keys to move focus"
-			/>
-		);
-
-		expect(
-			container.querySelector('.clay-keyboard-arrows-indicator')
-		).toHaveAttribute('aria-label', 'Press the arrow keys to move focus');
-	});
-
-	it('exposes the indicator as an image to assistive technology', () => {
+	it('is hidden from assistive technology as a purely visual hint', () => {
 		const {container} = render(<KeyboardArrowsIndicator direction="all" />);
 
-		expect(
-			container.querySelector('.clay-keyboard-arrows-indicator')
-		).toHaveAttribute('role', 'img');
+		const indicator = container.querySelector(
+			'.clay-keyboard-arrows-indicator'
+		);
+
+		expect(indicator).toHaveAttribute('aria-hidden', 'true');
+		expect(indicator).not.toHaveAttribute('role');
+		expect(indicator).not.toHaveAttribute('aria-label');
 	});
 
 	it('forwards a custom className', () => {

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/keyboard-arrows-indicator/__tests__/KeyboardArrowsIndicator.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/keyboard-arrows-indicator/__tests__/KeyboardArrowsIndicator.tsx
@@ -84,4 +84,35 @@ describe('KeyboardArrowsIndicator', () => {
 			container.querySelector('.clay-keyboard-arrows-indicator')
 		).toHaveClass('my-hint');
 	});
+
+	it('does not apply the floating modifier when no anchorRef is provided', () => {
+		const {container} = render(<KeyboardArrowsIndicator direction="all" />);
+
+		expect(
+			container.querySelector('.clay-keyboard-arrows-indicator')
+		).not.toHaveClass('clay-keyboard-arrows-indicator-floating');
+	});
+
+	it('applies the floating modifier when an anchorRef is provided', () => {
+		function Harness() {
+			const anchorRef = React.useRef<HTMLDivElement>(null);
+
+			return (
+				<>
+					<div ref={anchorRef}>Anchor</div>
+
+					<KeyboardArrowsIndicator
+						anchorRef={anchorRef}
+						direction="vertical"
+					/>
+				</>
+			);
+		}
+
+		const {container} = render(<Harness />);
+
+		expect(
+			container.querySelector('.clay-keyboard-arrows-indicator')
+		).toHaveClass('clay-keyboard-arrows-indicator-floating');
+	});
 });

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/picker/Picker.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/picker/Picker.tsx
@@ -6,6 +6,7 @@
 import Button from '@clayui/button';
 import Icon from '@clayui/icon';
 import {
+	ClayPortal,
 	InternalDispatch,
 	Keys,
 	Overlay,
@@ -24,6 +25,7 @@ import classNames from 'classnames';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 
 import {Collection, useCollection} from '../collection';
+import {KeyboardArrowsIndicator} from '../keyboard-arrows-indicator';
 import {LiveAnnouncer} from '../live-announcer';
 import {Search} from './Search';
 import {PickerContext} from './context';
@@ -111,6 +113,15 @@ type Props<T> = {
 	'disabled'?: boolean;
 
 	/**
+	 * Flag to render the `KeyboardArrowsIndicator` alongside the Picker
+	 * trigger, hinting that up and down arrow keys can be used to navigate
+	 * the option list. The indicator floats to the right of the trigger
+	 * and flips to the left when it would overflow the viewport. It is
+	 * only rendered while the menu is open.
+	 */
+	'displayKeyboardArrowsIndicator'?: boolean;
+
+	/**
 	 * Defines the name of the property key that is used in the items filter
 	 * test.
 	 */
@@ -120,6 +131,14 @@ type Props<T> = {
 	 * The id of the component.
 	 */
 	'id'?: string;
+
+	/**
+	 * Localized `aria-label` for the keyboard arrows indicator. Defaults
+	 * to the indicator's built-in English string when omitted. Pass a
+	 * translated value (e.g. via `Liferay.Language.get`) when the host
+	 * page needs i18n.
+	 */
+	'keyboardArrowsIndicatorLabel'?: string;
 
 	/**
 	 * Messages for the Picker.
@@ -196,9 +215,11 @@ export function Picker<T extends Record<string, any> | string | number>({
 	defaultSelectedKey,
 	direction = 'bottom',
 	disabled,
+	displayKeyboardArrowsIndicator = false,
 	filterKey,
 	id,
 	items,
+	keyboardArrowsIndicatorLabel,
 	messages: externalMessages,
 	native = false,
 	onActiveChange,
@@ -778,6 +799,16 @@ export function Picker<T extends Record<string, any> | string | number>({
 							)}
 					</div>
 				</Overlay>
+			)}
+
+			{active && displayKeyboardArrowsIndicator && (
+				<ClayPortal>
+					<KeyboardArrowsIndicator
+						anchorRef={triggerRef}
+						direction="vertical"
+						label={keyboardArrowsIndicatorLabel}
+					/>
+				</ClayPortal>
 			)}
 		</>
 	);

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/picker/Picker.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/picker/Picker.tsx
@@ -133,14 +133,6 @@ type Props<T> = {
 	'id'?: string;
 
 	/**
-	 * Localized `aria-label` for the keyboard arrows indicator. Defaults
-	 * to the indicator's built-in English string when omitted. Pass a
-	 * translated value (e.g. via `Liferay.Language.get`) when the host
-	 * page needs i18n.
-	 */
-	'keyboardArrowsIndicatorLabel'?: string;
-
-	/**
 	 * Messages for the Picker.
 	 */
 	'messages'?: Partial<PickerMessages>;
@@ -219,7 +211,6 @@ export function Picker<T extends Record<string, any> | string | number>({
 	filterKey,
 	id,
 	items,
-	keyboardArrowsIndicatorLabel,
 	messages: externalMessages,
 	native = false,
 	onActiveChange,
@@ -806,7 +797,6 @@ export function Picker<T extends Record<string, any> | string | number>({
 					<KeyboardArrowsIndicator
 						anchorRef={triggerRef}
 						direction="vertical"
-						label={keyboardArrowsIndicatorLabel}
 					/>
 				</ClayPortal>
 			)}

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/picker/__tests__/BasicRendering.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/picker/__tests__/BasicRendering.tsx
@@ -315,7 +315,7 @@ describe('Picker basic rendering', () => {
 		expect(getByText('4').closest('a')).toBeNull();
 	});
 
-	it('does not render the keyboard arrows indicator by default', () => {
+	it('does not render the keyboard arrows indicator by default', async () => {
 		const {getByRole, queryByRole} = render(
 			<Picker>
 				<Option key="apple">Apple</Option>
@@ -324,14 +324,14 @@ describe('Picker basic rendering', () => {
 			</Picker>
 		);
 
-		userEvent.click(getByRole('combobox'));
+		await userEvent.click(getByRole('combobox'));
 
 		expect(queryByRole('img')).not.toHaveClass(
 			'clay-keyboard-arrows-indicator'
 		);
 	});
 
-	it('renders the keyboard arrows indicator alongside the menu when enabled', () => {
+	it('renders the keyboard arrows indicator alongside the menu when enabled', async () => {
 		const {getByRole} = render(
 			<Picker displayKeyboardArrowsIndicator>
 				<Option key="apple">Apple</Option>
@@ -340,7 +340,7 @@ describe('Picker basic rendering', () => {
 			</Picker>
 		);
 
-		userEvent.click(getByRole('combobox'));
+		await userEvent.click(getByRole('combobox'));
 
 		const indicator = document.querySelector(
 			'.clay-keyboard-arrows-indicator'

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/picker/__tests__/BasicRendering.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/picker/__tests__/BasicRendering.tsx
@@ -352,23 +352,4 @@ describe('Picker basic rendering', () => {
 			'clay-keyboard-arrows-indicator-floating'
 		);
 	});
-
-	it('uses the localized label on the keyboard arrows indicator', () => {
-		const {getByRole} = render(
-			<Picker
-				displayKeyboardArrowsIndicator
-				keyboardArrowsIndicatorLabel="Use up and down to navigate options"
-			>
-				<Option key="apple">Apple</Option>
-
-				<Option key="banana">Banana</Option>
-			</Picker>
-		);
-
-		userEvent.click(getByRole('combobox'));
-
-		expect(
-			document.querySelector('.clay-keyboard-arrows-indicator')
-		).toHaveAttribute('aria-label', 'Use up and down to navigate options');
-	});
 });

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/picker/__tests__/BasicRendering.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/picker/__tests__/BasicRendering.tsx
@@ -314,4 +314,61 @@ describe('Picker basic rendering', () => {
 		expect(getByText('2').closest('a')).toBeNull();
 		expect(getByText('4').closest('a')).toBeNull();
 	});
+
+	it('does not render the keyboard arrows indicator by default', () => {
+		const {getByRole, queryByRole} = render(
+			<Picker>
+				<Option key="apple">Apple</Option>
+
+				<Option key="banana">Banana</Option>
+			</Picker>
+		);
+
+		userEvent.click(getByRole('combobox'));
+
+		expect(queryByRole('img')).not.toHaveClass(
+			'clay-keyboard-arrows-indicator'
+		);
+	});
+
+	it('renders the keyboard arrows indicator alongside the menu when enabled', () => {
+		const {getByRole} = render(
+			<Picker displayKeyboardArrowsIndicator>
+				<Option key="apple">Apple</Option>
+
+				<Option key="banana">Banana</Option>
+			</Picker>
+		);
+
+		userEvent.click(getByRole('combobox'));
+
+		const indicator = document.querySelector(
+			'.clay-keyboard-arrows-indicator'
+		);
+
+		expect(indicator).toBeInTheDocument();
+		expect(indicator).toHaveClass('clay-keyboard-arrows-vertical');
+		expect(indicator).toHaveClass(
+			'clay-keyboard-arrows-indicator-floating'
+		);
+	});
+
+	it('uses the localized label on the keyboard arrows indicator', () => {
+		const {getByRole} = render(
+			<Picker
+				displayKeyboardArrowsIndicator
+				keyboardArrowsIndicatorLabel="Use up and down to navigate options"
+			>
+				<Option key="apple">Apple</Option>
+
+				<Option key="banana">Banana</Option>
+			</Picker>
+		);
+
+		userEvent.click(getByRole('combobox'));
+
+		expect(
+			document.querySelector('.clay-keyboard-arrows-indicator')
+		).toHaveAttribute('aria-label', 'Use up and down to navigate options');
+	});
 });

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/resize-handle/ResizeHandle.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/resize-handle/ResizeHandle.tsx
@@ -3,9 +3,11 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {Keys} from '@clayui/shared';
+import {ClayPortal, Keys} from '@clayui/shared';
 import classnames from 'classnames';
-import React from 'react';
+import React, {useRef} from 'react';
+
+import {KeyboardArrowsIndicator} from '../keyboard-arrows-indicator';
 
 export type Position = 'left' | 'right';
 
@@ -15,6 +17,22 @@ type Props = {
 	 * ID of the element being resized.
 	 */
 	'aria-controls': string;
+
+	/**
+	 * Flag to render the `KeyboardArrowsIndicator` overlaid on the
+	 * center of the resizer, hinting that all four arrow keys are active
+	 * for resizing. The indicator marks the handle itself (no tooltip
+	 * arrow) and is visible while the handle has keyboard focus.
+	 */
+	'displayKeyboardArrowsIndicator'?: boolean;
+
+	/**
+	 * Localized `aria-label` for the keyboard arrows indicator. Defaults
+	 * to the indicator's built-in English string when omitted. Pass a
+	 * translated value (e.g. via `Liferay.Language.get`) when the host
+	 * page needs i18n.
+	 */
+	'keyboardArrowsIndicatorLabel'?: string;
 
 	/**
 	 * The maximum width allowed.
@@ -56,6 +74,8 @@ let keyDownCounter = 0;
 
 export function ResizeHandle({
 	'aria-controls': ariaControls,
+	displayKeyboardArrowsIndicator = false,
+	keyboardArrowsIndicatorLabel,
 	maxWidth,
 	minWidth,
 	onWidthChange,
@@ -64,6 +84,8 @@ export function ResizeHandle({
 	...otherProps
 }: Props) {
 	const positionLeft = position === 'left';
+
+	const resizerRef = useRef<HTMLDivElement>(null);
 
 	const decreaseWidth = (delta = 1) => {
 		const nextWidth = Math.round(width - delta);
@@ -88,100 +110,120 @@ export function ResizeHandle({
 	};
 
 	return (
-		<div
-			aria-label={DEFAULT_ARIA_LABELS[position]}
-			aria-orientation="vertical"
-			aria-valuemax={maxWidth}
-			aria-valuemin={minWidth}
-			aria-valuenow={width}
-			aria-valuetext={`${width}px`}
-			{...otherProps}
-			aria-controls={ariaControls}
-			className={classnames('c-horizontal-resizer', {
-				'c-horizontal-resizer-end':
-					document.dir === 'rtl' ? positionLeft : !positionLeft,
-			})}
-			onKeyDown={(event: React.KeyboardEvent<HTMLDivElement>) => {
-				const delta = keyDownCounter > 7 ? 10 : 1;
+		<>
+			<div
+				aria-label={DEFAULT_ARIA_LABELS[position]}
+				aria-orientation="vertical"
+				aria-valuemax={maxWidth}
+				aria-valuemin={minWidth}
+				aria-valuenow={width}
+				aria-valuetext={`${width}px`}
+				{...otherProps}
+				aria-controls={ariaControls}
+				className={classnames('c-horizontal-resizer', {
+					'c-horizontal-resizer-end':
+						document.dir === 'rtl' ? positionLeft : !positionLeft,
+				})}
+				onKeyDown={(event: React.KeyboardEvent<HTMLDivElement>) => {
+					const delta = keyDownCounter > 7 ? 10 : 1;
 
-				keyDownCounter++;
+					keyDownCounter++;
 
-				switch (event.key) {
-					case Keys.Down: {
-						decreaseWidth(delta);
-
-						break;
-					}
-					case Keys.Left: {
-						if (positionLeft) {
+					switch (event.key) {
+						case Keys.Down: {
 							decreaseWidth(delta);
+
+							break;
 						}
-						else {
+						case Keys.Left: {
+							if (positionLeft) {
+								decreaseWidth(delta);
+							}
+							else {
+								increaseWidth(delta);
+							}
+
+							break;
+						}
+						case Keys.Right: {
+							if (positionLeft) {
+								increaseWidth(delta);
+							}
+							else {
+								decreaseWidth(delta);
+							}
+
+							break;
+						}
+						case Keys.Up: {
+							increaseWidth(delta);
+
+							break;
+						}
+						default: {
+							break;
+						}
+					}
+				}}
+				onKeyUp={() => {
+					keyDownCounter = 0;
+				}}
+				onPointerDown={(event) => {
+					const startXPos = event.pageX;
+
+					function onResizerMove(event: any) {
+						const delta = Math.abs(event.pageX - startXPos);
+
+						if (
+							(event.pageX >= startXPos && positionLeft) ||
+							(event.pageX < startXPos && !positionLeft)
+						) {
 							increaseWidth(delta);
 						}
-
-						break;
-					}
-					case Keys.Right: {
-						if (positionLeft) {
-							increaseWidth(delta);
-						}
-						else {
+						else if (
+							(event.pageX < startXPos && positionLeft) ||
+							(event.pageX >= startXPos && !positionLeft)
+						) {
 							decreaseWidth(delta);
 						}
-
-						break;
 					}
-					case Keys.Up: {
-						increaseWidth(delta);
 
-						break;
+					function removeResizerEvents() {
+						document.removeEventListener(
+							'pointermove',
+							onResizerMove
+						);
+
+						document.removeEventListener(
+							'pointerup',
+							removeResizerEvents
+						);
 					}
-					default: {
-						break;
+
+					if (event.button === MAIN_MOUSE_BUTTON) {
+						document.addEventListener('pointermove', onResizerMove);
+
+						document.addEventListener(
+							'pointerup',
+							removeResizerEvents
+						);
 					}
-				}
-			}}
-			onKeyUp={() => {
-				keyDownCounter = 0;
-			}}
-			onPointerDown={(event) => {
-				const startXPos = event.pageX;
+				}}
+				ref={resizerRef}
+				role="separator"
+				tabIndex={0}
+			/>
 
-				function onResizerMove(event: any) {
-					const delta = Math.abs(event.pageX - startXPos);
-
-					if (
-						(event.pageX >= startXPos && positionLeft) ||
-						(event.pageX < startXPos && !positionLeft)
-					) {
-						increaseWidth(delta);
-					}
-					else if (
-						(event.pageX < startXPos && positionLeft) ||
-						(event.pageX >= startXPos && !positionLeft)
-					) {
-						decreaseWidth(delta);
-					}
-				}
-
-				function removeResizerEvents() {
-					document.removeEventListener('pointermove', onResizerMove);
-
-					document.removeEventListener(
-						'pointerup',
-						removeResizerEvents
-					);
-				}
-
-				if (event.button === MAIN_MOUSE_BUTTON) {
-					document.addEventListener('pointermove', onResizerMove);
-
-					document.addEventListener('pointerup', removeResizerEvents);
-				}
-			}}
-			role="separator"
-			tabIndex={0}
-		/>
+			{displayKeyboardArrowsIndicator && (
+				<ClayPortal>
+					<KeyboardArrowsIndicator
+						anchorRef={resizerRef}
+						direction="all"
+						label={keyboardArrowsIndicatorLabel}
+						placement="center"
+					/>
+				</ClayPortal>
+			)}
+		</>
 	);
 }

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/resize-handle/ResizeHandle.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/resize-handle/ResizeHandle.tsx
@@ -27,14 +27,6 @@ type Props = {
 	'displayKeyboardArrowsIndicator'?: boolean;
 
 	/**
-	 * Localized `aria-label` for the keyboard arrows indicator. Defaults
-	 * to the indicator's built-in English string when omitted. Pass a
-	 * translated value (e.g. via `Liferay.Language.get`) when the host
-	 * page needs i18n.
-	 */
-	'keyboardArrowsIndicatorLabel'?: string;
-
-	/**
 	 * The maximum width allowed.
 	 */
 	'maxWidth': number;
@@ -75,7 +67,6 @@ let keyDownCounter = 0;
 export function ResizeHandle({
 	'aria-controls': ariaControls,
 	displayKeyboardArrowsIndicator = false,
-	keyboardArrowsIndicatorLabel,
 	maxWidth,
 	minWidth,
 	onWidthChange,
@@ -219,7 +210,6 @@ export function ResizeHandle({
 					<KeyboardArrowsIndicator
 						anchorRef={resizerRef}
 						direction="all"
-						label={keyboardArrowsIndicatorLabel}
 						placement="center"
 					/>
 				</ClayPortal>

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/resize-handle/__tests__/ResizeHandle.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/resize-handle/__tests__/ResizeHandle.tsx
@@ -210,25 +210,6 @@ describe('ResizeHandle', () => {
 				'clay-keyboard-arrows-indicator-floating-tooltip'
 			);
 		});
-
-		test('uses the localized label on the indicator', () => {
-			render(
-				<ResizeHandle
-					data-testid="resizer"
-					displayKeyboardArrowsIndicator
-					keyboardArrowsIndicatorLabel="Use arrow keys to resize"
-					maxWidth={600}
-					minWidth={200}
-					onWidthChange={jest.fn()}
-					position="left"
-					width={500}
-				/>
-			);
-
-			expect(
-				document.body.querySelector('.clay-keyboard-arrows-indicator')
-			).toHaveAttribute('aria-label', 'Use arrow keys to resize');
-		});
 	});
 });
 

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/resize-handle/__tests__/ResizeHandle.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/resize-handle/__tests__/ResizeHandle.tsx
@@ -171,6 +171,65 @@ describe('ResizeHandle', () => {
 			);
 		});
 	});
+
+	describe('keyboard arrows indicator', () => {
+		test('does not render the indicator by default', () => {
+			renderComponent({});
+
+			expect(
+				document.body.querySelector('.clay-keyboard-arrows-indicator')
+			).not.toBeInTheDocument();
+		});
+
+		test('renders the centered indicator with direction "all" when enabled', () => {
+			render(
+				<ResizeHandle
+					data-testid="resizer"
+					displayKeyboardArrowsIndicator
+					maxWidth={600}
+					minWidth={200}
+					onWidthChange={jest.fn()}
+					position="left"
+					width={500}
+				/>
+			);
+
+			const indicator = document.body.querySelector(
+				'.clay-keyboard-arrows-indicator'
+			);
+
+			expect(indicator).toBeInTheDocument();
+			expect(indicator).toHaveClass('clay-keyboard-arrows-all');
+			expect(indicator).toHaveClass(
+				'clay-keyboard-arrows-indicator-floating'
+			);
+			expect(indicator).toHaveClass(
+				'clay-keyboard-arrows-indicator-floating-centered'
+			);
+			expect(indicator).not.toHaveClass(
+				'clay-keyboard-arrows-indicator-floating-tooltip'
+			);
+		});
+
+		test('uses the localized label on the indicator', () => {
+			render(
+				<ResizeHandle
+					data-testid="resizer"
+					displayKeyboardArrowsIndicator
+					keyboardArrowsIndicatorLabel="Use arrow keys to resize"
+					maxWidth={600}
+					minWidth={200}
+					onWidthChange={jest.fn()}
+					position="left"
+					width={500}
+				/>
+			);
+
+			expect(
+				document.body.querySelector('.clay-keyboard-arrows-indicator')
+			).toHaveAttribute('aria-label', 'Use arrow keys to resize');
+		});
+	});
 });
 
 function simulateMouseEvent(

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/table/Table.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/table/Table.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {sub, useControlledState, useId} from '@clayui/shared';
+import {ClayPortal, sub, useControlledState, useId} from '@clayui/shared';
 import RootTable from '@clayui/table';
 import classNames from 'classnames';
 import React, {useCallback, useRef, useState} from 'react';
@@ -11,6 +11,7 @@ import {createPortal} from 'react-dom';
 
 import {FocusWithinProvider} from '../aria';
 import {useForwardRef} from '../hooks';
+import {KeyboardArrowsIndicator} from '../keyboard-arrows-indicator';
 import {LiveAnnouncer} from '../live-announcer';
 import {Sorting, TableContext} from './context';
 import {useTreeNavigation} from './useTreeNavigation';
@@ -60,6 +61,17 @@ interface IProps extends React.HTMLAttributes<HTMLTableElement> {
 	 * Default value for visible columns in the table (uncontrolled).
 	 */
 	defaultVisibleColumns?: Map<React.Key, number>;
+
+	/**
+	 * Flag to render the `KeyboardArrowsIndicator` alongside the table,
+	 * hinting that all four arrow keys are active for navigating the
+	 * grid (up and down between rows, left and right between cells and
+	 * to collapse or expand nested rows). The indicator floats to the
+	 * right of the table and flips to the left when it would overflow
+	 * the viewport. It is only rendered when `nestedKey` is set, since
+	 * arrow-key navigation is exclusive to the treegrid mode.
+	 */
+	displayKeyboardArrowsIndicator?: boolean;
 
 	/**
 	 * The currently expanded keys in the collection (controlled).
@@ -187,6 +199,7 @@ export const Table = React.forwardRef(
 			defaultExpandedKeys = defaultSet,
 			defaultSort,
 			defaultVisibleColumns = new Map(),
+			displayKeyboardArrowsIndicator = false,
 			expandedKeys: externalExpandedKeys,
 			itemIdKey = 'id',
 			messages = {
@@ -352,6 +365,15 @@ export const Table = React.forwardRef(
 						{messages!.sortDescription}
 					</div>,
 					document.body
+				)}
+
+				{nestedKey && displayKeyboardArrowsIndicator && (
+					<ClayPortal>
+						<KeyboardArrowsIndicator
+							anchorRef={ref}
+							direction="all"
+						/>
+					</ClayPortal>
 				)}
 			</RootTable>
 		);

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/table/__tests__/IncrementalInteractions.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/table/__tests__/IncrementalInteractions.tsx
@@ -890,5 +890,117 @@ describe('Table incremental interactions', () => {
 				expect(firstRow).toHaveFocus();
 			});
 		});
+
+		describe('keyboard arrows indicator', () => {
+			it('does not render the indicator by default', () => {
+				render(
+					<Table columnsVisibility={false} nestedKey="children">
+						<Head items={columns}>
+							{(column) => (
+								<Cell key={column.id}>{column.name}</Cell>
+							)}
+						</Head>
+
+						<Body defaultItems={itemsTree}>
+							{(row) => (
+								<Row items={columns}>
+									{(column) => (
+										<Cell key={`${row.id}:${column.id}`}>
+
+											{/** @ts-ignore */}
+
+											{row[column.id]}
+										</Cell>
+									)}
+								</Row>
+							)}
+						</Body>
+					</Table>
+				);
+
+				expect(
+					document.body.querySelector(
+						'.clay-keyboard-arrows-indicator'
+					)
+				).not.toBeInTheDocument();
+			});
+
+			it('renders the floating indicator with direction "all" when enabled', () => {
+				render(
+					<Table
+						columnsVisibility={false}
+						displayKeyboardArrowsIndicator
+						nestedKey="children"
+					>
+						<Head items={columns}>
+							{(column) => (
+								<Cell key={column.id}>{column.name}</Cell>
+							)}
+						</Head>
+
+						<Body defaultItems={itemsTree}>
+							{(row) => (
+								<Row items={columns}>
+									{(column) => (
+										<Cell key={`${row.id}:${column.id}`}>
+
+											{/** @ts-ignore */}
+
+											{row[column.id]}
+										</Cell>
+									)}
+								</Row>
+							)}
+						</Body>
+					</Table>
+				);
+
+				const indicator = document.body.querySelector(
+					'.clay-keyboard-arrows-indicator'
+				);
+
+				expect(indicator).toBeInTheDocument();
+				expect(indicator).toHaveClass('clay-keyboard-arrows-all');
+				expect(indicator).toHaveClass(
+					'clay-keyboard-arrows-indicator-floating'
+				);
+			});
+
+			it('does not render the indicator when nestedKey is omitted', () => {
+				render(
+					<Table
+						columnsVisibility={false}
+						displayKeyboardArrowsIndicator
+					>
+						<Head items={columns}>
+							{(column) => (
+								<Cell key={column.id}>{column.name}</Cell>
+							)}
+						</Head>
+
+						<Body defaultItems={itemsTree}>
+							{(row) => (
+								<Row items={columns}>
+									{(column) => (
+										<Cell key={`${row.id}:${column.id}`}>
+
+											{/** @ts-ignore */}
+
+											{row[column.id]}
+										</Cell>
+									)}
+								</Row>
+							)}
+						</Body>
+					</Table>
+				);
+
+				expect(
+					document.body.querySelector(
+						'.clay-keyboard-arrows-indicator'
+					)
+				).not.toBeInTheDocument();
+			});
+		});
 	});
 });

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/vertical-bar/VerticalBar.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/vertical-bar/VerticalBar.tsx
@@ -188,6 +188,7 @@ export function VerticalBar({
 					<KeyboardArrowsIndicator
 						anchorRef={rootRef}
 						direction="vertical"
+						placement="tooltip-top"
 					/>
 				</ClayPortal>
 			)}

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/vertical-bar/VerticalBar.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/vertical-bar/VerticalBar.tsx
@@ -72,14 +72,6 @@ type Props = {
 	displayKeyboardArrowsIndicator?: boolean;
 
 	/**
-	 * Localized `aria-label` for the keyboard arrows indicator. Defaults
-	 * to the indicator's built-in English string when omitted. Pass a
-	 * translated value (e.g. via `Liferay.Language.get`) when the host
-	 * page needs i18n.
-	 */
-	keyboardArrowsIndicatorLabel?: string;
-
-	/**
 	 * Callback is called when the active state changes (controlled).
 	 */
 	onActiveChange?: InternalDispatch<React.Key | null>;
@@ -124,7 +116,6 @@ export function VerticalBar({
 	defaultActive = null,
 	defaultPanelWidth = 320,
 	displayKeyboardArrowsIndicator = false,
-	keyboardArrowsIndicatorLabel,
 	onActiveChange,
 	onPanelWidthChange,
 	panelWidth: externalPanelWidth,
@@ -197,7 +188,6 @@ export function VerticalBar({
 					<KeyboardArrowsIndicator
 						anchorRef={rootRef}
 						direction="vertical"
-						label={keyboardArrowsIndicatorLabel}
 					/>
 				</ClayPortal>
 			)}

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/vertical-bar/VerticalBar.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/vertical-bar/VerticalBar.tsx
@@ -3,10 +3,16 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {InternalDispatch, useControlledState, useId} from '@clayui/shared';
+import {
+	ClayPortal,
+	InternalDispatch,
+	useControlledState,
+	useId,
+} from '@clayui/shared';
 import classNames from 'classnames';
-import React from 'react';
+import React, {useRef} from 'react';
 
+import {KeyboardArrowsIndicator} from '../keyboard-arrows-indicator';
 import {Bar} from './Bar';
 import {Content} from './Content';
 import {Item} from './Item';
@@ -56,6 +62,24 @@ type Props = {
 	defaultPanelWidth?: number;
 
 	/**
+	 * Flag to render the `KeyboardArrowsIndicator` alongside the
+	 * component, hinting that up and down arrow keys can be used to step
+	 * between the bar items. The indicator anchors to the outer
+	 * `c-slideout` wrapper so it follows the expanded surface when a
+	 * panel opens, and flips to the opposite side when it would overflow
+	 * the viewport. Visible only while the component has keyboard focus.
+	 */
+	displayKeyboardArrowsIndicator?: boolean;
+
+	/**
+	 * Localized `aria-label` for the keyboard arrows indicator. Defaults
+	 * to the indicator's built-in English string when omitted. Pass a
+	 * translated value (e.g. via `Liferay.Language.get`) when the host
+	 * page needs i18n.
+	 */
+	keyboardArrowsIndicatorLabel?: string;
+
+	/**
 	 * Callback is called when the active state changes (controlled).
 	 */
 	onActiveChange?: InternalDispatch<React.Key | null>;
@@ -99,6 +123,8 @@ export function VerticalBar({
 	className,
 	defaultActive = null,
 	defaultPanelWidth = 320,
+	displayKeyboardArrowsIndicator = false,
+	keyboardArrowsIndicatorLabel,
 	onActiveChange,
 	onPanelWidthChange,
 	panelWidth: externalPanelWidth,
@@ -120,6 +146,8 @@ export function VerticalBar({
 
 	const [panelNext, setPanelNext] = React.useState<React.Key | null>(null);
 
+	const rootRef = useRef<HTMLDivElement>(null);
+
 	const [panelWidth, setPanelWidth] = useControlledState({
 		defaultName: 'defaultPanelWidth',
 		defaultValue: defaultPanelWidth,
@@ -130,33 +158,50 @@ export function VerticalBar({
 	});
 
 	return (
-		<div
-			className={classNames('c-slideout c-slideout-shown', className, {
-				'c-slideout-absolute': absolute,
-				'c-slideout-end': position === 'right',
-				'c-slideout-fixed': !absolute,
-				'c-slideout-start sidenav-start': position === 'left',
-			})}
-		>
-			<VerticalBarContext.Provider
-				value={{
-					activation,
-					activePanel,
-					id: `${id}-verticalbar`,
-					onActivePanel: setActivePanel,
-					onPanelWidthChange: setPanelWidth,
-					panelNext,
-					panelWidth,
-					panelWidthMax,
-					panelWidthMin,
-					position,
-					resize,
-					setPanelNext,
-				}}
+		<>
+			<div
+				className={classNames(
+					'c-slideout c-slideout-shown',
+					className,
+					{
+						'c-slideout-absolute': absolute,
+						'c-slideout-end': position === 'right',
+						'c-slideout-fixed': !absolute,
+						'c-slideout-start sidenav-start': position === 'left',
+					}
+				)}
+				ref={rootRef}
 			>
-				{children}
-			</VerticalBarContext.Provider>
-		</div>
+				<VerticalBarContext.Provider
+					value={{
+						activation,
+						activePanel,
+						id: `${id}-verticalbar`,
+						onActivePanel: setActivePanel,
+						onPanelWidthChange: setPanelWidth,
+						panelNext,
+						panelWidth,
+						panelWidthMax,
+						panelWidthMin,
+						position,
+						resize,
+						setPanelNext,
+					}}
+				>
+					{children}
+				</VerticalBarContext.Provider>
+			</div>
+
+			{displayKeyboardArrowsIndicator && (
+				<ClayPortal>
+					<KeyboardArrowsIndicator
+						anchorRef={rootRef}
+						direction="vertical"
+						label={keyboardArrowsIndicatorLabel}
+					/>
+				</ClayPortal>
+			)}
+		</>
 	);
 }
 

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/vertical-bar/__tests__/IncrementalInteractions.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/vertical-bar/__tests__/IncrementalInteractions.tsx
@@ -261,20 +261,5 @@ describe('VerticalBar incremental interactions', () => {
 				document.body.querySelector('.clay-keyboard-arrows-indicator')
 			).toBeInTheDocument();
 		});
-
-		it('uses the localized label on the indicator', () => {
-			renderWithIndicator({
-				displayKeyboardArrowsIndicator: true,
-				keyboardArrowsIndicatorLabel:
-					'Use up and down arrow keys to navigate the bar items',
-			});
-
-			expect(
-				document.body.querySelector('.clay-keyboard-arrows-indicator')
-			).toHaveAttribute(
-				'aria-label',
-				'Use up and down arrow keys to navigate the bar items'
-			);
-		});
 	});
 });

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/vertical-bar/__tests__/IncrementalInteractions.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/vertical-bar/__tests__/IncrementalInteractions.tsx
@@ -200,4 +200,81 @@ describe('VerticalBar incremental interactions', () => {
 			expect(tagPanel.classList).toContain('c-slideout-show');
 		});
 	});
+
+	describe('keyboard arrows indicator', () => {
+		function renderWithIndicator(extraProps = {}) {
+			return render(
+				<VerticalBar {...extraProps}>
+					<VerticalBar.Content>
+						<VerticalBar.Panel>Tag</VerticalBar.Panel>
+
+						<VerticalBar.Panel>Message</VerticalBar.Panel>
+					</VerticalBar.Content>
+
+					<VerticalBar.Bar>
+						<VerticalBar.Item>
+							<Button aria-label="Tag" displayType={null}>
+								<Icon spritemap={spritemap} symbol="tag" />
+							</Button>
+						</VerticalBar.Item>
+
+						<VerticalBar.Item>
+							<Button aria-label="Message" displayType={null}>
+								<Icon spritemap={spritemap} symbol="message" />
+							</Button>
+						</VerticalBar.Item>
+					</VerticalBar.Bar>
+				</VerticalBar>
+			);
+		}
+
+		it('does not render the indicator by default', () => {
+			renderWithIndicator();
+
+			expect(
+				document.body.querySelector('.clay-keyboard-arrows-indicator')
+			).not.toBeInTheDocument();
+		});
+
+		it('renders the floating indicator alongside the bar when enabled', () => {
+			renderWithIndicator({displayKeyboardArrowsIndicator: true});
+
+			const indicator = document.body.querySelector(
+				'.clay-keyboard-arrows-indicator'
+			);
+
+			expect(indicator).toBeInTheDocument();
+			expect(indicator).toHaveClass('clay-keyboard-arrows-vertical');
+			expect(indicator).toHaveClass(
+				'clay-keyboard-arrows-indicator-floating'
+			);
+		});
+
+		it('keeps the indicator visible after a panel opens', () => {
+			const {getByLabelText} = renderWithIndicator({
+				displayKeyboardArrowsIndicator: true,
+			});
+
+			fireEvent.click(getByLabelText('Tag'));
+
+			expect(
+				document.body.querySelector('.clay-keyboard-arrows-indicator')
+			).toBeInTheDocument();
+		});
+
+		it('uses the localized label on the indicator', () => {
+			renderWithIndicator({
+				displayKeyboardArrowsIndicator: true,
+				keyboardArrowsIndicatorLabel:
+					'Use up and down arrow keys to navigate the bar items',
+			});
+
+			expect(
+				document.body.querySelector('.clay-keyboard-arrows-indicator')
+			).toHaveAttribute(
+				'aria-label',
+				'Use up and down arrow keys to navigate the bar items'
+			);
+		});
+	});
 });

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/vertical-nav/VerticalNav.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/vertical-nav/VerticalNav.tsx
@@ -96,14 +96,6 @@ type Props<T extends Record<string, any> | string> = {
 	'items'?: Array<T>;
 
 	/**
-	 * Localized `aria-label` for the keyboard arrows indicator. Defaults
-	 * to the indicator's built-in English string when omitted. Pass a
-	 * translated value (e.g. via `Liferay.Language.get`) when the host
-	 * page needs i18n.
-	 */
-	'keyboardArrowsIndicatorLabel'?: string;
-
-	/**
 	 * Flag to indicate if `menubar-vertical-expand-lg` class is applied.
 	 * @deprecated Use "size" to determine the desired breakpoint
 	 */
@@ -186,7 +178,6 @@ function VerticalNav<T extends Record<string, any> | string>({
 	'expandedKeys': externalExpandedKeys,
 	'itemAriaCurrent': ariaCurrent = true,
 	items,
-	keyboardArrowsIndicatorLabel,
 	large,
 	nestMargins,
 	onExpandedChange,
@@ -380,7 +371,6 @@ function VerticalNav<T extends Record<string, any> | string>({
 					<KeyboardArrowsIndicator
 						anchorRef={containerRef}
 						direction="all"
-						label={keyboardArrowsIndicatorLabel}
 					/>
 				</ClayPortal>
 			)}

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/vertical-nav/VerticalNav.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/vertical-nav/VerticalNav.tsx
@@ -5,6 +5,7 @@
 
 import Icon from '@clayui/icon';
 import {
+	ClayPortal,
 	InternalDispatch,
 	useControlledState,
 	useNavigation,
@@ -14,6 +15,7 @@ import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import warning from 'warning';
 
 import {Collection, useCollection} from '../collection';
+import {KeyboardArrowsIndicator} from '../keyboard-arrows-indicator';
 import {Nav} from '../nav';
 import {Item} from './Item';
 import {Trigger} from './Trigger';
@@ -63,6 +65,15 @@ type Props<T extends Record<string, any> | string> = {
 	'defaultExpandedKeys'?: Set<React.Key>;
 
 	/**
+	 * Flag to render the `KeyboardArrowsIndicator` alongside the
+	 * navigation, hinting that all four arrow keys are active: up and
+	 * down to step between items, left and right to collapse and expand
+	 * tree nodes. The indicator floats to the right of the nav and flips
+	 * to the left when it would overflow the viewport.
+	 */
+	'displayKeyboardArrowsIndicator'?: boolean;
+
+	/**
 	 * Determines the Vertical Nav variant to use.
 	 * @default transparent
 	 */
@@ -83,6 +94,14 @@ type Props<T extends Record<string, any> | string> = {
 	 * Property to inform the dynamic data of the tree.
 	 */
 	'items'?: Array<T>;
+
+	/**
+	 * Localized `aria-label` for the keyboard arrows indicator. Defaults
+	 * to the indicator's built-in English string when omitted. Pass a
+	 * translated value (e.g. via `Liferay.Language.get`) when the host
+	 * page needs i18n.
+	 */
+	'keyboardArrowsIndicatorLabel'?: string;
 
 	/**
 	 * Flag to indicate if `menubar-vertical-expand-lg` class is applied.
@@ -161,11 +180,13 @@ function VerticalNav<T extends Record<string, any> | string>({
 	children,
 	collapse,
 	decorated,
+	displayKeyboardArrowsIndicator = false,
 	displayType = 'transparent',
 	defaultExpandedKeys = new Set(),
 	'expandedKeys': externalExpandedKeys,
 	'itemAriaCurrent': ariaCurrent = true,
 	items,
+	keyboardArrowsIndicatorLabel,
 	large,
 	nestMargins,
 	onExpandedChange,
@@ -353,6 +374,16 @@ function VerticalNav<T extends Record<string, any> | string>({
 			)}
 
 			{!collapse && content}
+
+			{displayKeyboardArrowsIndicator && (
+				<ClayPortal>
+					<KeyboardArrowsIndicator
+						anchorRef={containerRef}
+						direction="all"
+						label={keyboardArrowsIndicatorLabel}
+					/>
+				</ClayPortal>
+			)}
 		</nav>
 	);
 }

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/vertical-nav/VerticalNav.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/vertical-nav/VerticalNav.tsx
@@ -371,6 +371,7 @@ function VerticalNav<T extends Record<string, any> | string>({
 					<KeyboardArrowsIndicator
 						anchorRef={containerRef}
 						direction="all"
+						placement="tooltip-top"
 					/>
 				</ClayPortal>
 			)}

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/vertical-nav/__tests__/BasicRendering.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/vertical-nav/__tests__/BasicRendering.tsx
@@ -114,4 +114,45 @@ describe('VerticalNav basic rendering', () => {
 			}
 		});
 	});
+
+	describe('keyboard arrows indicator', () => {
+		it('does not render the indicator by default', () => {
+			const {container} = renderStaticWithProps();
+
+			expect(
+				container.querySelector('.clay-keyboard-arrows-indicator')
+			).not.toBeInTheDocument();
+		});
+
+		it('renders the floating indicator with direction "all" when enabled', () => {
+			const {container} = renderStaticWithProps({
+				displayKeyboardArrowsIndicator: true,
+			});
+
+			const indicator = container.querySelector(
+				'.clay-keyboard-arrows-indicator'
+			);
+
+			expect(indicator).toBeInTheDocument();
+			expect(indicator).toHaveClass('clay-keyboard-arrows-all');
+			expect(indicator).toHaveClass(
+				'clay-keyboard-arrows-indicator-floating'
+			);
+		});
+
+		it('uses the localized label on the indicator', () => {
+			const {container} = renderStaticWithProps({
+				displayKeyboardArrowsIndicator: true,
+				keyboardArrowsIndicatorLabel:
+					'Use arrow keys to navigate the menu',
+			});
+
+			expect(
+				container.querySelector('.clay-keyboard-arrows-indicator')
+			).toHaveAttribute(
+				'aria-label',
+				'Use arrow keys to navigate the menu'
+			);
+		});
+	});
 });

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/vertical-nav/__tests__/BasicRendering.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/vertical-nav/__tests__/BasicRendering.tsx
@@ -139,20 +139,5 @@ describe('VerticalNav basic rendering', () => {
 				'clay-keyboard-arrows-indicator-floating'
 			);
 		});
-
-		it('uses the localized label on the indicator', () => {
-			const {container} = renderStaticWithProps({
-				displayKeyboardArrowsIndicator: true,
-				keyboardArrowsIndicatorLabel:
-					'Use arrow keys to navigate the menu',
-			});
-
-			expect(
-				container.querySelector('.clay-keyboard-arrows-indicator')
-			).toHaveAttribute(
-				'aria-label',
-				'Use arrow keys to navigate the menu'
-			);
-		});
 	});
 });

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/stories/IconSelector.stories.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/stories/IconSelector.stories.tsx
@@ -24,7 +24,6 @@ export function KeyboardArrowsIndicator() {
 			<IconSelector
 				defaultActive
 				displayKeyboardArrowsIndicator
-				keyboardArrowsIndicatorLabel="Use up and down arrow keys to step through the icons"
 				spritemap={spritemap}
 			/>
 		</div>

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/stories/IconSelector.stories.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/stories/IconSelector.stories.tsx
@@ -18,3 +18,15 @@ export function Default() {
 		</div>
 	);
 }
+export function KeyboardArrowsIndicator() {
+	return (
+		<div>
+			<IconSelector
+				defaultActive
+				displayKeyboardArrowsIndicator
+				keyboardArrowsIndicatorLabel="Use up and down arrow keys to step through the icons"
+				spritemap={spritemap}
+			/>
+		</div>
+	);
+}

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/stories/Picker.stories.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/stories/Picker.stories.tsx
@@ -452,3 +452,37 @@ export function Width() {
 		</div>
 	);
 }
+export function KeyboardArrowsIndicator() {
+	const pickerId = useId();
+	const labelId = useId();
+
+	return (
+		<div style={{width: '200px'}}>
+			<Form.Group>
+				<label htmlFor={pickerId} id={labelId}>
+					Choose a fruit
+				</label>
+
+				<Picker
+					aria-labelledby={labelId}
+					defaultActive
+					displayKeyboardArrowsIndicator
+					id={pickerId}
+					keyboardArrowsIndicatorLabel="Use up and down arrow keys to navigate options"
+				>
+					<Option key="apple">Apple</Option>
+
+					<Option key="banana">Banana</Option>
+
+					<Option key="mangos">Mangos</Option>
+
+					<Option key="blueberry">Blueberry</Option>
+
+					<Option key="cherry">Cherry</Option>
+
+					<Option key="grape">Grape</Option>
+				</Picker>
+			</Form.Group>
+		</div>
+	);
+}

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/stories/Picker.stories.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/stories/Picker.stories.tsx
@@ -468,7 +468,6 @@ export function KeyboardArrowsIndicator() {
 					defaultActive
 					displayKeyboardArrowsIndicator
 					id={pickerId}
-					keyboardArrowsIndicatorLabel="Use up and down arrow keys to navigate options"
 				>
 					<Option key="apple">Apple</Option>
 

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/stories/ResizeHandle.stories.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/stories/ResizeHandle.stories.tsx
@@ -89,3 +89,39 @@ export function ResizingRight() {
 		</div>
 	);
 }
+
+export function KeyboardArrowsIndicator() {
+	const [width, setWidth] = useState(320);
+
+	return (
+		<div
+			className="border d-flex overflow-hidden rounded"
+			style={{height: 280}}
+		>
+			<div className="bg-light p-3 position-relative" style={{width}}>
+				<div className="text-secondary">Resizable region</div>
+
+				<div className="text-weight-semi-bold">{width}px</div>
+
+				<ResizeHandle
+					aria-label="Resize region"
+					displayKeyboardArrowsIndicator
+					keyboardArrowsIndicatorLabel="Use arrow keys to resize"
+					maxWidth={MAX_WIDTH}
+					minWidth={MIN_WIDTH}
+					onWidthChange={setWidth}
+					position="left"
+					width={width}
+				/>
+			</div>
+
+			<div className="bg-white flex-grow-1 p-3">
+				<div className="text-secondary">Remaining region</div>
+
+				<div className="text-weight-semi-bold">
+					Tab into the resizer to see the indicator.
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/stories/ResizeHandle.stories.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/stories/ResizeHandle.stories.tsx
@@ -106,7 +106,6 @@ export function KeyboardArrowsIndicator() {
 				<ResizeHandle
 					aria-label="Resize region"
 					displayKeyboardArrowsIndicator
-					keyboardArrowsIndicatorLabel="Use arrow keys to resize"
 					maxWidth={MAX_WIDTH}
 					minWidth={MIN_WIDTH}
 					onWidthChange={setWidth}

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/stories/Table.stories.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/stories/Table.stories.tsx
@@ -288,6 +288,63 @@ export function Treegrid() {
 		</Table>
 	);
 }
+export function KeyboardArrowsIndicator() {
+	const [expandedKeys, setExpandedKeys] = useState<Set<React.Key>>(
+		new Set([2, 3])
+	);
+
+	const columns = [
+		{
+			id: 'name',
+			name: 'Name',
+		},
+		{
+			id: 'type',
+			name: 'Type',
+		},
+	];
+
+	const ICON_TYPES = {
+		Folder: <Icon symbol="folder" />,
+		Image: <Icon symbol="picture" />,
+		Text: <Icon symbol="document" />,
+		Vector: <Icon symbol="document-vector" />,
+	};
+
+	return (
+		<Table
+			aria-label="File Explorer"
+			displayKeyboardArrowsIndicator
+			expandedKeys={expandedKeys}
+			nestedKey="children"
+			onExpandedChange={setExpandedKeys}
+		>
+			<Head items={columns}>
+				{(column) => (
+					<Cell className="table-cell-minw-300" key={column.id}>
+						{column.name}
+					</Cell>
+				)}
+			</Head>
+
+			<Body defaultItems={items}>
+				{(row) => (
+					<Row>
+						<Cell key={`${row.id}:name`}>
+							{ICON_TYPES[row['type']]}
+
+							<Text size={3} weight="semi-bold">
+								{row['name']}
+							</Text>
+						</Cell>
+
+						<Cell key={`${row.id}:type`}>{row['type']}</Cell>
+					</Row>
+				)}
+			</Body>
+		</Table>
+	);
+}
 export function AsyncLoad() {
 	return (
 		<Table

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/stories/VerticalBar.stories.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/stories/VerticalBar.stories.tsx
@@ -239,7 +239,6 @@ export function KeyboardArrowsIndicator(args: any) {
 			<VerticalBar
 				activation={args.activation}
 				displayKeyboardArrowsIndicator
-				keyboardArrowsIndicatorLabel="Use up and down arrow keys to navigate the bar items"
 				position="left"
 				resize={args.enableResize}
 			>
@@ -289,7 +288,6 @@ export function KeyboardArrowsIndicator(args: any) {
 			<VerticalBar
 				activation={args.activation}
 				displayKeyboardArrowsIndicator
-				keyboardArrowsIndicatorLabel="Use up and down arrow keys to navigate the bar items"
 				position="right"
 				resize={args.enableResize}
 			>

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/stories/VerticalBar.stories.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/stories/VerticalBar.stories.tsx
@@ -232,3 +232,115 @@ DynamicContent.args = {
 	barDisplayType: 'light',
 	contentDisplayType: 'light',
 };
+
+export function KeyboardArrowsIndicator(args: any) {
+	return (
+		<>
+			<VerticalBar
+				activation={args.activation}
+				displayKeyboardArrowsIndicator
+				keyboardArrowsIndicatorLabel="Use up and down arrow keys to navigate the bar items"
+				position="left"
+				resize={args.enableResize}
+			>
+				<VerticalBar.Bar displayType={args.barDisplayType}>
+					<VerticalBar.Item>
+						<Button aria-label="Tag tab" displayType={null}>
+							<Icon symbol="tag" />
+						</Button>
+					</VerticalBar.Item>
+
+					<VerticalBar.Item divider>
+						<Button aria-label="Message tab" displayType={null}>
+							<Icon symbol="message" />
+						</Button>
+					</VerticalBar.Item>
+
+					<VerticalBar.Item>
+						<Button
+							aria-label="Effects tab"
+							displayType={null}
+							onClick={(event) => {
+								event.preventDefault();
+
+								alert('Clicked');
+							}}
+						>
+							<Icon symbol="effects" />
+						</Button>
+					</VerticalBar.Item>
+				</VerticalBar.Bar>
+
+				<VerticalBar.Content displayType={args.contentDisplayType}>
+					<VerticalBar.Panel tabIndex={0}>
+						<div className="sidebar-header">
+							<div className="component-title">Tag</div>
+						</div>
+					</VerticalBar.Panel>
+
+					<VerticalBar.Panel tabIndex={0}>
+						<div className="sidebar-header">
+							<div className="component-title">Message</div>
+						</div>
+					</VerticalBar.Panel>
+				</VerticalBar.Content>
+			</VerticalBar>
+
+			<VerticalBar
+				activation={args.activation}
+				displayKeyboardArrowsIndicator
+				keyboardArrowsIndicatorLabel="Use up and down arrow keys to navigate the bar items"
+				position="right"
+				resize={args.enableResize}
+			>
+				<VerticalBar.Content displayType={args.contentDisplayType}>
+					<VerticalBar.Panel tabIndex={0}>
+						<div className="sidebar-header">
+							<div className="component-title">Tag</div>
+						</div>
+					</VerticalBar.Panel>
+
+					<VerticalBar.Panel tabIndex={0}>
+						<div className="sidebar-header">
+							<div className="component-title">Message</div>
+						</div>
+					</VerticalBar.Panel>
+				</VerticalBar.Content>
+
+				<VerticalBar.Bar displayType={args.barDisplayType}>
+					<VerticalBar.Item>
+						<Button aria-label="Tag tab" displayType={null}>
+							<Icon symbol="tag" />
+						</Button>
+					</VerticalBar.Item>
+
+					<VerticalBar.Item divider>
+						<Button aria-label="Message tab" displayType={null}>
+							<Icon symbol="message" />
+						</Button>
+					</VerticalBar.Item>
+
+					<VerticalBar.Item>
+						<Button
+							aria-label="Effects tab"
+							displayType={null}
+							onClick={(event) => {
+								event.preventDefault();
+
+								alert('Clicked');
+							}}
+						>
+							<Icon symbol="effects" />
+						</Button>
+					</VerticalBar.Item>
+				</VerticalBar.Bar>
+			</VerticalBar>
+		</>
+	);
+}
+
+KeyboardArrowsIndicator.args = {
+	activation: 'manual',
+	barDisplayType: 'light',
+	contentDisplayType: 'light',
+};

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/stories/VerticalNav.stories.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/stories/VerticalNav.stories.tsx
@@ -719,7 +719,6 @@ export function KeyboardArrowsIndicator() {
 				defaultExpandedKeys={new Set(['about'])}
 				displayKeyboardArrowsIndicator
 				items={navItems}
-				keyboardArrowsIndicatorLabel="Use arrow keys to navigate the menu"
 			>
 				{(item: Item) => (
 					<VerticalNav.Item

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/stories/VerticalNav.stories.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/stories/VerticalNav.stories.tsx
@@ -689,3 +689,48 @@ export function Primary() {
 		</VerticalNav>
 	);
 }
+export function KeyboardArrowsIndicator() {
+	const navItems = [
+		{
+			href: '#home',
+			id: 'home',
+			label: 'Home',
+		},
+		{
+			id: 'about',
+			items: [
+				{href: '#team', id: 'team', label: 'Team'},
+				{href: '#history', id: 'history', label: 'History'},
+			],
+			label: 'About',
+		},
+		{
+			href: '#contact',
+			id: 'contact',
+			label: 'Contact',
+		},
+	];
+
+	return (
+		<div style={{maxWidth: '320px'}}>
+			<VerticalNav
+				active="home"
+				aria-label="Site navigation"
+				defaultExpandedKeys={new Set(['about'])}
+				displayKeyboardArrowsIndicator
+				items={navItems}
+				keyboardArrowsIndicatorLabel="Use arrow keys to navigate the menu"
+			>
+				{(item: Item) => (
+					<VerticalNav.Item
+						href={item.href}
+						items={item.items}
+						key={item.id}
+					>
+						{item.label}
+					</VerticalNav.Item>
+				)}
+			</VerticalNav>
+		</div>
+	);
+}

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/components/_icons.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/components/_icons.scss
@@ -38,6 +38,67 @@
 	}
 }
 
+.clay-keyboard-arrows-indicator-floating {
+	background-color: $cadmin-white;
+	border-radius: 0.1413em;
+	position: absolute;
+	transition:
+		bottom 0.3s ease-in-out,
+		left 0.3s ease-in-out,
+		right 0.3s ease-in-out,
+		top 0.3s ease-in-out;
+	z-index: $cadmin-zindex-tooltip;
+
+	&.clay-keyboard-arrows-indicator-floating-hidden {
+		opacity: 0;
+		pointer-events: none;
+		visibility: hidden;
+	}
+
+	&.clay-keyboard-arrows-indicator-floating-tooltip {
+		&::before,
+		&::after {
+			border-style: solid;
+			content: '';
+			height: 0;
+			position: absolute;
+			top: 50%;
+			transform: translateY(-50%);
+			width: 0;
+		}
+
+		&::before {
+			border-color: transparent $cadmin-border-color transparent
+				transparent;
+			border-width: 7px 7px 7px 0;
+			left: -7px;
+		}
+
+		&::after {
+			border-color: transparent $cadmin-white transparent transparent;
+			border-width: 6px 6px 6px 0;
+			left: -6px;
+		}
+
+		&.clay-keyboard-arrows-indicator-floating-flipped {
+			&::before {
+				border-color: transparent transparent transparent
+					$cadmin-border-color;
+				border-width: 7px 0 7px 7px;
+				left: auto;
+				right: -7px;
+			}
+
+			&::after {
+				border-color: transparent transparent transparent $cadmin-white;
+				border-width: 6px 0 6px 6px;
+				left: auto;
+				right: -6px;
+			}
+		}
+	}
+}
+
 .order-arrow-down-active {
 	.order-arrow-arrow-down {
 		fill: $cadmin-order-arrow-down-active-color;

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/components/_icons.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/components/_icons.scss
@@ -38,6 +38,81 @@
 	}
 }
 
+.clay-keyboard-arrows-indicator-floating {
+	background-color: $white;
+	border-radius: 0.1413em; // matches `.lexicon-icon-arrows-all`
+	position: absolute;
+
+	// Position timing matches `$c-slideout-transition-in` so the
+	// indicator slides in lockstep with a `VerticalBar` panel opening
+	// rather than vanishing and reappearing at the new position. The
+	// focus-within toggle stays instantaneous.
+	transition:
+		bottom 0.3s ease-in-out,
+		left 0.3s ease-in-out,
+		right 0.3s ease-in-out,
+		top 0.3s ease-in-out;
+	z-index: $zindex-tooltip;
+
+	&.clay-keyboard-arrows-indicator-floating-hidden {
+		opacity: 0;
+		pointer-events: none;
+		visibility: hidden;
+	}
+
+	// `tooltip` placement (default): the indicator sits next to the
+	// anchor with a directional CSS-triangle arrow. The arrow's fill
+	// matches the icon's semi-transparent white surface, with the icon's
+	// border color outlining it.
+
+	&.clay-keyboard-arrows-indicator-floating-tooltip {
+		&::before,
+		&::after {
+			border-style: solid;
+			content: '';
+			height: 0;
+			position: absolute;
+			top: 50%;
+			transform: translateY(-50%);
+			width: 0;
+		}
+
+		// Default: indicator sits to the right of the anchor, so the arrow
+		// points left (toward the anchor).
+
+		&::before {
+			border-color: transparent $border-color transparent transparent;
+			border-width: 7px 7px 7px 0;
+			left: -7px;
+		}
+
+		&::after {
+			border-color: transparent $white transparent transparent;
+			border-width: 6px 6px 6px 0;
+			left: -6px;
+		}
+
+		&.clay-keyboard-arrows-indicator-floating-flipped {
+			// Flipped: indicator sits to the left of the anchor, so the
+			// arrow points right (toward the anchor).
+
+			&::before {
+				border-color: transparent transparent transparent $border-color;
+				border-width: 7px 0 7px 7px;
+				left: auto;
+				right: -7px;
+			}
+
+			&::after {
+				border-color: transparent transparent transparent $white;
+				border-width: 6px 0 6px 6px;
+				left: auto;
+				right: -6px;
+			}
+		}
+	}
+}
+
 .order-arrow-down-active {
 	.order-arrow-arrow-down {
 		fill: $order-arrow-down-active-color;

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-date-picker/src/__tests__/IncrementalInteractions.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-date-picker/src/__tests__/IncrementalInteractions.tsx
@@ -800,4 +800,69 @@ describe('IncrementalInteractions', () => {
 
 		jest.useRealTimers();
 	});
+
+	describe('keyboard arrows indicator', () => {
+		it('does not render the indicator by default', () => {
+			const {getByTestId} = render(
+				<ClayDatePicker
+					defaultMonth={new Date(2019, 3, 18)}
+					placeholder="YYYY-MM-DD"
+					spritemap={spritemap}
+					years={{end: 2019, start: 2019}}
+				/>
+			);
+
+			fireEvent.click(getByTestId('date-button'));
+
+			expect(
+				document.body.querySelector('.clay-keyboard-arrows-indicator')
+			).not.toBeInTheDocument();
+		});
+
+		it('renders the floating indicator with direction "all" when enabled', () => {
+			const {getByTestId} = render(
+				<ClayDatePicker
+					defaultMonth={new Date(2019, 3, 18)}
+					displayKeyboardArrowsIndicator
+					placeholder="YYYY-MM-DD"
+					spritemap={spritemap}
+					years={{end: 2019, start: 2019}}
+				/>
+			);
+
+			fireEvent.click(getByTestId('date-button'));
+
+			const indicator = document.body.querySelector(
+				'.clay-keyboard-arrows-indicator'
+			);
+
+			expect(indicator).toBeInTheDocument();
+			expect(indicator).toHaveClass('clay-keyboard-arrows-all');
+			expect(indicator).toHaveClass(
+				'clay-keyboard-arrows-indicator-floating'
+			);
+		});
+
+		it('uses the localized label on the indicator', () => {
+			const {getByTestId} = render(
+				<ClayDatePicker
+					defaultMonth={new Date(2019, 3, 18)}
+					displayKeyboardArrowsIndicator
+					keyboardArrowsIndicatorLabel="Use arrow keys to navigate the calendar"
+					placeholder="YYYY-MM-DD"
+					spritemap={spritemap}
+					years={{end: 2019, start: 2019}}
+				/>
+			);
+
+			fireEvent.click(getByTestId('date-button'));
+
+			expect(
+				document.body.querySelector('.clay-keyboard-arrows-indicator')
+			).toHaveAttribute(
+				'aria-label',
+				'Use arrow keys to navigate the calendar'
+			);
+		});
+	});
 });

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-date-picker/src/__tests__/IncrementalInteractions.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-date-picker/src/__tests__/IncrementalInteractions.tsx
@@ -842,27 +842,5 @@ describe('IncrementalInteractions', () => {
 				'clay-keyboard-arrows-indicator-floating'
 			);
 		});
-
-		it('uses the localized label on the indicator', () => {
-			const {getByTestId} = render(
-				<ClayDatePicker
-					defaultMonth={new Date(2019, 3, 18)}
-					displayKeyboardArrowsIndicator
-					keyboardArrowsIndicatorLabel="Use arrow keys to navigate the calendar"
-					placeholder="YYYY-MM-DD"
-					spritemap={spritemap}
-					years={{end: 2019, start: 2019}}
-				/>
-			);
-
-			fireEvent.click(getByTestId('date-button'));
-
-			expect(
-				document.body.querySelector('.clay-keyboard-arrows-indicator')
-			).toHaveAttribute(
-				'aria-label',
-				'Use arrow keys to navigate the calendar'
-			);
-		});
 	});
 });

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-date-picker/src/index.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-date-picker/src/index.tsx
@@ -4,10 +4,12 @@
  */
 
 import Button from '@clayui/button';
+import {KeyboardArrowsIndicator} from '@clayui/core';
 import DropDown from '@clayui/drop-down';
 import {ClayInput} from '@clayui/form';
 import Icon from '@clayui/icon';
 import {
+	ClayPortal,
 	FocusScope,
 	InternalDispatch,
 	sub,
@@ -89,6 +91,16 @@ interface IProps
 	disabled?: boolean;
 
 	/**
+	 * Flag to render the `KeyboardArrowsIndicator` alongside the calendar
+	 * panel, hinting that all four arrow keys are active for navigating
+	 * the date grid (up and down between weeks, left and right between
+	 * days). The indicator floats to the right of the panel and flips to
+	 * the left when it would overflow the viewport. It is only rendered
+	 * while the panel is open.
+	 */
+	displayKeyboardArrowsIndicator?: boolean;
+
+	/**
 	 * Determines if menu is expanded or not (controlled).
 	 */
 	expanded?: boolean;
@@ -128,6 +140,14 @@ interface IProps
 	 * Name of the input.
 	 */
 	inputName?: string;
+
+	/**
+	 * Localized `aria-label` for the keyboard arrows indicator. Defaults
+	 * to the indicator's built-in English string when omitted. Pass a
+	 * translated value (e.g. via `Liferay.Language.get`) when the host
+	 * page needs i18n.
+	 */
+	keyboardArrowsIndicatorLabel?: string;
 
 	/**
 	 * The names of the months.
@@ -256,6 +276,7 @@ const DatePicker = React.forwardRef<HTMLInputElement, IProps>(
 			defaultMonth,
 			defaultValue,
 			disabled,
+			displayKeyboardArrowsIndicator = false,
 			expanded,
 			firstDayOfWeek = 0,
 			footerElement,
@@ -263,6 +284,7 @@ const DatePicker = React.forwardRef<HTMLInputElement, IProps>(
 			initialExpanded = false,
 			initialMonth,
 			inputName,
+			keyboardArrowsIndicatorLabel,
 			months = [
 				'January',
 				'February',
@@ -406,6 +428,13 @@ const DatePicker = React.forwardRef<HTMLInputElement, IProps>(
 		 * Create a ref to store the datepicker DOM element
 		 */
 		const triggerElementRef = useRef<HTMLDivElement | null>(null);
+
+		/**
+		 * Anchor for the floating `KeyboardArrowsIndicator` — points to
+		 * the calendar dropdown panel so the tooltip sits alongside the
+		 * grid the user is navigating.
+		 */
+		const menuElementRef = useRef<HTMLDivElement>(null);
 
 		/**
 		 * Handles the change of the current month of the Date Picker
@@ -724,6 +753,7 @@ const DatePicker = React.forwardRef<HTMLInputElement, IProps>(
 							id={ariaControls}
 							lock
 							onActiveChange={setExpandedValue}
+							ref={menuElementRef}
 							role="dialog"
 							triggerRef={chooseDateRef}
 						>
@@ -806,6 +836,18 @@ const DatePicker = React.forwardRef<HTMLInputElement, IProps>(
 							</div>
 						</DropDown.Menu>
 					)}
+
+					{!useNative &&
+						expandedValue &&
+						displayKeyboardArrowsIndicator && (
+							<ClayPortal>
+								<KeyboardArrowsIndicator
+									anchorRef={menuElementRef}
+									direction="all"
+									label={keyboardArrowsIndicatorLabel}
+								/>
+							</ClayPortal>
+						)}
 				</div>
 			</FocusScope>
 		);

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-date-picker/src/index.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-date-picker/src/index.tsx
@@ -142,14 +142,6 @@ interface IProps
 	inputName?: string;
 
 	/**
-	 * Localized `aria-label` for the keyboard arrows indicator. Defaults
-	 * to the indicator's built-in English string when omitted. Pass a
-	 * translated value (e.g. via `Liferay.Language.get`) when the host
-	 * page needs i18n.
-	 */
-	keyboardArrowsIndicatorLabel?: string;
-
-	/**
 	 * The names of the months.
 	 */
 	months?: Array<string>;
@@ -284,7 +276,6 @@ const DatePicker = React.forwardRef<HTMLInputElement, IProps>(
 			initialExpanded = false,
 			initialMonth,
 			inputName,
-			keyboardArrowsIndicatorLabel,
 			months = [
 				'January',
 				'February',
@@ -844,7 +835,6 @@ const DatePicker = React.forwardRef<HTMLInputElement, IProps>(
 								<KeyboardArrowsIndicator
 									anchorRef={menuElementRef}
 									direction="all"
-									label={keyboardArrowsIndicatorLabel}
 								/>
 							</ClayPortal>
 						)}

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-date-picker/stories/DatePicker.stories.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-date-picker/stories/DatePicker.stories.tsx
@@ -288,7 +288,6 @@ export function KeyboardArrowsIndicator() {
 		<ClayDatePickerWithState
 			defaultExpanded
 			displayKeyboardArrowsIndicator
-			keyboardArrowsIndicatorLabel="Use arrow keys to navigate the calendar"
 			placeholder="YYYY-MM-DD"
 			years={{
 				end: new Date().getFullYear(),

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-date-picker/stories/DatePicker.stories.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-date-picker/stories/DatePicker.stories.tsx
@@ -283,3 +283,17 @@ export function InDropdownMenu() {
 		</>
 	);
 }
+export function KeyboardArrowsIndicator() {
+	return (
+		<ClayDatePickerWithState
+			defaultExpanded
+			displayKeyboardArrowsIndicator
+			keyboardArrowsIndicatorLabel="Use arrow keys to navigate the calendar"
+			placeholder="YYYY-MM-DD"
+			years={{
+				end: new Date().getFullYear(),
+				start: 1998,
+			}}
+		/>
+	);
+}

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-drop-down/src/DropDown.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-drop-down/src/DropDown.tsx
@@ -112,14 +112,6 @@ interface IProps<T> extends DropDownHTMLAttributes {
 	items?: Array<T>;
 
 	/**
-	 * Localized `aria-label` for the keyboard arrows indicator. Defaults
-	 * to the indicator's built-in English string when omitted. Pass a
-	 * translated value (e.g. via `Liferay.Language.get`) when the host
-	 * page needs i18n.
-	 */
-	keyboardArrowsIndicatorLabel?: string;
-
-	/**
 	 * Prop to pass DOM element attributes to DropDown.Menu.
 	 */
 	menuElementAttrs?: React.HTMLAttributes<HTMLDivElement> &
@@ -200,7 +192,6 @@ function DropDown<T>({
 	hasLeftSymbols,
 	hasRightSymbols,
 	items,
-	keyboardArrowsIndicatorLabel,
 	menuElementAttrs,
 	menuHeight,
 	menuWidth,
@@ -433,7 +424,6 @@ function DropDown<T>({
 					<KeyboardArrowsIndicator
 						anchorRef={menuElementRef}
 						direction="vertical"
-						label={keyboardArrowsIndicatorLabel}
 					/>
 				</ClayPortal>
 			)}

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-drop-down/src/DropDown.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-drop-down/src/DropDown.tsx
@@ -3,9 +3,10 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {__NOT_PUBLIC_COLLECTION} from '@clayui/core';
+import {KeyboardArrowsIndicator, __NOT_PUBLIC_COLLECTION} from '@clayui/core';
 import ClayIcon from '@clayui/icon';
 import {
+	ClayPortal,
 	FOCUSABLE_ELEMENTS,
 	Keys,
 	getFocusableList,
@@ -80,6 +81,16 @@ interface IProps<T> extends DropDownHTMLAttributes {
 	defaultActive?: boolean;
 
 	/**
+	 * Flag to render the `KeyboardArrowsIndicator` alongside the DropDown
+	 * menu, hinting that up and down arrow keys can be used to navigate
+	 * the menu items. The indicator floats to the right of the menu and
+	 * flips to the left when it would overflow the viewport. It is only
+	 * rendered while the menu is open and visible while the menu has
+	 * keyboard focus.
+	 */
+	displayKeyboardArrowsIndicator?: boolean;
+
+	/**
 	 * Defines the name of the property key that is used in the items filter
 	 * test (Dynamic content).
 	 */
@@ -99,6 +110,14 @@ interface IProps<T> extends DropDownHTMLAttributes {
 	 * Property to render content with dynamic data.
 	 */
 	items?: Array<T>;
+
+	/**
+	 * Localized `aria-label` for the keyboard arrows indicator. Defaults
+	 * to the indicator's built-in English string when omitted. Pass a
+	 * translated value (e.g. via `Liferay.Language.get`) when the host
+	 * page needs i18n.
+	 */
+	keyboardArrowsIndicatorLabel?: string;
 
 	/**
 	 * Prop to pass DOM element attributes to DropDown.Menu.
@@ -176,10 +195,12 @@ function DropDown<T>({
 	closeOnClickOutside,
 	containerElement: ContainerElement = 'div',
 	defaultActive = false,
+	displayKeyboardArrowsIndicator = false,
 	filterKey,
 	hasLeftSymbols,
 	hasRightSymbols,
 	items,
+	keyboardArrowsIndicatorLabel,
 	menuElementAttrs,
 	menuHeight,
 	menuWidth,
@@ -405,6 +426,16 @@ function DropDown<T>({
 						</DropDownContext.Provider>
 					</FocusMenu>
 				</Menu>
+			)}
+
+			{internalActive && displayKeyboardArrowsIndicator && (
+				<ClayPortal>
+					<KeyboardArrowsIndicator
+						anchorRef={menuElementRef}
+						direction="vertical"
+						label={keyboardArrowsIndicatorLabel}
+					/>
+				</ClayPortal>
 			)}
 		</ContainerElement>
 	);

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-drop-down/src/__tests__/index.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-drop-down/src/__tests__/index.tsx
@@ -540,4 +540,70 @@ describe('ClayDropDown', () => {
 		expect(fruits.length).toBe(1);
 		expect(vegetables.length).toBe(1);
 	});
+
+	it('does not render the keyboard arrows indicator by default', () => {
+		const {container} = render(
+			<DropDownWithState>
+				<ClayDropDown.ItemList>
+					<ClayDropDown.Item href="#one" spritemap="/foo/bar">
+						one
+					</ClayDropDown.Item>
+				</ClayDropDown.ItemList>
+			</DropDownWithState>
+		);
+
+		fireEvent.click(container.querySelector('.dropdown-toggle')!);
+
+		expect(
+			document.body.querySelector('.clay-keyboard-arrows-indicator')
+		).not.toBeInTheDocument();
+	});
+
+	it('renders the floating indicator alongside the trigger when enabled', () => {
+		const {container} = render(
+			<DropDownWithState displayKeyboardArrowsIndicator>
+				<ClayDropDown.ItemList>
+					<ClayDropDown.Item href="#one" spritemap="/foo/bar">
+						one
+					</ClayDropDown.Item>
+				</ClayDropDown.ItemList>
+			</DropDownWithState>
+		);
+
+		fireEvent.click(container.querySelector('.dropdown-toggle')!);
+
+		const indicator = document.body.querySelector(
+			'.clay-keyboard-arrows-indicator'
+		);
+
+		expect(indicator).toBeInTheDocument();
+		expect(indicator).toHaveClass('clay-keyboard-arrows-vertical');
+		expect(indicator).toHaveClass(
+			'clay-keyboard-arrows-indicator-floating'
+		);
+	});
+
+	it('uses the localized label on the keyboard arrows indicator', () => {
+		const {container} = render(
+			<DropDownWithState
+				displayKeyboardArrowsIndicator
+				keyboardArrowsIndicatorLabel="Use up and down to navigate menu items"
+			>
+				<ClayDropDown.ItemList>
+					<ClayDropDown.Item href="#one" spritemap="/foo/bar">
+						one
+					</ClayDropDown.Item>
+				</ClayDropDown.ItemList>
+			</DropDownWithState>
+		);
+
+		fireEvent.click(container.querySelector('.dropdown-toggle')!);
+
+		expect(
+			document.body.querySelector('.clay-keyboard-arrows-indicator')
+		).toHaveAttribute(
+			'aria-label',
+			'Use up and down to navigate menu items'
+		);
+	});
 });

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-drop-down/src/__tests__/index.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-drop-down/src/__tests__/index.tsx
@@ -582,28 +582,4 @@ describe('ClayDropDown', () => {
 			'clay-keyboard-arrows-indicator-floating'
 		);
 	});
-
-	it('uses the localized label on the keyboard arrows indicator', () => {
-		const {container} = render(
-			<DropDownWithState
-				displayKeyboardArrowsIndicator
-				keyboardArrowsIndicatorLabel="Use up and down to navigate menu items"
-			>
-				<ClayDropDown.ItemList>
-					<ClayDropDown.Item href="#one" spritemap="/foo/bar">
-						one
-					</ClayDropDown.Item>
-				</ClayDropDown.ItemList>
-			</DropDownWithState>
-		);
-
-		fireEvent.click(container.querySelector('.dropdown-toggle')!);
-
-		expect(
-			document.body.querySelector('.clay-keyboard-arrows-indicator')
-		).toHaveAttribute(
-			'aria-label',
-			'Use up and down to navigate menu items'
-		);
-	});
 });

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-drop-down/stories/DropDown.stories.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-drop-down/stories/DropDown.stories.tsx
@@ -676,7 +676,6 @@ export function KeyboardArrowsIndicator() {
 		<ClayDropDown
 			defaultActive
 			displayKeyboardArrowsIndicator
-			keyboardArrowsIndicatorLabel="Use up and down arrow keys to navigate menu items"
 			trigger={<ClayButton>Choose a fruit</ClayButton>}
 		>
 			<ClayDropDown.ItemList>

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-drop-down/stories/DropDown.stories.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-drop-down/stories/DropDown.stories.tsx
@@ -671,3 +671,27 @@ export function CascadingMenu() {
 		/>
 	);
 }
+export function KeyboardArrowsIndicator() {
+	return (
+		<ClayDropDown
+			defaultActive
+			displayKeyboardArrowsIndicator
+			keyboardArrowsIndicatorLabel="Use up and down arrow keys to navigate menu items"
+			trigger={<ClayButton>Choose a fruit</ClayButton>}
+		>
+			<ClayDropDown.ItemList>
+				<ClayDropDown.Item href="#apple">Apple</ClayDropDown.Item>
+
+				<ClayDropDown.Item href="#banana">Banana</ClayDropDown.Item>
+
+				<ClayDropDown.Item href="#blueberry">
+					Blueberry
+				</ClayDropDown.Item>
+
+				<ClayDropDown.Item href="#cherry">Cherry</ClayDropDown.Item>
+
+				<ClayDropDown.Item href="#grape">Grape</ClayDropDown.Item>
+			</ClayDropDown.ItemList>
+		</ClayDropDown>
+	);
+}

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-multi-select/src/MultiSelect.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-multi-select/src/MultiSelect.tsx
@@ -481,155 +481,158 @@ export const MultiSelect = React.forwardRef(function MultiSelectInner<
 	return (
 		<Container {...containerProps}>
 			<>
-			<div
-				className={classNames(
-					'form-control form-control-tag-group input-group',
-					{
-						focus: isFocused && isValid,
-						[`form-control-tag-group-${size}`]: size,
-					}
-				)}
-				ref={containerRef}
-			>
-				<Autocomplete<T>
-					{...otherProps}
-					UNSAFE_loadingShrink
-					active={MenuRenderer ? false : active}
-					allowsCustomLabel={
-						typeof locator.label === 'function' ||
-						typeof locator.value === 'function'
-							? false
-							: allowsCustomLabel
-					}
-					ariaDescriptionId={ariaDescriptionId}
-					as={Labels}
-					closeButtonAriaLabel={closeButtonAriaLabel}
-					containerElementRef={containerRef}
-					defaultItems={!hasAsyncItems ? sourceItems : undefined}
-					disabled={disabled}
-					filterKey={locator.label}
-					inputName={inputName}
-					items={hasAsyncItems ? sourceItems : undefined}
-					labels={items}
-					lastChangesRef={lastChangesRef}
-					loadingState={loadingState}
-					locator={locator}
-					menuTrigger="focus"
-					messages={messages}
-					onActiveChange={MenuRenderer ? () => {} : setActive}
-					onChange={setValue}
-					onFocus={
-						MenuRenderer && sourceItems
-							? (event: React.FocusEvent<HTMLInputElement>) => {
-									if (otherProps.onFocus) {
-										otherProps.onFocus(event);
-									}
-
-									setActive(
-										!!value && sourceItems.length !== 0
-									);
-								}
-							: otherProps.onFocus
-					}
-					onFocusChange={setIsFocused}
-					onItemsChange={hasAsyncItems ? () => {} : undefined}
-					onLabelsChange={setItems}
-					onLoadMore={onLoadMore}
-					placeholder={placeholder}
-					ref={inputElementRef}
-					selectedKeys={selectedKeys}
-					spritemap={spritemap}
-					suggestionList={sourceItems ?? []}
-					value={value}
+				<div
+					className={classNames(
+						'form-control form-control-tag-group input-group',
+						{
+							focus: isFocused && isValid,
+							[`form-control-tag-group-${size}`]: size,
+						}
+					)}
+					ref={containerRef}
 				>
-					{memoizedChildren}
-				</Autocomplete>
+					<Autocomplete<T>
+						{...otherProps}
+						UNSAFE_loadingShrink
+						active={MenuRenderer ? false : active}
+						allowsCustomLabel={
+							typeof locator.label === 'function' ||
+							typeof locator.value === 'function'
+								? false
+								: allowsCustomLabel
+						}
+						ariaDescriptionId={ariaDescriptionId}
+						as={Labels}
+						closeButtonAriaLabel={closeButtonAriaLabel}
+						containerElementRef={containerRef}
+						defaultItems={!hasAsyncItems ? sourceItems : undefined}
+						disabled={disabled}
+						filterKey={locator.label}
+						inputName={inputName}
+						items={hasAsyncItems ? sourceItems : undefined}
+						labels={items}
+						lastChangesRef={lastChangesRef}
+						loadingState={loadingState}
+						locator={locator}
+						menuTrigger="focus"
+						messages={messages}
+						onActiveChange={MenuRenderer ? () => {} : setActive}
+						onChange={setValue}
+						onFocus={
+							MenuRenderer && sourceItems
+								? (
+										event: React.FocusEvent<HTMLInputElement>
+									) => {
+										if (otherProps.onFocus) {
+											otherProps.onFocus(event);
+										}
 
-				{sourceItems && MenuRenderer && !!sourceItems.length && (
-					<ACT.DropDown
-						active={active}
-						alignElementRef={containerRef}
-						alignmentByViewport={alignmentByViewport}
-						onActiveChange={setActive}
+										setActive(
+											!!value && sourceItems.length !== 0
+										);
+									}
+								: otherProps.onFocus
+						}
+						onFocusChange={setIsFocused}
+						onItemsChange={hasAsyncItems ? () => {} : undefined}
+						onLabelsChange={setItems}
+						onLoadMore={onLoadMore}
+						placeholder={placeholder}
+						ref={inputElementRef}
+						selectedKeys={selectedKeys}
+						spritemap={spritemap}
+						suggestionList={sourceItems ?? []}
+						value={value}
 					>
-						<MenuRenderer
-							inputValue={value}
-							locator={locator}
-							onItemClick={(item) => {
-								setItems([...items, item as unknown as T]);
-								setValue('');
+						{memoizedChildren}
+					</Autocomplete>
 
-								if (inputElementRef.current) {
-									inputElementRef.current.focus();
-								}
-							}}
-							sourceItems={sourceItems}
-							value={value}
-						/>
-					</ACT.DropDown>
-				)}
-
-				{!disabled &&
-					!disabledClearAll &&
-					(value || !!items.length) && (
-						<ClayInput.GroupItem shrink>
-							<ClayButtonWithIcon
-								aria-label={clearAllTitle}
-								borderless
-								className="component-action"
-								displayType="secondary"
-								onClick={() => {
-									if (onClearAllButtonClick) {
-										onClearAllButtonClick();
-									}
-									else {
-										setItems([]);
-										setValue('');
-									}
+					{sourceItems && MenuRenderer && !!sourceItems.length && (
+						<ACT.DropDown
+							active={active}
+							alignElementRef={containerRef}
+							alignmentByViewport={alignmentByViewport}
+							onActiveChange={setActive}
+						>
+							<MenuRenderer
+								inputValue={value}
+								locator={locator}
+								onItemClick={(item) => {
+									setItems([...items, item as unknown as T]);
+									setValue('');
 
 									if (inputElementRef.current) {
 										inputElementRef.current.focus();
 									}
 								}}
-								outline
-								spritemap={spritemap}
-								symbol="times-circle"
-								title={clearAllTitle}
+								sourceItems={sourceItems}
+								value={value}
 							/>
-						</ClayInput.GroupItem>
+						</ACT.DropDown>
 					)}
 
-				<div className="sr-only">
-					<span id={ariaDescriptionId}>
-						{hotkeysDescription ?? messages.hotkeys}
-					</span>
+					{!disabled &&
+						!disabledClearAll &&
+						(value || !!items.length) && (
+							<ClayInput.GroupItem shrink>
+								<ClayButtonWithIcon
+									aria-label={clearAllTitle}
+									borderless
+									className="component-action"
+									displayType="secondary"
+									onClick={() => {
+										if (onClearAllButtonClick) {
+											onClearAllButtonClick();
+										}
+										else {
+											setItems([]);
+											setValue('');
+										}
 
-					<span aria-live="polite" aria-relevant="text">
-						{lastChangesRef.current
-							? sub(
-									liveRegion
-										? liveRegion[
-												lastChangesRef.current.action
-											]
-										: lastChangesRef.current.action ===
-											  'added'
-											? messages.labelAdded
-											: messages.labelRemoved,
-									[lastChangesRef.current.label]
-								)
-							: null}
-					</span>
+										if (inputElementRef.current) {
+											inputElementRef.current.focus();
+										}
+									}}
+									outline
+									spritemap={spritemap}
+									symbol="times-circle"
+									title={clearAllTitle}
+								/>
+							</ClayInput.GroupItem>
+						)}
+
+					<div className="sr-only">
+						<span id={ariaDescriptionId}>
+							{hotkeysDescription ?? messages.hotkeys}
+						</span>
+
+						<span aria-live="polite" aria-relevant="text">
+							{lastChangesRef.current
+								? sub(
+										liveRegion
+											? liveRegion[
+													lastChangesRef.current
+														.action
+												]
+											: lastChangesRef.current.action ===
+												  'added'
+												? messages.labelAdded
+												: messages.labelRemoved,
+										[lastChangesRef.current.label]
+									)
+								: null}
+						</span>
+					</div>
 				</div>
-			</div>
 
-			{active && displayKeyboardArrowsIndicator && (
-				<ClayPortal>
-					<KeyboardArrowsIndicator
-						anchorRef={containerRef}
-						direction="vertical"
-					/>
-				</ClayPortal>
-			)}
+				{active && displayKeyboardArrowsIndicator && (
+					<ClayPortal>
+						<KeyboardArrowsIndicator
+							anchorRef={containerRef}
+							direction="vertical"
+						/>
+					</ClayPortal>
+				)}
 			</>
 		</Container>
 	);

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-multi-select/src/MultiSelect.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-multi-select/src/MultiSelect.tsx
@@ -479,8 +479,8 @@ export const MultiSelect = React.forwardRef(function MultiSelectInner<
 	);
 
 	return (
-		<Container {...containerProps}>
-			<>
+		<>
+			<Container {...containerProps}>
 				<div
 					className={classNames(
 						'form-control form-control-tag-group input-group',
@@ -624,17 +624,17 @@ export const MultiSelect = React.forwardRef(function MultiSelectInner<
 						</span>
 					</div>
 				</div>
+			</Container>
 
-				{active && displayKeyboardArrowsIndicator && (
-					<ClayPortal>
-						<KeyboardArrowsIndicator
-							anchorRef={containerRef}
-							direction="vertical"
-						/>
-					</ClayPortal>
-				)}
-			</>
-		</Container>
+			{active && displayKeyboardArrowsIndicator && (
+				<ClayPortal>
+					<KeyboardArrowsIndicator
+						anchorRef={containerRef}
+						direction="vertical"
+					/>
+				</ClayPortal>
+			)}
+		</>
 	);
 }) as Component;
 

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-multi-select/src/MultiSelect.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-multi-select/src/MultiSelect.tsx
@@ -161,14 +161,6 @@ export interface IProps<T extends Record<string, any> = Item>
 	items?: Array<T>;
 
 	/**
-	 * Localized `aria-label` for the keyboard arrows indicator. Defaults
-	 * to the indicator's built-in English string when omitted. Pass a
-	 * translated value (e.g. via `Liferay.Language.get`) when the host
-	 * page needs i18n.
-	 */
-	keyboardArrowsIndicatorLabel?: string;
-
-	/**
 	 * The off-screen live region informs screen reader users the result of
 	 * removing or adding a label.
 	 * @deprecated since v3.96.1 - use `messages` instead.
@@ -296,7 +288,6 @@ export const MultiSelect = React.forwardRef(function MultiSelectInner<
 		isLoading: _i,
 		isValid = true,
 		items: externalItems,
-		keyboardArrowsIndicatorLabel,
 		liveRegion,
 		locator = {
 			id: 'key',
@@ -636,7 +627,6 @@ export const MultiSelect = React.forwardRef(function MultiSelectInner<
 					<KeyboardArrowsIndicator
 						anchorRef={containerRef}
 						direction="vertical"
-						label={keyboardArrowsIndicatorLabel}
 					/>
 				</ClayPortal>
 			)}

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-multi-select/src/MultiSelect.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-multi-select/src/MultiSelect.tsx
@@ -8,8 +8,10 @@ import ACT, {
 	Item as AutocompleteItem,
 } from '@clayui/autocomplete';
 import {ClayButtonWithIcon} from '@clayui/button';
+import {KeyboardArrowsIndicator} from '@clayui/core';
 import {ClayInput} from '@clayui/form';
 import {
+	ClayPortal,
 	FocusScope,
 	InternalDispatch,
 	getLocatorValue,
@@ -116,6 +118,15 @@ export interface IProps<T extends Record<string, any> = Item>
 	disabledClearAll?: boolean;
 
 	/**
+	 * Flag to render the `KeyboardArrowsIndicator` alongside the MultiSelect
+	 * input, hinting that up and down arrow keys can be used to navigate
+	 * the suggestions list. The indicator floats to the right of the input
+	 * and flips to the left when it would overflow the viewport. It is
+	 * only rendered while the suggestions panel is open.
+	 */
+	displayKeyboardArrowsIndicator?: boolean;
+
+	/**
 	 * Defines the description of hotkeys for the component, use this
 	 * to handle internationalization.
 	 * @deprecated since v3.96.1 - use `messages` instead.
@@ -148,6 +159,14 @@ export interface IProps<T extends Record<string, any> = Item>
 	 * Values that display as label items (controlled).
 	 */
 	items?: Array<T>;
+
+	/**
+	 * Localized `aria-label` for the keyboard arrows indicator. Defaults
+	 * to the indicator's built-in English string when omitted. Pass a
+	 * translated value (e.g. via `Liferay.Language.get`) when the host
+	 * page needs i18n.
+	 */
+	keyboardArrowsIndicatorLabel?: string;
 
 	/**
 	 * The off-screen live region informs screen reader users the result of
@@ -270,12 +289,14 @@ export const MultiSelect = React.forwardRef(function MultiSelectInner<
 		defaultValue = '',
 		disabled,
 		disabledClearAll,
+		displayKeyboardArrowsIndicator = false,
 		hotkeysDescription,
 		inputName,
 		inputValue,
 		isLoading: _i,
 		isValid = true,
 		items: externalItems,
+		keyboardArrowsIndicatorLabel,
 		liveRegion,
 		locator = {
 			id: 'key',
@@ -468,6 +489,7 @@ export const MultiSelect = React.forwardRef(function MultiSelectInner<
 
 	return (
 		<Container {...containerProps}>
+			<>
 			<div
 				className={classNames(
 					'form-control form-control-tag-group input-group',
@@ -608,6 +630,17 @@ export const MultiSelect = React.forwardRef(function MultiSelectInner<
 					</span>
 				</div>
 			</div>
+
+			{active && displayKeyboardArrowsIndicator && (
+				<ClayPortal>
+					<KeyboardArrowsIndicator
+						anchorRef={containerRef}
+						direction="vertical"
+						label={keyboardArrowsIndicatorLabel}
+					/>
+				</ClayPortal>
+			)}
+			</>
 		</Container>
 	);
 }) as Component;

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-multi-select/src/__tests__/IncrementalInteractions.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-multi-select/src/__tests__/IncrementalInteractions.tsx
@@ -152,4 +152,66 @@ describe('MultiSelect incremental interactions', () => {
 
 		expect(document.activeElement).toEqual(close);
 	});
+
+	describe('keyboard arrows indicator', () => {
+		it('does not render the indicator by default', () => {
+			const {getByRole} = render(
+				<MultiSelect
+					defaultItems={[labels[0]!]}
+					sourceItems={labels}
+					spritemap="/foo/bar"
+				/>
+			);
+
+			userEvent.click(getByRole('combobox'));
+
+			expect(
+				document.body.querySelector('.clay-keyboard-arrows-indicator')
+			).not.toBeInTheDocument();
+		});
+
+		it('renders the floating indicator with direction "vertical" when enabled', () => {
+			const {getByRole} = render(
+				<MultiSelect
+					defaultItems={[labels[0]!]}
+					displayKeyboardArrowsIndicator
+					sourceItems={labels}
+					spritemap="/foo/bar"
+				/>
+			);
+
+			userEvent.click(getByRole('combobox'));
+
+			const indicator = document.body.querySelector(
+				'.clay-keyboard-arrows-indicator'
+			);
+
+			expect(indicator).toBeInTheDocument();
+			expect(indicator).toHaveClass('clay-keyboard-arrows-vertical');
+			expect(indicator).toHaveClass(
+				'clay-keyboard-arrows-indicator-floating'
+			);
+		});
+
+		it('uses the localized label on the indicator', () => {
+			const {getByRole} = render(
+				<MultiSelect
+					defaultItems={[labels[0]!]}
+					displayKeyboardArrowsIndicator
+					keyboardArrowsIndicatorLabel="Use up and down arrow keys to navigate suggestions"
+					sourceItems={labels}
+					spritemap="/foo/bar"
+				/>
+			);
+
+			userEvent.click(getByRole('combobox'));
+
+			expect(
+				document.body.querySelector('.clay-keyboard-arrows-indicator')
+			).toHaveAttribute(
+				'aria-label',
+				'Use up and down arrow keys to navigate suggestions'
+			);
+		});
+	});
 });

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-multi-select/src/__tests__/IncrementalInteractions.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-multi-select/src/__tests__/IncrementalInteractions.tsx
@@ -192,26 +192,5 @@ describe('MultiSelect incremental interactions', () => {
 				'clay-keyboard-arrows-indicator-floating'
 			);
 		});
-
-		it('uses the localized label on the indicator', () => {
-			const {getByRole} = render(
-				<MultiSelect
-					defaultItems={[labels[0]!]}
-					displayKeyboardArrowsIndicator
-					keyboardArrowsIndicatorLabel="Use up and down arrow keys to navigate suggestions"
-					sourceItems={labels}
-					spritemap="/foo/bar"
-				/>
-			);
-
-			userEvent.click(getByRole('combobox'));
-
-			expect(
-				document.body.querySelector('.clay-keyboard-arrows-indicator')
-			).toHaveAttribute(
-				'aria-label',
-				'Use up and down arrow keys to navigate suggestions'
-			);
-		});
 	});
 });

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-multi-select/src/__tests__/IncrementalInteractions.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-multi-select/src/__tests__/IncrementalInteractions.tsx
@@ -154,7 +154,7 @@ describe('MultiSelect incremental interactions', () => {
 	});
 
 	describe('keyboard arrows indicator', () => {
-		it('does not render the indicator by default', () => {
+		it('does not render the indicator by default', async () => {
 			const {getByRole} = render(
 				<MultiSelect
 					defaultItems={[labels[0]!]}
@@ -163,14 +163,14 @@ describe('MultiSelect incremental interactions', () => {
 				/>
 			);
 
-			userEvent.click(getByRole('combobox'));
+			await userEvent.click(getByRole('combobox'));
 
 			expect(
 				document.body.querySelector('.clay-keyboard-arrows-indicator')
 			).not.toBeInTheDocument();
 		});
 
-		it('renders the floating indicator with direction "vertical" when enabled', () => {
+		it('renders the floating indicator with direction "vertical" when enabled', async () => {
 			const {getByRole} = render(
 				<MultiSelect
 					defaultItems={[labels[0]!]}
@@ -180,7 +180,7 @@ describe('MultiSelect incremental interactions', () => {
 				/>
 			);
 
-			userEvent.click(getByRole('combobox'));
+			await userEvent.click(getByRole('combobox'));
 
 			const indicator = document.body.querySelector(
 				'.clay-keyboard-arrows-indicator'

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-multi-select/stories/MultiSelect.stories.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-multi-select/stories/MultiSelect.stories.tsx
@@ -483,3 +483,22 @@ export function WithPrimaryAction() {
 		</>
 	);
 }
+export function KeyboardArrowsIndicator() {
+	const [value, setValue] = useState('');
+	const [items, setItems] = useState<Array<any>>([sourceItems[0]!]);
+
+	return (
+		<div style={{maxWidth: '320px'}}>
+			<ClayMultiSelect
+				defaultActive
+				displayKeyboardArrowsIndicator
+				items={items}
+				keyboardArrowsIndicatorLabel="Use up and down arrow keys to navigate suggestions"
+				onChange={setValue}
+				onItemsChange={(val) => setItems(val as any)}
+				sourceItems={sourceItems}
+				value={value}
+			/>
+		</div>
+	);
+}

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-multi-select/stories/MultiSelect.stories.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-multi-select/stories/MultiSelect.stories.tsx
@@ -493,7 +493,6 @@ export function KeyboardArrowsIndicator() {
 				defaultActive
 				displayKeyboardArrowsIndicator
 				items={items}
-				keyboardArrowsIndicatorLabel="Use up and down arrow keys to navigate suggestions"
 				onChange={setValue}
 				onItemsChange={(val) => setItems(val as any)}
 				sourceItems={sourceItems}

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-shared/src/useOverlayPosition.ts
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-shared/src/useOverlayPosition.ts
@@ -37,6 +37,7 @@ const ALIGN_MAP = {
 	BottomCenter: ['tc', 'bc'],
 	BottomLeft: ['tl', 'bl'],
 	BottomRight: ['tr', 'br'],
+	Center: ['cc', 'cc'],
 	LeftBottom: ['br', 'bl'],
 	LeftCenter: ['cr', 'cl'],
 	LeftTop: ['tr', 'tl'],

--- a/modules/apps/frontend-js/frontend-js-clay-web/node-scripts.config.js
+++ b/modules/apps/frontend-js/frontend-js-clay-web/node-scripts.config.js
@@ -72,6 +72,7 @@ module.exports = {
 			'Heading',
 			'Icon',
 			'IconSelector',
+			'KeyboardArrowsIndicator',
 			'LanguagePicker',
 			'Modal',
 			'ModalContext',

--- a/modules/node-scripts.config.js
+++ b/modules/node-scripts.config.js
@@ -10,7 +10,7 @@
  */
 
 module.exports = {
-	hash: '05097b20f14f210f442152c224b132906879fa39404d1f8afc696bf8fe3e3276',
+	hash: '4cb5d4f47dcf9c9cf50bf1d79ec074ee6f2cdacdb3b273dd4bcf0897d4612089',
 	imports: {
 		'@liferay/accessibility-menu-web': [],
 		'@liferay/accessibility-settings-state-web': [],

--- a/modules/node-scripts.config.js
+++ b/modules/node-scripts.config.js
@@ -522,6 +522,7 @@ module.exports = {
 			'Heading',
 			'Icon',
 			'IconSelector',
+			'KeyboardArrowsIndicator',
 			'LanguagePicker',
 			'Modal',
 			'ModalContext',


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-39987

## What is being fixed

LPD-39987 asks for a consistent visual indicator that tells keyboard users which arrow keys are active inside Clay components that support arrow-key navigation, with screen-reader descriptions per direction ("all arrows active", "up and down", "left and right"). The KeyboardArrowsIndicator component itself landed in LPD-40038; this branch wires it into the eight components the parent ticket lists as subtasks, plus the ResizeHandle (LPD-91699) follow-up.

## How it is being fixed

The first commit reshapes KeyboardArrowsIndicator into a tooltip-style anchored component. When given an `anchorRef`, it positions itself alongside the anchor via `useOverlayPosition` with `autoBestAlign` flipping to the opposite side on viewport overflow, hides under a `:focus-within`-equivalent JS check when the anchor is not keyboard-engaged, and transitions its `top`/`left`/`right`/`bottom` over 0.3s `ease-in-out` so the indicator slides along when the anchor moves (matching the c-slideout panel slide-in). A `placement` prop adds a `center` variant for narrow surfaces like the resize handle, which renders the indicator overlaid on the handle with no tooltip arrow.

Each subsequent commit wires one consumer. Each adds two opt-in props (`displayKeyboardArrowsIndicator` and `keyboardArrowsIndicatorLabel`), renders the indicator in a `ClayPortal` anchored to the focus-receiving element of that component, picks the `direction` that matches the component's actual keyboard contract, and adds tests plus a story. The anchor choice is per-component: trigger refs for Picker, Autocomplete, and MultiSelect (focus stays on the trigger via aria-activedescendant or input); menu refs for DropDown, IconSelector, and DatePicker (focus moves into the open panel); the bar's nav for VerticalNav; and the outer c-slideout wrapper for VerticalBar so the indicator follows the panel as it slides in.

## How to test

You can test in the storybook, each component now have a new story for keyboard indicator.

/cc @marcoscv-work 