### PR TITLE
LPD-90973 Add Content Label component and variants to Clay

### DIFF
--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_labels.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_labels.scss
@@ -1336,6 +1336,366 @@ $label-inverse-dark: map-deep-merge(
 	$label-inverse-dark
 );
 
+$label-inverse-content-0: () !default;
+$label-inverse-content-0: map-deep-merge(
+	(
+		background-color:
+			var(--label-inverse-content-0-background-color, $secondary-l3),
+		border-color: var(--label-inverse-content-0-border-color, transparent),
+		color: var(--label-inverse-content-0-color, $dark-d2),
+		href: (
+			hover: (
+				background-color:
+					var(
+						--label-inverse-content-0-hover-background-color,
+						$secondary-l3
+					),
+				border-color:
+					var(
+						--label-inverse-content-0-hover-border-color,
+						transparent
+					),
+				color: var(--label-inverse-content-0-hover-color, $dark-d2),
+			),
+
+			focus: (
+				background-color:
+					var(
+						--label-inverse-content-0-focus-background-color,
+						$secondary-l3
+					),
+				border-color:
+					var(
+						--label-inverse-content-0-focus-border-color,
+						transparent
+					),
+				color: var(--label-inverse-content-0-focus-color, $dark-d2),
+			),
+		),
+	),
+	$label-inverse-content-0
+);
+
+$label-inverse-content-1: () !default;
+$label-inverse-content-1: map-deep-merge(
+	(
+		background-color:
+			var(--label-inverse-content-1-background-color, $purple-l5),
+		border-color: var(--label-inverse-content-1-border-color, transparent),
+		color: var(--label-inverse-content-1-color, $purple-d2),
+		href: (
+			hover: (
+				background-color:
+					var(
+						--label-inverse-content-1-hover-background-color,
+						$purple-l5
+					),
+				border-color:
+					var(
+						--label-inverse-content-1-hover-border-color,
+						transparent
+					),
+				color: var(--label-inverse-content-1-hover-color, $purple-d2),
+			),
+
+			focus: (
+				background-color:
+					var(
+						--label-inverse-content-1-focus-background-color,
+						$purple-l5
+					),
+				border-color:
+					var(
+						--label-inverse-content-1-focus-border-color,
+						transparent
+					),
+				color: var(--label-inverse-content-1-focus-color, $purple-d2),
+			),
+		),
+	),
+	$label-inverse-content-1
+);
+
+$label-inverse-content-2: () !default;
+$label-inverse-content-2: map-deep-merge(
+	(
+		background-color:
+			var(--label-inverse-content-2-background-color, $yellow-l5),
+		border-color: var(--label-inverse-content-2-border-color, transparent),
+		color: var(--label-inverse-content-2-color, $yellow-d4),
+		href: (
+			hover: (
+				background-color:
+					var(
+						--label-inverse-content-2-hover-background-color,
+						$yellow-l5
+					),
+				border-color:
+					var(
+						--label-inverse-content-2-hover-border-color,
+						transparent
+					),
+				color: var(--label-inverse-content-2-hover-color, $yellow-d4),
+			),
+
+			focus: (
+				background-color:
+					var(
+						--label-inverse-content-2-focus-background-color,
+						$yellow-l5
+					),
+				border-color:
+					var(
+						--label-inverse-content-2-focus-border-color,
+						transparent
+					),
+				color: var(--label-inverse-content-2-focus-color, $yellow-d4),
+			),
+		),
+	),
+	$label-inverse-content-2
+);
+
+$label-inverse-content-3: () !default;
+$label-inverse-content-3: map-deep-merge(
+	(
+		background-color:
+			var(--label-inverse-content-3-background-color, $green-l5),
+		border-color: var(--label-inverse-content-3-border-color, transparent),
+		color: var(--label-inverse-content-3-color, $green-d2),
+		href: (
+			hover: (
+				background-color:
+					var(
+						--label-inverse-content-3-hover-background-color,
+						$green-l5
+					),
+				border-color:
+					var(
+						--label-inverse-content-3-hover-border-color,
+						transparent
+					),
+				color: var(--label-inverse-content-3-hover-color, $green-d2),
+			),
+
+			focus: (
+				background-color:
+					var(
+						--label-inverse-content-3-focus-background-color,
+						$green-l5
+					),
+				border-color:
+					var(
+						--label-inverse-content-3-focus-border-color,
+						transparent
+					),
+				color: var(--label-inverse-content-3-focus-color, $green-d2),
+			),
+		),
+	),
+	$label-inverse-content-3
+);
+
+$label-inverse-content-4: () !default;
+$label-inverse-content-4: map-deep-merge(
+	(
+		background-color:
+			var(--label-inverse-content-4-background-color, $red-l5),
+		border-color: var(--label-inverse-content-4-border-color, transparent),
+		color: var(--label-inverse-content-4-color, $red-d2),
+		href: (
+			hover: (
+				background-color:
+					var(
+						--label-inverse-content-4-hover-background-color,
+						$red-l5
+					),
+				border-color:
+					var(
+						--label-inverse-content-4-hover-border-color,
+						transparent
+					),
+				color: var(--label-inverse-content-4-hover-color, $red-d2),
+			),
+
+			focus: (
+				background-color:
+					var(
+						--label-inverse-content-4-focus-background-color,
+						$red-l5
+					),
+				border-color:
+					var(
+						--label-inverse-content-4-focus-border-color,
+						transparent
+					),
+				color: var(--label-inverse-content-4-focus-color, $red-d2),
+			),
+		),
+	),
+	$label-inverse-content-4
+);
+
+$label-inverse-content-5: () !default;
+$label-inverse-content-5: map-deep-merge(
+	(
+		background-color:
+			var(--label-inverse-content-5-background-color, $teal-l5),
+		border-color: var(--label-inverse-content-5-border-color, transparent),
+		color: var(--label-inverse-content-5-color, $teal-d2),
+		href: (
+			hover: (
+				background-color:
+					var(
+						--label-inverse-content-5-hover-background-color,
+						$teal-l5
+					),
+				border-color:
+					var(
+						--label-inverse-content-5-hover-border-color,
+						transparent
+					),
+				color: var(--label-inverse-content-5-hover-color, $teal-d2),
+			),
+
+			focus: (
+				background-color:
+					var(
+						--label-inverse-content-5-focus-background-color,
+						$teal-l5
+					),
+				border-color:
+					var(
+						--label-inverse-content-5-focus-border-color,
+						transparent
+					),
+				color: var(--label-inverse-content-5-focus-color, $teal-d2),
+			),
+		),
+	),
+	$label-inverse-content-5
+);
+
+$label-inverse-content-6: () !default;
+$label-inverse-content-6: map-deep-merge(
+	(
+		background-color:
+			var(--label-inverse-content-6-background-color, $cyan-l5),
+		border-color: var(--label-inverse-content-6-border-color, transparent),
+		color: var(--label-inverse-content-6-color, $cyan-d2),
+		href: (
+			hover: (
+				background-color:
+					var(
+						--label-inverse-content-6-hover-background-color,
+						$cyan-l5
+					),
+				border-color:
+					var(
+						--label-inverse-content-6-hover-border-color,
+						transparent
+					),
+				color: var(--label-inverse-content-6-hover-color, $cyan-d2),
+			),
+
+			focus: (
+				background-color:
+					var(
+						--label-inverse-content-6-focus-background-color,
+						$cyan-l5
+					),
+				border-color:
+					var(
+						--label-inverse-content-6-focus-border-color,
+						transparent
+					),
+				color: var(--label-inverse-content-6-focus-color, $cyan-d2),
+			),
+		),
+	),
+	$label-inverse-content-6
+);
+
+$label-inverse-content-7: () !default;
+$label-inverse-content-7: map-deep-merge(
+	(
+		background-color:
+			var(--label-inverse-content-7-background-color, $orange-l5),
+		border-color: var(--label-inverse-content-7-border-color, transparent),
+		color: var(--label-inverse-content-7-color, $orange-d2),
+		href: (
+			hover: (
+				background-color:
+					var(
+						--label-inverse-content-7-hover-background-color,
+						$orange-l5
+					),
+				border-color:
+					var(
+						--label-inverse-content-7-hover-border-color,
+						transparent
+					),
+				color: var(--label-inverse-content-7-hover-color, $orange-d2),
+			),
+
+			focus: (
+				background-color:
+					var(
+						--label-inverse-content-7-focus-background-color,
+						$orange-l5
+					),
+				border-color:
+					var(
+						--label-inverse-content-7-focus-border-color,
+						transparent
+					),
+				color: var(--label-inverse-content-7-focus-color, $orange-d2),
+			),
+		),
+	),
+	$label-inverse-content-7
+);
+
+$label-inverse-content-8: () !default;
+$label-inverse-content-8: map-deep-merge(
+	(
+		background-color:
+			var(--label-inverse-content-8-background-color, $pink-l5),
+		border-color: var(--label-inverse-content-8-border-color, transparent),
+		color: var(--label-inverse-content-8-color, $pink-d2),
+		href: (
+			hover: (
+				background-color:
+					var(
+						--label-inverse-content-8-hover-background-color,
+						$pink-l5
+					),
+				border-color:
+					var(
+						--label-inverse-content-8-hover-border-color,
+						transparent
+					),
+				color: var(--label-inverse-content-8-hover-color, $pink-d2),
+			),
+
+			focus: (
+				background-color:
+					var(
+						--label-inverse-content-8-focus-background-color,
+						$pink-l5
+					),
+				border-color:
+					var(
+						--label-inverse-content-8-focus-border-color,
+						transparent
+					),
+				color: var(--label-inverse-content-8-focus-color, $pink-d2),
+			),
+		),
+	),
+	$label-inverse-content-8
+);
+
 $label-palette: () !default;
 $label-palette: map-deep-merge(
 	(
@@ -1370,6 +1730,24 @@ $label-palette: map-deep-merge(
 		inverse-light: $label-inverse-light,
 
 		inverse-dark: $label-inverse-dark,
+
+		inverse-content-0: $label-inverse-content-0,
+
+		inverse-content-1: $label-inverse-content-1,
+
+		inverse-content-2: $label-inverse-content-2,
+
+		inverse-content-3: $label-inverse-content-3,
+
+		inverse-content-4: $label-inverse-content-4,
+
+		inverse-content-5: $label-inverse-content-5,
+
+		inverse-content-6: $label-inverse-content-6,
+
+		inverse-content-7: $label-inverse-content-7,
+
+		inverse-content-8: $label-inverse-content-8,
 	),
 	$label-palette
 );

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas/variables/_labels.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas/variables/_labels.scss
@@ -621,6 +621,276 @@ $label-inverse-dark: map-deep-merge(
 	$label-inverse-dark
 );
 
+$label-inverse-content-0: () !default;
+$label-inverse-content-0: map-deep-merge(
+	(
+		background-color: $secondary-l3,
+		border-color: $secondary-l3,
+		color: $dark-d2,
+
+		href: (
+			hover: (
+				background-color: $secondary-l3,
+				border-color: $secondary-l3,
+				color: $dark-d2,
+			),
+		),
+
+		link: (
+			hover: (
+				color: $dark-d2,
+			),
+		),
+
+		close: (
+			hover: (
+				color: $dark-d2,
+			),
+		),
+	),
+	$label-inverse-content-0
+);
+
+$label-inverse-content-1: () !default;
+$label-inverse-content-1: map-deep-merge(
+	(
+		background-color: $purple-l5,
+		border-color: $purple-l5,
+		color: $purple-d2,
+
+		href: (
+			hover: (
+				background-color: $purple-l5,
+				border-color: $purple-l5,
+				color: $purple-d2,
+			),
+		),
+
+		link: (
+			hover: (
+				color: $purple-d2,
+			),
+		),
+
+		close: (
+			hover: (
+				color: $purple-d2,
+			),
+		),
+	),
+	$label-inverse-content-1
+);
+
+$label-inverse-content-2: () !default;
+$label-inverse-content-2: map-deep-merge(
+	(
+		background-color: $yellow-l5,
+		border-color: $yellow-l5,
+		color: $yellow-d4,
+
+		href: (
+			hover: (
+				background-color: $yellow-l5,
+				border-color: $yellow-l5,
+				color: $yellow-d4,
+			),
+		),
+
+		link: (
+			hover: (
+				color: $yellow-d4,
+			),
+		),
+
+		close: (
+			hover: (
+				color: $yellow-d4,
+			),
+		),
+	),
+	$label-inverse-content-2
+);
+
+$label-inverse-content-3: () !default;
+$label-inverse-content-3: map-deep-merge(
+	(
+		background-color: $green-l5,
+		border-color: $green-l5,
+		color: $green-d2,
+
+		href: (
+			hover: (
+				background-color: $green-l5,
+				border-color: $green-l5,
+				color: $green-d2,
+			),
+		),
+
+		link: (
+			hover: (
+				color: $green-d2,
+			),
+		),
+
+		close: (
+			hover: (
+				color: $green-d2,
+			),
+		),
+	),
+	$label-inverse-content-3
+);
+
+$label-inverse-content-4: () !default;
+$label-inverse-content-4: map-deep-merge(
+	(
+		background-color: $red-l5,
+		border-color: $red-l5,
+		color: $red-d2,
+
+		href: (
+			hover: (
+				background-color: $red-l5,
+				border-color: $red-l5,
+				color: $red-d2,
+			),
+		),
+
+		link: (
+			hover: (
+				color: $red-d2,
+			),
+		),
+
+		close: (
+			hover: (
+				color: $red-d2,
+			),
+		),
+	),
+	$label-inverse-content-4
+);
+
+$label-inverse-content-5: () !default;
+$label-inverse-content-5: map-deep-merge(
+	(
+		background-color: $teal-l5,
+		border-color: $teal-l5,
+		color: $teal-d2,
+
+		href: (
+			hover: (
+				background-color: $teal-l5,
+				border-color: $teal-l5,
+				color: $teal-d2,
+			),
+		),
+
+		link: (
+			hover: (
+				color: $teal-d2,
+			),
+		),
+
+		close: (
+			hover: (
+				color: $teal-d2,
+			),
+		),
+	),
+	$label-inverse-content-5
+);
+
+$label-inverse-content-6: () !default;
+$label-inverse-content-6: map-deep-merge(
+	(
+		background-color: $cyan-l5,
+		border-color: $cyan-l5,
+		color: $cyan-d2,
+
+		href: (
+			hover: (
+				background-color: $cyan-l5,
+				border-color: $cyan-l5,
+				color: $cyan-d2,
+			),
+		),
+
+		link: (
+			hover: (
+				color: $cyan-d2,
+			),
+		),
+
+		close: (
+			hover: (
+				color: $cyan-d2,
+			),
+		),
+	),
+	$label-inverse-content-6
+);
+
+$label-inverse-content-7: () !default;
+$label-inverse-content-7: map-deep-merge(
+	(
+		background-color: $orange-l5,
+		border-color: $orange-l5,
+		color: $orange-d2,
+
+		href: (
+			hover: (
+				background-color: $orange-l5,
+				border-color: $orange-l5,
+				color: $orange-d2,
+			),
+		),
+
+		link: (
+			hover: (
+				color: $orange-d2,
+			),
+		),
+
+		close: (
+			hover: (
+				color: $orange-d2,
+			),
+		),
+	),
+	$label-inverse-content-7
+);
+
+$label-inverse-content-8: () !default;
+$label-inverse-content-8: map-deep-merge(
+	(
+		background-color: $pink-l5,
+		border-color: $pink-l5,
+		color: $pink-d2,
+
+		href: (
+			hover: (
+				background-color: $pink-l5,
+				border-color: $pink-l5,
+				color: $pink-d2,
+			),
+		),
+
+		link: (
+			hover: (
+				color: $pink-d2,
+			),
+		),
+
+		close: (
+			hover: (
+				color: $pink-d2,
+			),
+		),
+	),
+	$label-inverse-content-8
+);
+
 $label-palette: () !default;
 $label-palette: map-deep-merge(
 	(
@@ -655,6 +925,24 @@ $label-palette: map-deep-merge(
 		inverse-light: $label-inverse-light,
 
 		inverse-dark: $label-inverse-dark,
+
+		inverse-content-0: $label-inverse-content-0,
+
+		inverse-content-1: $label-inverse-content-1,
+
+		inverse-content-2: $label-inverse-content-2,
+
+		inverse-content-3: $label-inverse-content-3,
+
+		inverse-content-4: $label-inverse-content-4,
+
+		inverse-content-5: $label-inverse-content-5,
+
+		inverse-content-6: $label-inverse-content-6,
+
+		inverse-content-7: $label-inverse-content-7,
+
+		inverse-content-8: $label-inverse-content-8,
 	),
 	$label-palette
 );

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas/variables/_labels.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas/variables/_labels.scss
@@ -395,7 +395,7 @@ $label-inverse-primary: map-deep-merge(
 		href: (
 			hover: (
 				background-color: null,
-				border-color: null,
+				border-color: transparent,
 				color: $white,
 			),
 		),
@@ -419,13 +419,13 @@ $label-inverse-secondary: () !default;
 $label-inverse-secondary: map-deep-merge(
 	(
 		background-color: $secondary-l3,
-		border-color: $secondary-l3,
+		border-color: transparent,
 		color: $dark-d2,
 
 		href: (
 			hover: (
 				background-color: $secondary-l3,
-				border-color: $secondary-l3,
+				border-color: transparent,
 				color: $dark-d2,
 			),
 		),
@@ -449,13 +449,13 @@ $label-inverse-success: () !default;
 $label-inverse-success: map-deep-merge(
 	(
 		background-color: $success-l2,
-		border-color: $success-l2,
+		border-color: transparent,
 		color: $success-d2,
 
 		href: (
 			hover: (
 				background-color: $success-l2,
-				border-color: $success-l2,
+				border-color: transparent,
 				color: $success-d2,
 			),
 		),
@@ -479,13 +479,13 @@ $label-inverse-info: () !default;
 $label-inverse-info: map-deep-merge(
 	(
 		background-color: $info-l2,
-		border-color: $info-l2,
+		border-color: transparent,
 		color: $info-d2,
 
 		href: (
 			hover: (
 				background-color: $info-l2,
-				border-color: $info-l2,
+				border-color: transparent,
 				color: $info-d2,
 			),
 		),
@@ -509,13 +509,13 @@ $label-inverse-warning: () !default;
 $label-inverse-warning: map-deep-merge(
 	(
 		background-color: $warning-l2,
-		border-color: $warning-l2,
+		border-color: transparent,
 		color: $warning-d2,
 
 		href: (
 			hover: (
 				background-color: $warning-l2,
-				border-color: $warning-l2,
+				border-color: transparent,
 				color: $warning-d2,
 			),
 		),
@@ -539,13 +539,13 @@ $label-inverse-danger: () !default;
 $label-inverse-danger: map-deep-merge(
 	(
 		background-color: $danger-l2,
-		border-color: $danger-l2,
+		border-color: transparent,
 		color: $danger-d2,
 
 		href: (
 			hover: (
 				background-color: $danger-l2,
-				border-color: $danger-l2,
+				border-color: transparent,
 				color: $danger-d2,
 			),
 		),
@@ -573,7 +573,7 @@ $label-inverse-light: map-deep-merge(
 		href: (
 			hover: (
 				background-color: null,
-				border-color: null,
+				border-color: transparent,
 				color: $dark,
 			),
 		),
@@ -601,7 +601,7 @@ $label-inverse-dark: map-deep-merge(
 		href: (
 			hover: (
 				background-color: null,
-				border-color: null,
+				border-color: transparent,
 				color: $white,
 			),
 		),
@@ -625,13 +625,13 @@ $label-inverse-content-0: () !default;
 $label-inverse-content-0: map-deep-merge(
 	(
 		background-color: $secondary-l3,
-		border-color: $secondary-l3,
+		border-color: transparent,
 		color: $dark-d2,
 
 		href: (
 			hover: (
 				background-color: $secondary-l3,
-				border-color: $secondary-l3,
+				border-color: transparent,
 				color: $dark-d2,
 			),
 		),
@@ -655,13 +655,13 @@ $label-inverse-content-1: () !default;
 $label-inverse-content-1: map-deep-merge(
 	(
 		background-color: $purple-l5,
-		border-color: $purple-l5,
+		border-color: transparent,
 		color: $purple-d2,
 
 		href: (
 			hover: (
 				background-color: $purple-l5,
-				border-color: $purple-l5,
+				border-color: transparent,
 				color: $purple-d2,
 			),
 		),
@@ -685,13 +685,13 @@ $label-inverse-content-2: () !default;
 $label-inverse-content-2: map-deep-merge(
 	(
 		background-color: $yellow-l5,
-		border-color: $yellow-l5,
+		border-color: transparent,
 		color: $yellow-d4,
 
 		href: (
 			hover: (
 				background-color: $yellow-l5,
-				border-color: $yellow-l5,
+				border-color: transparent,
 				color: $yellow-d4,
 			),
 		),
@@ -715,13 +715,13 @@ $label-inverse-content-3: () !default;
 $label-inverse-content-3: map-deep-merge(
 	(
 		background-color: $green-l5,
-		border-color: $green-l5,
+		border-color: transparent,
 		color: $green-d2,
 
 		href: (
 			hover: (
 				background-color: $green-l5,
-				border-color: $green-l5,
+				border-color: transparent,
 				color: $green-d2,
 			),
 		),
@@ -745,13 +745,13 @@ $label-inverse-content-4: () !default;
 $label-inverse-content-4: map-deep-merge(
 	(
 		background-color: $red-l5,
-		border-color: $red-l5,
+		border-color: transparent,
 		color: $red-d2,
 
 		href: (
 			hover: (
 				background-color: $red-l5,
-				border-color: $red-l5,
+				border-color: transparent,
 				color: $red-d2,
 			),
 		),
@@ -775,13 +775,13 @@ $label-inverse-content-5: () !default;
 $label-inverse-content-5: map-deep-merge(
 	(
 		background-color: $teal-l5,
-		border-color: $teal-l5,
+		border-color: transparent,
 		color: $teal-d2,
 
 		href: (
 			hover: (
 				background-color: $teal-l5,
-				border-color: $teal-l5,
+				border-color: transparent,
 				color: $teal-d2,
 			),
 		),
@@ -805,13 +805,13 @@ $label-inverse-content-6: () !default;
 $label-inverse-content-6: map-deep-merge(
 	(
 		background-color: $cyan-l5,
-		border-color: $cyan-l5,
+		border-color: transparent,
 		color: $cyan-d2,
 
 		href: (
 			hover: (
 				background-color: $cyan-l5,
-				border-color: $cyan-l5,
+				border-color: transparent,
 				color: $cyan-d2,
 			),
 		),
@@ -835,13 +835,13 @@ $label-inverse-content-7: () !default;
 $label-inverse-content-7: map-deep-merge(
 	(
 		background-color: $orange-l5,
-		border-color: $orange-l5,
+		border-color: transparent,
 		color: $orange-d2,
 
 		href: (
 			hover: (
 				background-color: $orange-l5,
-				border-color: $orange-l5,
+				border-color: transparent,
 				color: $orange-d2,
 			),
 		),
@@ -865,13 +865,13 @@ $label-inverse-content-8: () !default;
 $label-inverse-content-8: map-deep-merge(
 	(
 		background-color: $pink-l5,
-		border-color: $pink-l5,
+		border-color: transparent,
 		color: $pink-d2,
 
 		href: (
 			hover: (
 				background-color: $pink-l5,
-				border-color: $pink-l5,
+				border-color: transparent,
 				color: $pink-d2,
 			),
 		),

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/variables/_labels.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/variables/_labels.scss
@@ -918,7 +918,7 @@ $cadmin-label-inverse-primary: () !default;
 $cadmin-label-inverse-primary: map-deep-merge(
 	(
 		background-color: $cadmin-primary,
-		border-color: $cadmin-primary,
+		border-color: transparent,
 		color: $cadmin-white,
 
 		href: (
@@ -934,7 +934,7 @@ $cadmin-label-inverse-secondary: () !default;
 $cadmin-label-inverse-secondary: map-deep-merge(
 	(
 		background-color: $cadmin-secondary-l3,
-		border-color: $cadmin-secondary-l3,
+		border-color: transparent,
 		color: $cadmin-dark-d2,
 
 		href: (
@@ -950,7 +950,7 @@ $cadmin-label-inverse-success: () !default;
 $cadmin-label-inverse-success: map-deep-merge(
 	(
 		background-color: $cadmin-success-l2,
-		border-color: $cadmin-success-l2,
+		border-color: transparent,
 		color: $cadmin-success-d2,
 
 		href: (
@@ -966,7 +966,7 @@ $cadmin-label-inverse-info: () !default;
 $cadmin-label-inverse-info: map-deep-merge(
 	(
 		background-color: $cadmin-info-l2,
-		border-color: $cadmin-info-l2,
+		border-color: transparent,
 		color: $cadmin-info-d2,
 
 		href: (
@@ -982,7 +982,7 @@ $cadmin-label-inverse-warning: () !default;
 $cadmin-label-inverse-warning: map-deep-merge(
 	(
 		background-color: $cadmin-warning-l2,
-		border-color: $cadmin-warning-l2,
+		border-color: transparent,
 		color: $cadmin-warning-d2,
 
 		href: (
@@ -998,7 +998,7 @@ $cadmin-label-inverse-danger: () !default;
 $cadmin-label-inverse-danger: map-deep-merge(
 	(
 		background-color: $cadmin-danger-l2,
-		border-color: $cadmin-danger-l2,
+		border-color: transparent,
 		color: $cadmin-danger-d2,
 
 		href: (
@@ -1014,7 +1014,7 @@ $cadmin-label-inverse-light: () !default;
 $cadmin-label-inverse-light: map-deep-merge(
 	(
 		background-color: $cadmin-light,
-		border-color: $cadmin-light,
+		border-color: transparent,
 		color: $cadmin-dark,
 
 		href: (
@@ -1030,7 +1030,7 @@ $cadmin-label-inverse-dark: () !default;
 $cadmin-label-inverse-dark: map-deep-merge(
 	(
 		background-color: $cadmin-dark,
-		border-color: $cadmin-dark,
+		border-color: transparent,
 		color: $cadmin-white,
 
 		href: (
@@ -1046,7 +1046,7 @@ $cadmin-label-inverse-content-0: () !default;
 $cadmin-label-inverse-content-0: map-deep-merge(
 	(
 		background-color: $cadmin-secondary-l3,
-		border-color: $cadmin-secondary-l3,
+		border-color: transparent,
 		color: $cadmin-dark-d2,
 
 		href: (
@@ -1062,7 +1062,7 @@ $cadmin-label-inverse-content-1: () !default;
 $cadmin-label-inverse-content-1: map-deep-merge(
 	(
 		background-color: $cadmin-purple-l5,
-		border-color: $cadmin-purple-l5,
+		border-color: transparent,
 		color: $cadmin-purple-d2,
 
 		href: (
@@ -1078,7 +1078,7 @@ $cadmin-label-inverse-content-2: () !default;
 $cadmin-label-inverse-content-2: map-deep-merge(
 	(
 		background-color: $cadmin-yellow-l5,
-		border-color: $cadmin-yellow-l5,
+		border-color: transparent,
 		color: $cadmin-yellow-d4,
 
 		href: (
@@ -1094,7 +1094,7 @@ $cadmin-label-inverse-content-3: () !default;
 $cadmin-label-inverse-content-3: map-deep-merge(
 	(
 		background-color: $cadmin-green-l5,
-		border-color: $cadmin-green-l5,
+		border-color: transparent,
 		color: $cadmin-green-d2,
 
 		href: (
@@ -1110,7 +1110,7 @@ $cadmin-label-inverse-content-4: () !default;
 $cadmin-label-inverse-content-4: map-deep-merge(
 	(
 		background-color: $cadmin-red-l5,
-		border-color: $cadmin-red-l5,
+		border-color: transparent,
 		color: $cadmin-red-d2,
 
 		href: (
@@ -1126,7 +1126,7 @@ $cadmin-label-inverse-content-5: () !default;
 $cadmin-label-inverse-content-5: map-deep-merge(
 	(
 		background-color: $cadmin-teal-l5,
-		border-color: $cadmin-teal-l5,
+		border-color: transparent,
 		color: $cadmin-teal-d2,
 
 		href: (
@@ -1142,7 +1142,7 @@ $cadmin-label-inverse-content-6: () !default;
 $cadmin-label-inverse-content-6: map-deep-merge(
 	(
 		background-color: $cadmin-cyan-l5,
-		border-color: $cadmin-cyan-l5,
+		border-color: transparent,
 		color: $cadmin-cyan-d2,
 
 		href: (
@@ -1158,7 +1158,7 @@ $cadmin-label-inverse-content-7: () !default;
 $cadmin-label-inverse-content-7: map-deep-merge(
 	(
 		background-color: $cadmin-orange-l5,
-		border-color: $cadmin-orange-l5,
+		border-color: transparent,
 		color: $cadmin-orange-d2,
 
 		href: (
@@ -1174,7 +1174,7 @@ $cadmin-label-inverse-content-8: () !default;
 $cadmin-label-inverse-content-8: map-deep-merge(
 	(
 		background-color: $cadmin-pink-l5,
-		border-color: $cadmin-pink-l5,
+		border-color: transparent,
 		color: $cadmin-pink-d2,
 
 		href: (

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/variables/_labels.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/variables/_labels.scss
@@ -1042,6 +1042,150 @@ $cadmin-label-inverse-dark: map-deep-merge(
 	$cadmin-label-inverse-dark
 );
 
+$cadmin-label-inverse-content-0: () !default;
+$cadmin-label-inverse-content-0: map-deep-merge(
+	(
+		background-color: $cadmin-secondary-l3,
+		border-color: $cadmin-secondary-l3,
+		color: $cadmin-dark-d2,
+
+		href: (
+			hover: (
+				color: $cadmin-dark-d2,
+			),
+		),
+	),
+	$cadmin-label-inverse-content-0
+);
+
+$cadmin-label-inverse-content-1: () !default;
+$cadmin-label-inverse-content-1: map-deep-merge(
+	(
+		background-color: $cadmin-purple-l5,
+		border-color: $cadmin-purple-l5,
+		color: $cadmin-purple-d2,
+
+		href: (
+			hover: (
+				color: $cadmin-purple-d2,
+			),
+		),
+	),
+	$cadmin-label-inverse-content-1
+);
+
+$cadmin-label-inverse-content-2: () !default;
+$cadmin-label-inverse-content-2: map-deep-merge(
+	(
+		background-color: $cadmin-yellow-l5,
+		border-color: $cadmin-yellow-l5,
+		color: $cadmin-yellow-d4,
+
+		href: (
+			hover: (
+				color: $cadmin-yellow-d4,
+			),
+		),
+	),
+	$cadmin-label-inverse-content-2
+);
+
+$cadmin-label-inverse-content-3: () !default;
+$cadmin-label-inverse-content-3: map-deep-merge(
+	(
+		background-color: $cadmin-green-l5,
+		border-color: $cadmin-green-l5,
+		color: $cadmin-green-d2,
+
+		href: (
+			hover: (
+				color: $cadmin-green-d2,
+			),
+		),
+	),
+	$cadmin-label-inverse-content-3
+);
+
+$cadmin-label-inverse-content-4: () !default;
+$cadmin-label-inverse-content-4: map-deep-merge(
+	(
+		background-color: $cadmin-red-l5,
+		border-color: $cadmin-red-l5,
+		color: $cadmin-red-d2,
+
+		href: (
+			hover: (
+				color: $cadmin-red-d2,
+			),
+		),
+	),
+	$cadmin-label-inverse-content-4
+);
+
+$cadmin-label-inverse-content-5: () !default;
+$cadmin-label-inverse-content-5: map-deep-merge(
+	(
+		background-color: $cadmin-teal-l5,
+		border-color: $cadmin-teal-l5,
+		color: $cadmin-teal-d2,
+
+		href: (
+			hover: (
+				color: $cadmin-teal-d2,
+			),
+		),
+	),
+	$cadmin-label-inverse-content-5
+);
+
+$cadmin-label-inverse-content-6: () !default;
+$cadmin-label-inverse-content-6: map-deep-merge(
+	(
+		background-color: $cadmin-cyan-l5,
+		border-color: $cadmin-cyan-l5,
+		color: $cadmin-cyan-d2,
+
+		href: (
+			hover: (
+				color: $cadmin-cyan-d2,
+			),
+		),
+	),
+	$cadmin-label-inverse-content-6
+);
+
+$cadmin-label-inverse-content-7: () !default;
+$cadmin-label-inverse-content-7: map-deep-merge(
+	(
+		background-color: $cadmin-orange-l5,
+		border-color: $cadmin-orange-l5,
+		color: $cadmin-orange-d2,
+
+		href: (
+			hover: (
+				color: $cadmin-orange-d2,
+			),
+		),
+	),
+	$cadmin-label-inverse-content-7
+);
+
+$cadmin-label-inverse-content-8: () !default;
+$cadmin-label-inverse-content-8: map-deep-merge(
+	(
+		background-color: $cadmin-pink-l5,
+		border-color: $cadmin-pink-l5,
+		color: $cadmin-pink-d2,
+
+		href: (
+			hover: (
+				color: $cadmin-pink-d2,
+			),
+		),
+	),
+	$cadmin-label-inverse-content-8
+);
+
 $cadmin-label-palette: () !default;
 $cadmin-label-palette: map-deep-merge(
 	(
@@ -1076,6 +1220,24 @@ $cadmin-label-palette: map-deep-merge(
 		inverse-light: $cadmin-label-inverse-light,
 
 		inverse-dark: $cadmin-label-inverse-dark,
+
+		inverse-content-0: $cadmin-label-inverse-content-0,
+
+		inverse-content-1: $cadmin-label-inverse-content-1,
+
+		inverse-content-2: $cadmin-label-inverse-content-2,
+
+		inverse-content-3: $cadmin-label-inverse-content-3,
+
+		inverse-content-4: $cadmin-label-inverse-content-4,
+
+		inverse-content-5: $cadmin-label-inverse-content-5,
+
+		inverse-content-6: $cadmin-label-inverse-content-6,
+
+		inverse-content-7: $cadmin-label-inverse-content-7,
+
+		inverse-content-8: $cadmin-label-inverse-content-8,
 	),
 	$cadmin-label-palette
 );

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/variables/_labels.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/variables/_labels.scss
@@ -904,7 +904,7 @@ $label-inverse-primary: map-deep-merge(
 		href: (
 			hover: (
 				background-color: clay-darken($primary, 10%),
-				border-color: clay-darken($primary, 10%),
+				border-color: transparent,
 				color: color-yiq(clay-darken($primary, 10%)),
 			),
 		),
@@ -933,7 +933,7 @@ $label-inverse-secondary: map-deep-merge(
 		href: (
 			hover: (
 				background-color: clay-darken($secondary, 10%),
-				border-color: clay-darken($secondary, 10%),
+				border-color: transparent,
 				color: color-yiq(clay-darken($secondary, 10%)),
 			),
 		),
@@ -962,7 +962,7 @@ $label-inverse-success: map-deep-merge(
 		href: (
 			hover: (
 				background-color: clay-darken($success, 10%),
-				border-color: clay-darken($success, 10%),
+				border-color: transparent,
 				color: color-yiq(clay-darken($success, 10%)),
 			),
 		),
@@ -991,7 +991,7 @@ $label-inverse-info: map-deep-merge(
 		href: (
 			hover: (
 				background-color: clay-darken($info, 10%),
-				border-color: clay-darken($info, 10%),
+				border-color: transparent,
 				color: color-yiq(clay-darken($info, 10%)),
 			),
 		),
@@ -1020,7 +1020,7 @@ $label-inverse-warning: map-deep-merge(
 		href: (
 			hover: (
 				background-color: clay-darken($warning, 10%),
-				border-color: clay-darken($warning, 10%),
+				border-color: transparent,
 				color: color-yiq(clay-darken($warning, 10%)),
 			),
 		),
@@ -1049,7 +1049,7 @@ $label-inverse-danger: map-deep-merge(
 		href: (
 			hover: (
 				background-color: clay-darken($danger, 10%),
-				border-color: clay-darken($danger, 10%),
+				border-color: transparent,
 				color: color-yiq(clay-darken($danger, 10%)),
 			),
 		),
@@ -1078,7 +1078,7 @@ $label-inverse-light: map-deep-merge(
 		href: (
 			hover: (
 				background-color: clay-darken($light, 10%),
-				border-color: clay-darken($light, 10%),
+				border-color: transparent,
 				color: color-yiq(clay-darken($light, 10%)),
 			),
 		),
@@ -1107,7 +1107,7 @@ $label-inverse-dark: map-deep-merge(
 		href: (
 			hover: (
 				background-color: clay-darken($dark, 10%),
-				border-color: clay-darken($dark, 10%),
+				border-color: transparent,
 				color: color-yiq(clay-darken($dark, 10%)),
 			),
 		),
@@ -1131,13 +1131,13 @@ $label-inverse-content-0: () !default;
 $label-inverse-content-0: map-deep-merge(
 	(
 		background-color: $secondary-l3,
-		border-color: $secondary-l3,
+		border-color: transparent,
 		color: $dark-d2,
 
 		href: (
 			hover: (
 				background-color: $secondary-l3,
-				border-color: $secondary-l3,
+				border-color: transparent,
 				color: $dark-d2,
 			),
 		),
@@ -1161,13 +1161,13 @@ $label-inverse-content-1: () !default;
 $label-inverse-content-1: map-deep-merge(
 	(
 		background-color: $purple-l5,
-		border-color: $purple-l5,
+		border-color: transparent,
 		color: $purple-d2,
 
 		href: (
 			hover: (
 				background-color: $purple-l5,
-				border-color: $purple-l5,
+				border-color: transparent,
 				color: $purple-d2,
 			),
 		),
@@ -1191,13 +1191,13 @@ $label-inverse-content-2: () !default;
 $label-inverse-content-2: map-deep-merge(
 	(
 		background-color: $yellow-l5,
-		border-color: $yellow-l5,
+		border-color: transparent,
 		color: $yellow-d4,
 
 		href: (
 			hover: (
 				background-color: $yellow-l5,
-				border-color: $yellow-l5,
+				border-color: transparent,
 				color: $yellow-d4,
 			),
 		),
@@ -1221,13 +1221,13 @@ $label-inverse-content-3: () !default;
 $label-inverse-content-3: map-deep-merge(
 	(
 		background-color: $green-l5,
-		border-color: $green-l5,
+		border-color: transparent,
 		color: $green-d2,
 
 		href: (
 			hover: (
 				background-color: $green-l5,
-				border-color: $green-l5,
+				border-color: transparent,
 				color: $green-d2,
 			),
 		),
@@ -1251,13 +1251,13 @@ $label-inverse-content-4: () !default;
 $label-inverse-content-4: map-deep-merge(
 	(
 		background-color: $red-l5,
-		border-color: $red-l5,
+		border-color: transparent,
 		color: $red-d2,
 
 		href: (
 			hover: (
 				background-color: $red-l5,
-				border-color: $red-l5,
+				border-color: transparent,
 				color: $red-d2,
 			),
 		),
@@ -1281,13 +1281,13 @@ $label-inverse-content-5: () !default;
 $label-inverse-content-5: map-deep-merge(
 	(
 		background-color: $teal-l5,
-		border-color: $teal-l5,
+		border-color: transparent,
 		color: $teal-d2,
 
 		href: (
 			hover: (
 				background-color: $teal-l5,
-				border-color: $teal-l5,
+				border-color: transparent,
 				color: $teal-d2,
 			),
 		),
@@ -1311,13 +1311,13 @@ $label-inverse-content-6: () !default;
 $label-inverse-content-6: map-deep-merge(
 	(
 		background-color: $cyan-l5,
-		border-color: $cyan-l5,
+		border-color: transparent,
 		color: $cyan-d2,
 
 		href: (
 			hover: (
 				background-color: $cyan-l5,
-				border-color: $cyan-l5,
+				border-color: transparent,
 				color: $cyan-d2,
 			),
 		),
@@ -1341,13 +1341,13 @@ $label-inverse-content-7: () !default;
 $label-inverse-content-7: map-deep-merge(
 	(
 		background-color: $orange-l5,
-		border-color: $orange-l5,
+		border-color: transparent,
 		color: $orange-d2,
 
 		href: (
 			hover: (
 				background-color: $orange-l5,
-				border-color: $orange-l5,
+				border-color: transparent,
 				color: $orange-d2,
 			),
 		),
@@ -1371,13 +1371,13 @@ $label-inverse-content-8: () !default;
 $label-inverse-content-8: map-deep-merge(
 	(
 		background-color: $pink-l5,
-		border-color: $pink-l5,
+		border-color: transparent,
 		color: $pink-d2,
 
 		href: (
 			hover: (
 				background-color: $pink-l5,
-				border-color: $pink-l5,
+				border-color: transparent,
 				color: $pink-d2,
 			),
 		),

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/variables/_labels.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/variables/_labels.scss
@@ -1127,6 +1127,276 @@ $label-inverse-dark: map-deep-merge(
 	$label-inverse-dark
 );
 
+$label-inverse-content-0: () !default;
+$label-inverse-content-0: map-deep-merge(
+	(
+		background-color: $secondary-l3,
+		border-color: $secondary-l3,
+		color: $dark-d2,
+
+		href: (
+			hover: (
+				background-color: $secondary-l3,
+				border-color: $secondary-l3,
+				color: $dark-d2,
+			),
+		),
+
+		link: (
+			hover: (
+				color: $dark-d2,
+			),
+		),
+
+		close: (
+			hover: (
+				color: $dark-d2,
+			),
+		),
+	),
+	$label-inverse-content-0
+);
+
+$label-inverse-content-1: () !default;
+$label-inverse-content-1: map-deep-merge(
+	(
+		background-color: $purple-l5,
+		border-color: $purple-l5,
+		color: $purple-d2,
+
+		href: (
+			hover: (
+				background-color: $purple-l5,
+				border-color: $purple-l5,
+				color: $purple-d2,
+			),
+		),
+
+		link: (
+			hover: (
+				color: $purple-d2,
+			),
+		),
+
+		close: (
+			hover: (
+				color: $purple-d2,
+			),
+		),
+	),
+	$label-inverse-content-1
+);
+
+$label-inverse-content-2: () !default;
+$label-inverse-content-2: map-deep-merge(
+	(
+		background-color: $yellow-l5,
+		border-color: $yellow-l5,
+		color: $yellow-d4,
+
+		href: (
+			hover: (
+				background-color: $yellow-l5,
+				border-color: $yellow-l5,
+				color: $yellow-d4,
+			),
+		),
+
+		link: (
+			hover: (
+				color: $yellow-d4,
+			),
+		),
+
+		close: (
+			hover: (
+				color: $yellow-d4,
+			),
+		),
+	),
+	$label-inverse-content-2
+);
+
+$label-inverse-content-3: () !default;
+$label-inverse-content-3: map-deep-merge(
+	(
+		background-color: $green-l5,
+		border-color: $green-l5,
+		color: $green-d2,
+
+		href: (
+			hover: (
+				background-color: $green-l5,
+				border-color: $green-l5,
+				color: $green-d2,
+			),
+		),
+
+		link: (
+			hover: (
+				color: $green-d2,
+			),
+		),
+
+		close: (
+			hover: (
+				color: $green-d2,
+			),
+		),
+	),
+	$label-inverse-content-3
+);
+
+$label-inverse-content-4: () !default;
+$label-inverse-content-4: map-deep-merge(
+	(
+		background-color: $red-l5,
+		border-color: $red-l5,
+		color: $red-d2,
+
+		href: (
+			hover: (
+				background-color: $red-l5,
+				border-color: $red-l5,
+				color: $red-d2,
+			),
+		),
+
+		link: (
+			hover: (
+				color: $red-d2,
+			),
+		),
+
+		close: (
+			hover: (
+				color: $red-d2,
+			),
+		),
+	),
+	$label-inverse-content-4
+);
+
+$label-inverse-content-5: () !default;
+$label-inverse-content-5: map-deep-merge(
+	(
+		background-color: $teal-l5,
+		border-color: $teal-l5,
+		color: $teal-d2,
+
+		href: (
+			hover: (
+				background-color: $teal-l5,
+				border-color: $teal-l5,
+				color: $teal-d2,
+			),
+		),
+
+		link: (
+			hover: (
+				color: $teal-d2,
+			),
+		),
+
+		close: (
+			hover: (
+				color: $teal-d2,
+			),
+		),
+	),
+	$label-inverse-content-5
+);
+
+$label-inverse-content-6: () !default;
+$label-inverse-content-6: map-deep-merge(
+	(
+		background-color: $cyan-l5,
+		border-color: $cyan-l5,
+		color: $cyan-d2,
+
+		href: (
+			hover: (
+				background-color: $cyan-l5,
+				border-color: $cyan-l5,
+				color: $cyan-d2,
+			),
+		),
+
+		link: (
+			hover: (
+				color: $cyan-d2,
+			),
+		),
+
+		close: (
+			hover: (
+				color: $cyan-d2,
+			),
+		),
+	),
+	$label-inverse-content-6
+);
+
+$label-inverse-content-7: () !default;
+$label-inverse-content-7: map-deep-merge(
+	(
+		background-color: $orange-l5,
+		border-color: $orange-l5,
+		color: $orange-d2,
+
+		href: (
+			hover: (
+				background-color: $orange-l5,
+				border-color: $orange-l5,
+				color: $orange-d2,
+			),
+		),
+
+		link: (
+			hover: (
+				color: $orange-d2,
+			),
+		),
+
+		close: (
+			hover: (
+				color: $orange-d2,
+			),
+		),
+	),
+	$label-inverse-content-7
+);
+
+$label-inverse-content-8: () !default;
+$label-inverse-content-8: map-deep-merge(
+	(
+		background-color: $pink-l5,
+		border-color: $pink-l5,
+		color: $pink-d2,
+
+		href: (
+			hover: (
+				background-color: $pink-l5,
+				border-color: $pink-l5,
+				color: $pink-d2,
+			),
+		),
+
+		link: (
+			hover: (
+				color: $pink-d2,
+			),
+		),
+
+		close: (
+			hover: (
+				color: $pink-d2,
+			),
+		),
+	),
+	$label-inverse-content-8
+);
+
 $label-palette: () !default;
 $label-palette: map-deep-merge(
 	(
@@ -1161,6 +1431,24 @@ $label-palette: map-deep-merge(
 		inverse-light: $label-inverse-light,
 
 		inverse-dark: $label-inverse-dark,
+
+		inverse-content-0: $label-inverse-content-0,
+
+		inverse-content-1: $label-inverse-content-1,
+
+		inverse-content-2: $label-inverse-content-2,
+
+		inverse-content-3: $label-inverse-content-3,
+
+		inverse-content-4: $label-inverse-content-4,
+
+		inverse-content-5: $label-inverse-content-5,
+
+		inverse-content-6: $label-inverse-content-6,
+
+		inverse-content-7: $label-inverse-content-7,
+
+		inverse-content-8: $label-inverse-content-8,
 	),
 	$label-palette
 );

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-label/docs/label/markup.mdx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-label/docs/label/markup.mdx
@@ -154,6 +154,68 @@ Outputs:
 }
 ```
 
+## Content Label variants
+
+<div className="sheet-example">
+	<span className="label label-inverse-content-0">
+		<span className="label-item label-item-expand">Content 0</span>
+	</span>
+	<span className="label label-inverse-content-1">
+		<span className="label-item label-item-expand">Content 1</span>
+	</span>
+	<span className="label label-inverse-content-2">
+		<span className="label-item label-item-expand">Content 2</span>
+	</span>
+	<span className="label label-inverse-content-3">
+		<span className="label-item label-item-expand">Content 3</span>
+	</span>
+	<span className="label label-inverse-content-4">
+		<span className="label-item label-item-expand">Content 4</span>
+	</span>
+	<span className="label label-inverse-content-5">
+		<span className="label-item label-item-expand">Content 5</span>
+	</span>
+	<span className="label label-inverse-content-6">
+		<span className="label-item label-item-expand">Content 6</span>
+	</span>
+	<span className="label label-inverse-content-7">
+		<span className="label-item label-item-expand">Content 7</span>
+	</span>
+	<span className="label label-inverse-content-8">
+		<span className="label-item label-item-expand">Content 8</span>
+	</span>
+</div>
+
+```html
+<span class="label label-inverse-content-0">
+	<span class="label-item label-item-expand">Content 0</span>
+</span>
+<span class="label label-inverse-content-1">
+	<span class="label-item label-item-expand">Content 1</span>
+</span>
+<span class="label label-inverse-content-2">
+	<span class="label-item label-item-expand">Content 2</span>
+</span>
+<span class="label label-inverse-content-3">
+	<span class="label-item label-item-expand">Content 3</span>
+</span>
+<span class="label label-inverse-content-4">
+	<span class="label-item label-item-expand">Content 4</span>
+</span>
+<span class="label label-inverse-content-5">
+	<span class="label-item label-item-expand">Content 5</span>
+</span>
+<span class="label label-inverse-content-6">
+	<span class="label-item label-item-expand">Content 6</span>
+</span>
+<span class="label label-inverse-content-7">
+	<span class="label-item label-item-expand">Content 7</span>
+</span>
+<span class="label label-inverse-content-8">
+	<span class="label-item label-item-expand">Content 8</span>
+</span>
+```
+
 ## Sizes
 
 Use `label-lg` to make the label larger, or use the mixin `label-size($sassMap)` to create a custom sized label:

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-label/src/__tests__/__snapshots__/index.tsx.snap
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-label/src/__tests__/__snapshots__/index.tsx.snap
@@ -1,5 +1,59 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ContentLabel rendering default 1`] = `
+<span
+  className="label label-inverse-secondary"
+>
+  <span
+    className="label-item label-item-expand"
+  >
+    Default Content Label
+  </span>
+</span>
+`;
+
+exports[`ContentLabel rendering renders as closable 1`] = `
+<span
+  className="label label-dismissible label-inverse-content-1"
+>
+  <span
+    className="label-item label-item-expand"
+  >
+    Content Closable
+  </span>
+  <span
+    className="label-item label-item-after"
+  >
+    <button
+      className="close"
+      onClick={[Function]}
+      type="button"
+    >
+      <svg
+        className="lexicon-icon lexicon-icon-times-small"
+        role="presentation"
+      >
+        <use
+          href="path/to/spritemap#times-small"
+        />
+      </svg>
+    </button>
+  </span>
+</span>
+`;
+
+exports[`ContentLabel rendering renders with a content displayType 1`] = `
+<span
+  className="label label-inverse-content-2"
+>
+  <span
+    className="label-item label-item-expand"
+  >
+    Content 2 Label
+  </span>
+</span>
+`;
+
 exports[`Rendering as a link 1`] = `
 <span
   className="label label-secondary"

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-label/src/__tests__/__snapshots__/index.tsx.snap
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-label/src/__tests__/__snapshots__/index.tsx.snap
@@ -1,17 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ContentLabel rendering default 1`] = `
-<span
-  className="label label-inverse-secondary"
->
-  <span
-    className="label-item label-item-expand"
-  >
-    Default Content Label
-  </span>
-</span>
-`;
-
 exports[`ContentLabel rendering renders as closable 1`] = `
 <span
   className="label label-dismissible label-inverse-content-1"

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-label/src/__tests__/index.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-label/src/__tests__/index.tsx
@@ -112,14 +112,6 @@ describe('Rendering', () => {
 });
 
 describe('ContentLabel rendering', () => {
-	it('default', () => {
-		const testRenderer = TestRenderer.create(
-			<ContentLabel>Default Content Label</ContentLabel>
-		);
-
-		expect(testRenderer.toJSON()).toMatchSnapshot();
-	});
-
 	it('renders with a content displayType', () => {
 		const testRenderer = TestRenderer.create(
 			<ContentLabel displayType="content-2">Content 2 Label</ContentLabel>

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-label/src/__tests__/index.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-label/src/__tests__/index.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import ClayLabel from '..';
+import ClayLabel, {ContentLabel} from '..';
 import {cleanup, fireEvent, render} from '@testing-library/react';
 import React from 'react';
 import TestRenderer from 'react-test-renderer';
@@ -105,6 +105,40 @@ describe('Rendering', () => {
 
 				<ClayLabel.ItemAfter>Content after</ClayLabel.ItemAfter>
 			</ClayLabel>
+		);
+
+		expect(testRenderer.toJSON()).toMatchSnapshot();
+	});
+});
+
+describe('ContentLabel rendering', () => {
+	it('default', () => {
+		const testRenderer = TestRenderer.create(
+			<ContentLabel>Default Content Label</ContentLabel>
+		);
+
+		expect(testRenderer.toJSON()).toMatchSnapshot();
+	});
+
+	it('renders with a content displayType', () => {
+		const testRenderer = TestRenderer.create(
+			<ContentLabel displayType="content-2">Content 2 Label</ContentLabel>
+		);
+
+		expect(testRenderer.toJSON()).toMatchSnapshot();
+	});
+
+	it('renders as closable', () => {
+		const testRenderer = TestRenderer.create(
+			<ContentLabel
+				closeButtonProps={{
+					onClick: () => {},
+				}}
+				displayType="content-1"
+				spritemap={spritemap}
+			>
+				Content Closable
+			</ContentLabel>
 		);
 
 		expect(testRenderer.toJSON()).toMatchSnapshot();

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-label/src/index.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-label/src/index.tsx
@@ -8,6 +8,27 @@ import ClayLink from '@clayui/link';
 import classNames from 'classnames';
 import React from 'react';
 
+type WithOptional<T, P extends keyof T> = Omit<T, P> & Partial<Pick<T, P>>;
+
+export type LabelDisplayType =
+	| 'danger'
+	| 'info'
+	| 'secondary'
+	| 'success'
+	| 'unstyled'
+	| 'warning';
+
+export type ContentLabelDisplayType =
+	| 'content-0'
+	| 'content-1'
+	| 'content-2'
+	| 'content-3'
+	| 'content-4'
+	| 'content-5'
+	| 'content-6'
+	| 'content-7'
+	| 'content-8';
+
 export const ItemAfter = React.forwardRef<
 	HTMLSpanElement,
 	React.HTMLAttributes<HTMLSpanElement>
@@ -58,25 +79,6 @@ export const ItemExpand = React.forwardRef<
 
 ItemExpand.displayName = 'ClayLabelItemExpand';
 
-export type LabelDisplayType =
-	| 'danger'
-	| 'info'
-	| 'secondary'
-	| 'success'
-	| 'unstyled'
-	| 'warning';
-
-export type ContentLabelDisplayType =
-	| 'content-0'
-	| 'content-1'
-	| 'content-2'
-	| 'content-3'
-	| 'content-4'
-	| 'content-5'
-	| 'content-6'
-	| 'content-7'
-	| 'content-8';
-
 interface IBaseProps<T extends string = string>
 	extends React.BaseHTMLAttributes<HTMLSpanElement> {
 
@@ -88,7 +90,7 @@ interface IBaseProps<T extends string = string>
 	/**
 	 * Determines the style of the label.
 	 */
-	displayType?: T;
+	displayType: T;
 
 	/**
 	 * Flag to indicate if the label should be of the `inverse` variant.
@@ -107,7 +109,7 @@ const OldLabel = React.forwardRef<HTMLSpanElement, IBaseProps>(
 			children,
 			className,
 			dismissible,
-			displayType = 'secondary',
+			displayType,
 			inverse = false,
 			large = false,
 			...otherProps
@@ -215,8 +217,10 @@ BaseLabel.displayName = 'ClayBaseLabel';
 
 const LabelComponent = React.forwardRef<
 	HTMLAnchorElement | HTMLSpanElement,
-	IProps<LabelDisplayType>
->((props, ref) => <BaseLabel {...props} ref={ref} />);
+	WithOptional<IProps<LabelDisplayType>, 'displayType'>
+>(({displayType = 'secondary', ...props}, ref) => (
+	<BaseLabel {...props} displayType={displayType} ref={ref} />
+));
 
 LabelComponent.displayName = 'ClayLabel';
 

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-label/src/index.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-label/src/index.tsx
@@ -58,7 +58,27 @@ export const ItemExpand = React.forwardRef<
 
 ItemExpand.displayName = 'ClayLabelItemExpand';
 
-interface IBaseProps extends React.BaseHTMLAttributes<HTMLSpanElement> {
+export type LabelDisplayType =
+	| 'danger'
+	| 'info'
+	| 'secondary'
+	| 'success'
+	| 'unstyled'
+	| 'warning';
+
+export type ContentLabelDisplayType =
+	| 'content-0'
+	| 'content-1'
+	| 'content-2'
+	| 'content-3'
+	| 'content-4'
+	| 'content-5'
+	| 'content-6'
+	| 'content-7'
+	| 'content-8';
+
+interface IBaseProps<T extends string = string>
+	extends React.BaseHTMLAttributes<HTMLSpanElement> {
 
 	/**
 	 * Flag to indicate if `label-dismissible` class should be applied.
@@ -68,13 +88,7 @@ interface IBaseProps extends React.BaseHTMLAttributes<HTMLSpanElement> {
 	/**
 	 * Determines the style of the label.
 	 */
-	displayType?:
-		| 'secondary'
-		| 'info'
-		| 'warning'
-		| 'danger'
-		| 'success'
-		| 'unstyled';
+	displayType?: T;
 
 	/**
 	 * Flag to indicate if the label should be of the `inverse` variant.
@@ -121,7 +135,7 @@ const OldLabel = React.forwardRef<HTMLSpanElement, IBaseProps>(
 
 OldLabel.displayName = 'ClayLabel';
 
-interface IProps extends IBaseProps {
+interface IProps<T extends string = string> extends IBaseProps<T> {
 
 	/**
 	 * HTML properties that are applied to the 'x' button.
@@ -146,10 +160,7 @@ interface IProps extends IBaseProps {
 	withClose?: boolean;
 }
 
-const LabelComponent = React.forwardRef<
-	HTMLAnchorElement | HTMLSpanElement,
-	IProps
->(
+const BaseLabel = React.forwardRef<HTMLAnchorElement | HTMLSpanElement, IProps>(
 	(
 		{
 			children,
@@ -159,7 +170,7 @@ const LabelComponent = React.forwardRef<
 			withClose = true,
 			spritemap,
 			...otherProps
-		}: IProps,
+		},
 		ref
 	) => {
 		return (
@@ -200,9 +211,29 @@ const LabelComponent = React.forwardRef<
 	}
 );
 
+BaseLabel.displayName = 'ClayBaseLabel';
+
+const LabelComponent = React.forwardRef<
+	HTMLAnchorElement | HTMLSpanElement,
+	IProps<LabelDisplayType>
+>((props, ref) => <BaseLabel {...props} ref={ref} />);
+
 LabelComponent.displayName = 'ClayLabel';
 
 const Label = Object.assign(LabelComponent, {
+	ItemAfter,
+	ItemBefore,
+	ItemExpand,
+});
+
+const ContentLabelComponent = React.forwardRef<
+	HTMLAnchorElement | HTMLSpanElement,
+	Omit<IProps<ContentLabelDisplayType>, 'inverse'>
+>((props, ref) => <BaseLabel {...props} inverse ref={ref} />);
+
+ContentLabelComponent.displayName = 'ClayContentLabel';
+
+export const ContentLabel = Object.assign(ContentLabelComponent, {
 	ItemAfter,
 	ItemBefore,
 	ItemExpand,

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-label/stories/Label.stories.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-label/stories/Label.stories.tsx
@@ -10,6 +10,16 @@ import ClayLabel, {ContentLabel} from '../src';
 
 export default {
 	argTypes: {
+		displayType: {
+			control: {type: 'select'},
+			options: [
+				'danger',
+				'info',
+				'secondary',
+				'success',
+				'warning',
+			] as const,
+		},
 		inverse: {
 			control: {type: 'boolean'},
 		},
@@ -30,6 +40,35 @@ const displayTypes = [
 ] as const;
 
 export function Default(args: typeof Default.args) {
+	return (
+		<ClayLabel
+			closeButtonProps={
+				args.closeable
+					? {
+							onClick: () => alert('close callback'),
+						}
+					: undefined
+			}
+			displayType={args.displayType as 'secondary'}
+			href={args.href}
+			inverse={args.inverse}
+			large={args.large}
+		>
+			{args.label}
+		</ClayLabel>
+	);
+}
+
+Default.args = {
+	closeable: false,
+	displayType: 'secondary',
+	href: '',
+	inverse: false,
+	label: 'Label',
+	large: false,
+};
+
+export function SeeAll(args: typeof Default.args) {
 	const closeButtonProps = args.closeable
 		? {
 				onClick: () => alert('close callback'),
@@ -57,7 +96,7 @@ export function Default(args: typeof Default.args) {
 	);
 }
 
-Default.args = {
+SeeAll.args = {
 	closeable: false,
 	href: '',
 	inverse: false,

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-label/stories/Label.stories.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-label/stories/Label.stories.tsx
@@ -6,7 +6,7 @@
 import ClayIcon from '@clayui/icon';
 import React from 'react';
 
-import ClayLabel from '../src';
+import ClayLabel, {ContentLabel} from '../src';
 
 export default {
 	argTypes: {
@@ -39,16 +39,19 @@ export function Default(args: typeof Default.args) {
 	return (
 		<>
 			{displayTypes.map((displayType) => (
-				<ClayLabel
-					closeButtonProps={closeButtonProps}
-					displayType={displayType}
-					href={args.href}
-					inverse={args.inverse}
-					key={displayType}
-					large={args.large}
-				>
-					{args.label}
-				</ClayLabel>
+				<div className="mb-4" key={displayType}>
+					<p className="mb-0">{displayType}</p>
+
+					<ClayLabel
+						closeButtonProps={closeButtonProps}
+						displayType={displayType}
+						href={args.href}
+						inverse={args.inverse}
+						large={args.large}
+					>
+						{args.label}
+					</ClayLabel>
+				</div>
 			))}
 		</>
 	);
@@ -111,5 +114,51 @@ export function ContentBefore(args: typeof Default.args) {
 
 ContentBefore.args = {
 	inverse: false,
+	large: false,
+};
+
+const contentDisplayTypes = [
+	'content-0',
+	'content-1',
+	'content-2',
+	'content-3',
+	'content-4',
+	'content-5',
+	'content-6',
+	'content-7',
+	'content-8',
+] as const;
+
+export function ContentVariants(args: typeof ContentVariants.args) {
+	const closeButtonProps = args.closeable
+		? {
+				onClick: () => alert('close callback'),
+			}
+		: undefined;
+
+	return (
+		<>
+			{contentDisplayTypes.map((displayType) => (
+				<div className="mb-4" key={displayType}>
+					<p className="mb-0">{displayType}</p>
+
+					<ContentLabel
+						closeButtonProps={closeButtonProps}
+						displayType={displayType}
+						href={args.href}
+						large={args.large}
+					>
+						{args.label}
+					</ContentLabel>
+				</div>
+			))}
+		</>
+	);
+}
+
+ContentVariants.args = {
+	closeable: false,
+	href: '',
+	label: 'Label',
 	large: false,
 };


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPD-90973

## What is being fixed

Lexicon is consolidating CMS and DXP labels under a single Content Label spec (parent epic LPD-89624, Story LPD-89626). Clay shipped only the named inverse label variants (`inverse-primary`, `inverse-secondary`, …) and had no React support for the nine product-ready content variants. Consumers had to hand-write `<span class="label label-inverse-content-N">` and remember to pair each `*-l5` background with the matching `*-d2` text token.

## How it is being fixed

Two layers, one commit each.

The SCSS layer adds `inverse-content-0` through `inverse-content-8` to Clay's label palette across all four theme variants (atlas, base, cadmin, atlas-custom-properties). Each entry pairs an `*-l5` background with the matching `*-d2` text token; yellow uses `*-d4` for slightly better contrast and knowingly stays at 4.24:1 pending a Color Foundations follow-up. All color tokens already exist in `_globals.scss`. The existing palette loop in `components/_labels.scss` picks up the new keys via the `inverse-*` branch and generates `.label-inverse-content-N` classes through the same `clay-label-variant()` mixin used by every other inverse variant. The `clay-label/docs/label/markup.mdx` reference gains a Content Label variants section.

The React layer genericizes `IBaseProps` and `IProps` over `displayType` and splits the existing label component into a shared widened-impl `BaseLabel` plus two narrow `forwardRef` wrappers: `Label` (unchanged signature, remains the default export) and a new `ContentLabel` named export. `ContentLabel` omits `inverse` from its public type and forces `inverse={true}` internally so the only renderable class shape is `.label-inverse-content-N`. The pattern avoids `as` casts entirely — the generic parameter lives on the prop interfaces while each `forwardRef` is an ordinary, non-generic call. Snapshot tests cover the new variant, the closable path, and the default render; existing `ClayLabel` snapshots are untouched.

---

~:warning: This branch is based on BChan's master, as there are some necessary previous commits that aren't part of our repo yet. I'll rebase ASAP. **For review**, focus on the last commits, the ones starting with `LPD-90973`~