### PR TITLE
LPD-89732 Add folder navigation to the CMS item selector modal

### DIFF
--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/css/DetachedCMSFilesItemSelectorModal.scss
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/css/DetachedCMSFilesItemSelectorModal.scss
@@ -11,3 +11,8 @@
 .item-selector-modal-breadcrumb-wrapper {
 	border-bottom: 1px solid $cadmin-border-color;
 }
+
+.cms-item-selector-folder-row .cell-select-item .custom-control,
+.cms-item-selector-folder-row .cell-select-item .form-check {
+	display: none;
+}

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/css/DetachedCMSFilesItemSelectorModal.scss
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/css/DetachedCMSFilesItemSelectorModal.scss
@@ -1,7 +1,13 @@
+@import 'cadmin-variables';
+
 .detached-cms-files-alert > .container {
 	margin-left: 0;
 	max-width: none;
 	padding-left: 0;
 	padding-right: 0;
 	width: 100%;
+}
+
+.item-selector-modal-breadcrumb-wrapper {
+	border-bottom: 1px solid $cadmin-border-color;
 }

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/DetachedCMSFilesItemSelectorModal.tsx
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/DetachedCMSFilesItemSelectorModal.tsx
@@ -26,7 +26,7 @@ import React, {
 	useState,
 } from 'react';
 
-import ItemSelectorModal from './ItemSelectorModal';
+import ItemSelectorModal, {FilesUploaderComponent} from './ItemSelectorModal';
 import {TDetachedItemSelectorModal} from './types';
 
 import '../css/DetachedCMSFilesItemSelectorModal.scss';
@@ -34,7 +34,7 @@ import '../css/DetachedCMSFilesItemSelectorModal.scss';
 const OBJECT_ENTRY_FOLDER_CLASS_NAME =
 	'com.liferay.object.model.ObjectEntryFolder';
 
-function isFolder(item: any): boolean {
+function isFolder(item?: {entryClassName: string}): boolean {
 	return item?.entryClassName === OBJECT_ENTRY_FOLDER_CLASS_NAME;
 }
 
@@ -156,12 +156,14 @@ const DetachedCMSFilesItemSelectorModal = <T extends Record<string, any>>(
 	const {observer, onOpenChange, open} = useModal();
 	const [newItemsCount, setNewItemsCount] = useState(0);
 	const [showInlineNotification, setShowInlineNotification] = useState(false);
-	const [currentFolder, setCurrentFolder] = useState<FolderCrumb[]>(() => [
-		{
-			id: null,
-			label: Liferay.Language.get('files'),
-		},
-	]);
+	const [breadcrumbFolders, setBreadcrumbFolders] = useState<FolderCrumb[]>(
+		() => [
+			{
+				id: null,
+				label: Liferay.Language.get('files'),
+			},
+		]
+	);
 
 	const isBrowserTabVisible = useBrowserTabVisibility();
 	const lastRequestTimeRef = useRef(new Date().toISOString());
@@ -170,9 +172,8 @@ const DetachedCMSFilesItemSelectorModal = <T extends Record<string, any>>(
 		onOpenChange(true);
 	}, [onOpenChange]);
 
-	const activeFolderId = currentFolder[currentFolder.length - 1].id;
-	const activeScopeId =
-		currentFolder[currentFolder.length - 1].scopeId ?? null;
+	const activeFolderId = breadcrumbFolders.at(-1)!.id;
+	const activeScopeId = breadcrumbFolders.at(-1)!.scopeId ?? null;
 
 	const apiURL = useMemo(
 		() => buildApiURL(activeFolderId),
@@ -196,8 +197,8 @@ const DetachedCMSFilesItemSelectorModal = <T extends Record<string, any>>(
 
 	const breadcrumbs = useMemo(
 		() =>
-			currentFolder.map((crumb, index) => {
-				const isLast = index === currentFolder.length - 1;
+			breadcrumbFolders.map((crumb, index) => {
+				const isLast = index === breadcrumbFolders.length - 1;
 
 				return {
 					active: isLast,
@@ -207,18 +208,18 @@ const DetachedCMSFilesItemSelectorModal = <T extends Record<string, any>>(
 						: (event: React.SyntheticEvent) => {
 								event.preventDefault();
 
-								setCurrentFolder((path) =>
+								setBreadcrumbFolders((path) =>
 									path.slice(0, index + 1)
 								);
 							},
 				};
 			}),
-		[currentFolder]
+		[breadcrumbFolders]
 	);
 
 	const navigateToFolder = useCallback(
 		(folder: {id: number; label: string; scopeId?: number | null}) => {
-			setCurrentFolder((path) => [...path, folder]);
+			setBreadcrumbFolders((path) => [...path, folder]);
 		},
 		[]
 	);
@@ -389,7 +390,12 @@ const DetachedCMSFilesItemSelectorModal = <T extends Record<string, any>>(
 	);
 
 	const filesUploaderComponent = useMemo(() => {
-		const InitialFileUploaderComponent = restProps.filesUploaderComponent;
+		const InitialFileUploaderComponent =
+			restProps.filesUploaderComponent as
+				| FilesUploaderComponent<{
+						parentObjectEntryFolderId?: number | null;
+				  }>
+				| undefined;
 
 		if (!InitialFileUploaderComponent) {
 			return undefined;
@@ -403,7 +409,7 @@ const DetachedCMSFilesItemSelectorModal = <T extends Record<string, any>>(
 			<InitialFileUploaderComponent
 				{...uploaderProps}
 				groupId={activeScopeId ?? uploaderProps.groupId}
-				{...({parentObjectEntryFolderId: activeFolderId} as any)}
+				parentObjectEntryFolderId={activeFolderId}
 			/>
 		);
 	}, [activeFolderId, activeScopeId, restProps.filesUploaderComponent]);

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/DetachedCMSFilesItemSelectorModal.tsx
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/DetachedCMSFilesItemSelectorModal.tsx
@@ -125,12 +125,30 @@ const NewItemsNotificationComponent = ({
 	);
 };
 
+type DetachedCMSFilesItemSelectorModalProps<T extends Record<string, any>> =
+	TDetachedItemSelectorModal<T> & {
+		buildApiURL: (folderId: number | null) => string;
+	};
+
+type FolderCrumb = {
+	id: number | null;
+	label: string;
+};
+
 const DetachedCMSFilesItemSelectorModal = <T extends Record<string, any>>(
-	props: TDetachedItemSelectorModal<T>
+	props: DetachedCMSFilesItemSelectorModalProps<T>
 ) => {
+	const {buildApiURL, ...restProps} = props;
+
 	const {observer, onOpenChange, open} = useModal();
 	const [newItemsCount, setNewItemsCount] = useState(0);
 	const [showInlineNotification, setShowInlineNotification] = useState(false);
+	const [currentFolder, setCurrentFolder] = useState<FolderCrumb[]>(() => [
+		{
+			id: null,
+			label: props.itemTypeLabel ?? Liferay.Language.get('files'),
+		},
+	]);
 
 	const isBrowserTabVisible = useBrowserTabVisibility();
 	const lastRequestTimeRef = useRef(new Date().toISOString());
@@ -154,12 +172,41 @@ const DetachedCMSFilesItemSelectorModal = <T extends Record<string, any>>(
 		}
 	}, [isBrowserTabVisible, open, props.apiURL]);
 
+	const activeFolderId = currentFolder[currentFolder.length - 1].id;
+
+	const apiURL = useMemo(
+		() => buildApiURL(activeFolderId),
+		[activeFolderId, buildApiURL]
+	);
+
+	const breadcrumbs = useMemo(
+		() =>
+			currentFolder.map((crumb, index) => {
+				const isLast = index === currentFolder.length - 1;
+
+				return {
+					active: isLast,
+					label: crumb.label,
+					onClick: isLast
+						? undefined
+						: (event: React.SyntheticEvent) => {
+								event.preventDefault();
+
+								setCurrentFolder((path) =>
+									path.slice(0, index + 1)
+								);
+							},
+				};
+			}),
+		[currentFolder]
+	);
+
 	const fdsProps = useMemo(
 		() => ({
-			...props.fdsProps,
+			...restProps.fdsProps,
 			inlineNotificationComponent: NewItemsNotificationComponent,
 		}),
-		[props.fdsProps]
+		[restProps.fdsProps]
 	);
 
 	return (
@@ -172,7 +219,10 @@ const DetachedCMSFilesItemSelectorModal = <T extends Record<string, any>>(
 		>
 			{open && (
 				<ItemSelectorModal
-					{...props}
+					{...restProps}
+					apiURL={apiURL}
+					breadcrumbs={breadcrumbs}
+					breadcrumbsLabel={false}
 					fdsProps={fdsProps}
 					observer={observer}
 					onOpenChange={onOpenChange}

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/DetachedCMSFilesItemSelectorModal.tsx
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/DetachedCMSFilesItemSelectorModal.tsx
@@ -170,9 +170,18 @@ const DetachedCMSFilesItemSelectorModal = <T extends Record<string, any>>(
 		onOpenChange(true);
 	}, [onOpenChange]);
 
+	const activeFolderId = currentFolder[currentFolder.length - 1].id;
+	const activeScopeId =
+		currentFolder[currentFolder.length - 1].scopeId ?? null;
+
+	const apiURL = useMemo(
+		() => buildApiURL(activeFolderId),
+		[activeFolderId, buildApiURL]
+	);
+
 	useEffect(() => {
 		if (isBrowserTabVisible && open) {
-			checkNewCMSFiles(props.apiURL, lastRequestTimeRef.current).then(
+			checkNewCMSFiles(apiURL, lastRequestTimeRef.current).then(
 				(response) => {
 					if (response.totalCount > 0) {
 						setNewItemsCount(response.totalCount);
@@ -183,16 +192,7 @@ const DetachedCMSFilesItemSelectorModal = <T extends Record<string, any>>(
 				}
 			);
 		}
-	}, [isBrowserTabVisible, open, props.apiURL]);
-
-	const activeFolderId = currentFolder[currentFolder.length - 1].id;
-	const activeScopeId =
-		currentFolder[currentFolder.length - 1].scopeId ?? null;
-
-	const apiURL = useMemo(
-		() => buildApiURL(activeFolderId),
-		[activeFolderId, buildApiURL]
-	);
+	}, [isBrowserTabVisible, open, apiURL]);
 
 	const breadcrumbs = useMemo(
 		() =>

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/DetachedCMSFilesItemSelectorModal.tsx
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/DetachedCMSFilesItemSelectorModal.tsx
@@ -14,7 +14,8 @@ import {
 	TSort,
 } from '@liferay/frontend-data-set-web';
 import {useBrowserTabVisibility} from '@liferay/frontend-js-react-web';
-import {fetch} from 'frontend-js-web';
+import classNames from 'classnames';
+import {fetch, mimeTypeUtils} from 'frontend-js-web';
 import React, {
 	createContext,
 	useCallback,
@@ -232,33 +233,67 @@ const DetachedCMSFilesItemSelectorModal = <T extends Record<string, any>>(
 						itemData: any;
 						value: any;
 					}) => {
-						if (!isFolder(itemData)) {
-							return value;
+						if (isFolder(itemData)) {
+							return (
+								<div className="align-items-center d-flex">
+									<ClaySticker className="c-mr-2 flex-shrink-0 inline-item inline-item-before">
+										<ClayIcon symbol="folder" />
+									</ClaySticker>
+
+									<div className="table-list-title">
+										<ClayLink
+											className="text-decoration-underline"
+											data-senna-off
+											href="#"
+											onClick={(
+												event: React.MouseEvent
+											) => {
+												event.preventDefault();
+
+												navigateToFolder({
+													id: itemData.embedded.id,
+													label: itemData.embedded
+														.title,
+												});
+											}}
+										>
+											{value}
+										</ClayLink>
+									</div>
+								</div>
+							);
+						}
+
+						const fileMimeType = itemData?.embedded?.file?.mimeType;
+
+						let stickerClassName = 'file-icon-color-5';
+						let iconSymbol = 'document-default';
+
+						if (fileMimeType) {
+							stickerClassName =
+								mimeTypeUtils.getClassNameFromMimeType(
+									fileMimeType
+								);
+							iconSymbol =
+								mimeTypeUtils.getIconFromMimeType(fileMimeType);
+						}
+						else if (itemData?.embedded?.videoURL) {
+							stickerClassName = 'file-icon-color-3';
+							iconSymbol = 'document-multimedia';
 						}
 
 						return (
-							<div className="d-flex">
-								<ClaySticker className="c-mr-2 flex-shrink-0 inline-item inline-item-before">
-									<ClayIcon symbol="folder" />
+							<div className="align-items-center d-flex">
+								<ClaySticker
+									className={classNames(
+										'c-mr-2 flex-shrink-0 inline-item inline-item-before',
+										stickerClassName
+									)}
+								>
+									<ClayIcon symbol={iconSymbol} />
 								</ClaySticker>
 
-								<div className="table-list-title">
-									<ClayLink
-										className="text-decoration-underline"
-										data-senna-off
-										href="#"
-										onClick={(event: React.MouseEvent) => {
-											event.preventDefault();
-
-											navigateToFolder({
-												id: itemData.embedded.id,
-												label: itemData.embedded.title,
-											});
-										}}
-									>
-										{value}
-									</ClayLink>
-								</div>
+								<span>{value}</span>
 							</div>
 						);
 					},

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/DetachedCMSFilesItemSelectorModal.tsx
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/DetachedCMSFilesItemSelectorModal.tsx
@@ -236,7 +236,7 @@ const DetachedCMSFilesItemSelectorModal = <T extends Record<string, any>>(
 						if (isFolder(itemData)) {
 							return (
 								<div className="align-items-center d-flex">
-									<ClaySticker className="c-mr-2 flex-shrink-0 inline-item inline-item-before">
+									<ClaySticker className="c-mr-2 file-icon-color-0 flex-shrink-0 inline-item inline-item-before">
 										<ClayIcon symbol="folder" />
 									</ClaySticker>
 
@@ -298,6 +298,17 @@ const DetachedCMSFilesItemSelectorModal = <T extends Record<string, any>>(
 						);
 					},
 					name: 'cmsFilesTitleCellRenderer',
+					type: 'internal' as const,
+				},
+				{
+					component: ({
+						itemData,
+						value,
+					}: {
+						itemData: any;
+						value: any;
+					}) => (isFolder(itemData) ? '--' : value),
+					name: 'cmsFilesFallbackCellRenderer',
 					type: 'internal' as const,
 				},
 			],

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/DetachedCMSFilesItemSelectorModal.tsx
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/DetachedCMSFilesItemSelectorModal.tsx
@@ -249,6 +249,7 @@ const DetachedCMSFilesItemSelectorModal = <T extends Record<string, any>>(
 												event: React.MouseEvent
 											) => {
 												event.preventDefault();
+												event.stopPropagation();
 
 												navigateToFolder({
 													id: itemData.embedded.id,

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/DetachedCMSFilesItemSelectorModal.tsx
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/DetachedCMSFilesItemSelectorModal.tsx
@@ -145,6 +145,7 @@ type DetachedCMSFilesItemSelectorModalProps<T extends Record<string, any>> =
 type FolderCrumb = {
 	id: number | null;
 	label: string;
+	scopeId?: number | null;
 };
 
 const DetachedCMSFilesItemSelectorModal = <T extends Record<string, any>>(
@@ -185,6 +186,8 @@ const DetachedCMSFilesItemSelectorModal = <T extends Record<string, any>>(
 	}, [isBrowserTabVisible, open, props.apiURL]);
 
 	const activeFolderId = currentFolder[currentFolder.length - 1].id;
+	const activeScopeId =
+		currentFolder[currentFolder.length - 1].scopeId ?? null;
 
 	const apiURL = useMemo(
 		() => buildApiURL(activeFolderId),
@@ -214,7 +217,7 @@ const DetachedCMSFilesItemSelectorModal = <T extends Record<string, any>>(
 	);
 
 	const navigateToFolder = useCallback(
-		(folder: {id: number; label: string}) => {
+		(folder: {id: number; label: string; scopeId?: number | null}) => {
 			setCurrentFolder((path) => [...path, folder]);
 		},
 		[]
@@ -255,6 +258,9 @@ const DetachedCMSFilesItemSelectorModal = <T extends Record<string, any>>(
 													id: itemData.embedded.id,
 													label: itemData.embedded
 														.title,
+													scopeId:
+														itemData.embedded
+															.scopeId,
 												});
 											}}
 										>
@@ -345,6 +351,7 @@ const DetachedCMSFilesItemSelectorModal = <T extends Record<string, any>>(
 									navigateToFolder({
 										id: item.embedded.id,
 										label: item.embedded.title,
+										scopeId: item.embedded.scopeId,
 									}),
 								...(view.contentRenderer === 'cards'
 									? {onSelectChange: null, symbol: 'folder'}
@@ -374,6 +381,26 @@ const DetachedCMSFilesItemSelectorModal = <T extends Record<string, any>>(
 		[customRenderers, restProps.fdsProps, views]
 	);
 
+	const filesUploaderComponent = useMemo(() => {
+		const InitialFileUploaderComponent = restProps.filesUploaderComponent;
+
+		if (!InitialFileUploaderComponent) {
+			return undefined;
+		}
+
+		return (
+			uploaderProps: React.ComponentProps<
+				typeof InitialFileUploaderComponent
+			>
+		) => (
+			<InitialFileUploaderComponent
+				{...uploaderProps}
+				groupId={activeScopeId ?? uploaderProps.groupId}
+				{...({parentObjectEntryFolderId: activeFolderId} as any)}
+			/>
+		);
+	}, [activeFolderId, activeScopeId, restProps.filesUploaderComponent]);
+
 	return (
 		<NotificationContext.Provider
 			value={{
@@ -389,6 +416,7 @@ const DetachedCMSFilesItemSelectorModal = <T extends Record<string, any>>(
 					breadcrumbs={breadcrumbs}
 					breadcrumbsLabel={false}
 					fdsProps={fdsProps}
+					filesUploaderComponent={filesUploaderComponent}
 					observer={observer}
 					onOpenChange={onOpenChange}
 					open={open}

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/DetachedCMSFilesItemSelectorModal.tsx
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/DetachedCMSFilesItemSelectorModal.tsx
@@ -255,12 +255,15 @@ const DetachedCMSFilesItemSelectorModal = <T extends Record<string, any>>(
 												event.stopPropagation();
 
 												navigateToFolder({
-													id: itemData.embedded.id,
-													label: itemData.embedded
-														.title,
+													id:
+														itemData.embedded.id ??
+														'',
+													label:
+														itemData.embedded
+															.title ?? '',
 													scopeId:
 														itemData.embedded
-															.scopeId,
+															.scopeId ?? 0,
 												});
 											}}
 										>
@@ -344,27 +347,31 @@ const DetachedCMSFilesItemSelectorModal = <T extends Record<string, any>>(
 						item: any;
 						props: any;
 					}) => {
+						const effectiveProps = original
+							? original({item, props})
+							: props;
+
 						if (isFolder(item)) {
 							return {
-								...props,
+								...effectiveProps,
 								onClick: () =>
 									navigateToFolder({
-										id: item.embedded.id,
-										label: item.embedded.title,
-										scopeId: item.embedded.scopeId,
+										id: item?.embedded?.id ?? 0,
+										label: item?.embedded?.title ?? '',
+										scopeId: item.embedded.scopeId ?? 0,
 									}),
 								...(view.contentRenderer === 'cards'
 									? {onSelectChange: null, symbol: 'folder'}
 									: {
 											className: classNames(
-												props.className,
+												effectiveProps.className,
 												'cms-item-selector-folder-row'
 											),
 										}),
 							};
 						}
 
-						return original ? original({item, props}) : props;
+						return effectiveProps;
 					},
 				};
 			}),

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/DetachedCMSFilesItemSelectorModal.tsx
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/DetachedCMSFilesItemSelectorModal.tsx
@@ -5,7 +5,10 @@
 
 import ClayAlert from '@clayui/alert';
 import ClayButton from '@clayui/button';
+import ClayIcon from '@clayui/icon';
+import ClayLink from '@clayui/link';
 import {useModal} from '@clayui/modal';
+import ClaySticker from '@clayui/sticker';
 import {
 	IInlineNotificationComponent,
 	TSort,
@@ -14,6 +17,7 @@ import {useBrowserTabVisibility} from '@liferay/frontend-js-react-web';
 import {fetch} from 'frontend-js-web';
 import React, {
 	createContext,
+	useCallback,
 	useContext,
 	useEffect,
 	useMemo,
@@ -25,6 +29,13 @@ import ItemSelectorModal from './ItemSelectorModal';
 import {TDetachedItemSelectorModal} from './types';
 
 import '../css/DetachedCMSFilesItemSelectorModal.scss';
+
+const OBJECT_ENTRY_FOLDER_CLASS_NAME =
+	'com.liferay.object.model.ObjectEntryFolder';
+
+function isFolder(item: any): boolean {
+	return item?.entryClassName === OBJECT_ENTRY_FOLDER_CLASS_NAME;
+}
 
 async function checkNewCMSFiles(
 	cmsRootFilesURL: string,
@@ -201,12 +212,110 @@ const DetachedCMSFilesItemSelectorModal = <T extends Record<string, any>>(
 		[currentFolder]
 	);
 
+	const navigateToFolder = useCallback(
+		(folder: {id: number; label: string}) => {
+			setCurrentFolder((path) => [...path, folder]);
+		},
+		[]
+	);
+
+	const customRenderers = useMemo(
+		() => ({
+			...restProps.fdsProps.customRenderers,
+			tableCell: [
+				...(restProps.fdsProps.customRenderers?.tableCell ?? []),
+				{
+					component: ({
+						itemData,
+						value,
+					}: {
+						itemData: any;
+						value: any;
+					}) => {
+						if (!isFolder(itemData)) {
+							return value;
+						}
+
+						return (
+							<div className="d-flex">
+								<ClaySticker className="c-mr-2 flex-shrink-0 inline-item inline-item-before">
+									<ClayIcon symbol="folder" />
+								</ClaySticker>
+
+								<div className="table-list-title">
+									<ClayLink
+										className="text-decoration-underline"
+										data-senna-off
+										href="#"
+										onClick={(event: React.MouseEvent) => {
+											event.preventDefault();
+
+											navigateToFolder({
+												id: itemData.embedded.id,
+												label: itemData.embedded.title,
+											});
+										}}
+									>
+										{value}
+									</ClayLink>
+								</div>
+							</div>
+						);
+					},
+					name: 'cmsFilesTitleCellRenderer',
+					type: 'internal' as const,
+				},
+			],
+		}),
+		[navigateToFolder, restProps.fdsProps.customRenderers]
+	);
+
+	const views = useMemo(
+		() =>
+			(restProps.fdsProps.views ?? []).map((view: any) => {
+				if (view.contentRenderer !== 'cards') {
+					return view;
+				}
+
+				const original = view.setItemComponentProps;
+
+				return {
+					...view,
+					setItemComponentProps: ({
+						item,
+						props,
+					}: {
+						item: any;
+						props: any;
+					}) => {
+						if (isFolder(item)) {
+							return {
+								...props,
+								onClick: () =>
+									navigateToFolder({
+										id: item.embedded.id,
+										label: item.embedded.title,
+									}),
+								onSelectChange: null,
+								symbol: 'folder',
+							};
+						}
+
+						return original ? original({item, props}) : props;
+					},
+				};
+			}),
+		[navigateToFolder, restProps.fdsProps.views]
+	);
+
 	const fdsProps = useMemo(
 		() => ({
 			...restProps.fdsProps,
+			customRenderers,
 			inlineNotificationComponent: NewItemsNotificationComponent,
+			views,
 		}),
-		[restProps.fdsProps]
+		[customRenderers, restProps.fdsProps, views]
 	);
 
 	return (

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/DetachedCMSFilesItemSelectorModal.tsx
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/DetachedCMSFilesItemSelectorModal.tsx
@@ -256,13 +256,13 @@ const DetachedCMSFilesItemSelectorModal = <T extends Record<string, any>>(
 
 												navigateToFolder({
 													id:
-														itemData.embedded.id ??
-														'',
+														itemData?.embedded.id ??
+														0,
 													label:
-														itemData.embedded
+														itemData?.embedded
 															.title ?? '',
 													scopeId:
-														itemData.embedded
+														itemData?.embedded
 															.scopeId ?? 0,
 												});
 											}}
@@ -358,7 +358,7 @@ const DetachedCMSFilesItemSelectorModal = <T extends Record<string, any>>(
 									navigateToFolder({
 										id: item?.embedded?.id ?? 0,
 										label: item?.embedded?.title ?? '',
-										scopeId: item.embedded.scopeId ?? 0,
+										scopeId: item?.embedded?.scopeId ?? 0,
 									}),
 								...(view.contentRenderer === 'cards'
 									? {onSelectChange: null, symbol: 'folder'}

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/DetachedCMSFilesItemSelectorModal.tsx
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/DetachedCMSFilesItemSelectorModal.tsx
@@ -319,7 +319,10 @@ const DetachedCMSFilesItemSelectorModal = <T extends Record<string, any>>(
 	const views = useMemo(
 		() =>
 			(restProps.fdsProps.views ?? []).map((view: any) => {
-				if (view.contentRenderer !== 'cards') {
+				if (
+					view.contentRenderer !== 'cards' &&
+					view.contentRenderer !== 'table'
+				) {
 					return view;
 				}
 
@@ -342,8 +345,14 @@ const DetachedCMSFilesItemSelectorModal = <T extends Record<string, any>>(
 										id: item.embedded.id,
 										label: item.embedded.title,
 									}),
-								onSelectChange: null,
-								symbol: 'folder',
+								...(view.contentRenderer === 'cards'
+									? {onSelectChange: null, symbol: 'folder'}
+									: {
+											className: classNames(
+												props.className,
+												'cms-item-selector-folder-row'
+											),
+										}),
 							};
 						}
 

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/DetachedCMSFilesItemSelectorModal.tsx
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/DetachedCMSFilesItemSelectorModal.tsx
@@ -158,7 +158,7 @@ const DetachedCMSFilesItemSelectorModal = <T extends Record<string, any>>(
 	const [currentFolder, setCurrentFolder] = useState<FolderCrumb[]>(() => [
 		{
 			id: null,
-			label: props.itemTypeLabel ?? Liferay.Language.get('files'),
+			label: Liferay.Language.get('files'),
 		},
 	]);
 

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/ItemSelectorModal.tsx
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/ItemSelectorModal.tsx
@@ -247,7 +247,10 @@ function ItemSelectorModal<T extends Record<string, any>>({
 					fluid
 				>
 					{breadcrumbs && (
-						<ClayLayout.Container fluid>
+						<ClayLayout.Container
+							className="item-selector-modal-breadcrumb-wrapper"
+							fluid
+						>
 							{breadcrumbsLabel && (
 								<h2 className="mb-0 mt-2">
 									{breadcrumbs[breadcrumbs.length - 1].label}

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/ItemSelectorModal.tsx
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/ItemSelectorModal.tsx
@@ -29,26 +29,28 @@ type IItemSelectorModalFDSProps = Omit<
 	| 'style'
 >;
 
-export type FilesUploaderComponent = React.ComponentType<{
-	allowedExtensions?: string;
+export type FilesUploaderComponent<T extends object = {}> = React.ComponentType<
+	{
+		allowedExtensions?: string;
 
-	/**
-	 * List of files that will represent the initial state of files to upload.
-	 */
-	files: FileData[];
+		/**
+		 * List of files that will represent the initial state of files to upload.
+		 */
+		files: FileData[];
 
-	/**
-	 * Site/Space where to upload items
-	 */
-	groupId?: number;
+		/**
+		 * Site/Space where to upload items
+		 */
+		groupId?: number;
 
-	maxFileSize?: number;
+		maxFileSize?: number;
 
-	/**
-	 * Callback for when upload is done in both cases: by success, or user cancelation.
-	 */
-	onCloseUploadView: () => void;
-}>;
+		/**
+		 * Callback for when upload is done in both cases: by success, or user cancelation.
+		 */
+		onCloseUploadView: () => void;
+	} & T
+>;
 
 export interface IItemSelectorModalProps<T> {
 

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/ItemSelectorModal.tsx
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/ItemSelectorModal.tsx
@@ -16,7 +16,7 @@ import {
 import classNames from 'classnames';
 import {FileData} from 'frontend-js-components-web';
 import {getObjectValueFromPath, sub} from 'frontend-js-web';
-import React, {useEffect, useMemo, useState} from 'react';
+import React, {useEffect, useMemo, useRef, useState} from 'react';
 
 type IItemSelectorModalFDSProps = Omit<
 	IFrontendDataSetProps,
@@ -192,6 +192,16 @@ function ItemSelectorModal<T extends Record<string, any>>({
 			setSelectedItems(externalItems);
 		}
 	}, [externalItems, open]);
+
+	const initialApiURLRef = useRef(apiURL);
+
+	useEffect(() => {
+		if (apiURL === initialApiURLRef.current) {
+			return;
+		}
+
+		setFdsRefreshKey((key) => key + 1);
+	}, [apiURL]);
 
 	const getSelectedItemLabel = function (selectedItem: T) {
 		return getObjectValueFromPath({

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/ItemSelectorModal.tsx
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/ItemSelectorModal.tsx
@@ -16,7 +16,7 @@ import {
 import classNames from 'classnames';
 import {FileData} from 'frontend-js-components-web';
 import {getObjectValueFromPath, sub} from 'frontend-js-web';
-import React, {useEffect, useMemo, useRef, useState} from 'react';
+import React, {useEffect, useMemo, useState} from 'react';
 
 type IItemSelectorModalFDSProps = Omit<
 	IFrontendDataSetProps,
@@ -192,16 +192,6 @@ function ItemSelectorModal<T extends Record<string, any>>({
 			setSelectedItems(externalItems);
 		}
 	}, [externalItems, open]);
-
-	const initialApiURLRef = useRef(apiURL);
-
-	useEffect(() => {
-		if (apiURL === initialApiURLRef.current) {
-			return;
-		}
-
-		setFdsRefreshKey((key) => key + 1);
-	}, [apiURL]);
 
 	const getSelectedItemLabel = function (selectedItem: T) {
 		return getObjectValueFromPath({

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/openCMSFileSelectorModal.ts
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/openCMSFileSelectorModal.ts
@@ -173,11 +173,13 @@ const FDS_PROPS: Omit<
 						sortable: true,
 					},
 					{
+						contentRenderer: 'cmsFilesFallbackCellRenderer',
 						fieldName: 'embedded.file.mimeType',
 						label: Liferay.Language.get('type'),
 						sortable: false,
 					},
 					{
+						contentRenderer: 'cmsFilesFallbackCellRenderer',
 						fieldName: 'embedded.file.size',
 						label: Liferay.Language.get('size'),
 						sortable: false,

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/openCMSFileSelectorModal.ts
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/openCMSFileSelectorModal.ts
@@ -241,27 +241,33 @@ export default function openCMSFileSelectorModal({
 	maxFileSize?: number;
 	onSelect: (items: Array<CMSFile>) => void;
 }) {
+	let effectiveFilters: string[] = [];
+
+	if (filters?.length) {
+		effectiveFilters = filters;
+	}
+	else if (allowedExtensions) {
+		effectiveFilters = [normalizeExtensions(allowedExtensions)];
+	}
+
+	const buildApiURL = (folderId: number | null) =>
+		urlBuilder({
+			filters: effectiveFilters,
+			folderId: folderId ?? undefined,
+		});
+
 	const finalConfig = {
 		...CMS_FILE_ITEM_SELECTOR_CONFIG,
 		...config,
+		apiURL: buildApiURL(null),
 	};
-
-	if (filters?.length) {
-		finalConfig.apiURL = urlBuilder({filters});
-	}
-	else if (allowedExtensions) {
-		const extensions = normalizeExtensions(allowedExtensions);
-
-		finalConfig.apiURL = urlBuilder({
-			filters: [extensions],
-		});
-	}
 
 	return render(
 		DetachedCMSFilesItemSelectorModal,
 		{
 			...finalConfig,
 			allowedExtensions,
+			buildApiURL,
 			fdsProps: {
 				...FDS_PROPS,
 				emptyState: allowDragAndDrop

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/openCMSFileSelectorModal.ts
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/openCMSFileSelectorModal.ts
@@ -46,19 +46,21 @@ type CMSFileItemSelectorModalConfig = {
 function urlBuilder({
 	base = location.origin,
 	filters = [],
+	folderId,
 	resource = '/o/search/v1.0/search',
 }: {
 	base?: string;
 	filters?: string[];
+	folderId?: number | null;
 	resource?: string;
 }) {
 	const finalURL = new URL(resource, base);
 
-	const filter = [
-		"(cmsKind eq 'object')",
-		"(cmsSection eq 'files')",
-		'(status in (0, 2, 3))',
-	]
+	const scopePredicates = folderId
+		? [`(folderId eq ${folderId})`]
+		: ["(cmsSection eq 'files')"];
+
+	const filter = [...scopePredicates, '(status in (0, 2, 3))']
 		.concat(filters.filter(Boolean))
 		.join(' and ');
 
@@ -215,7 +217,7 @@ function normalizeExtensions(allowedExtensions: string) {
 
 	const extensions = cleanExtensions.map((item) => `'${item}'`).join(',');
 
-	return `(extension in (${extensions}))`;
+	return `(extension in (${extensions}) or cmsKind eq 'folder')`;
 }
 
 export default function openCMSFileSelectorModal({

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/openCMSFileSelectorModal.ts
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/openCMSFileSelectorModal.ts
@@ -58,7 +58,7 @@ function urlBuilder({
 
 	const scopePredicates = folderId
 		? [`(folderId eq ${folderId})`]
-		: ["(cmsSection eq 'files')"];
+		: ["(cmsSection eq 'files')", '(cmsRoot eq true)'];
 
 	const filter = [...scopePredicates, '(status in (0, 2, 3))']
 		.concat(filters.filter(Boolean))

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector_file_uploader/CMSFileUploaderComponent.tsx
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector_file_uploader/CMSFileUploaderComponent.tsx
@@ -16,11 +16,6 @@ import React, {useId, useState} from 'react';
 import ItemSelector from '../item_selector/ItemSelector';
 import {FilesUploaderComponent} from '../item_selector/ItemSelectorModal';
 
-type CMSFileUploaderComponentProps =
-	React.ComponentProps<FilesUploaderComponent> & {
-		parentObjectEntryFolderId?: number | null;
-	};
-
 type AssetLibrary = {
 	externalReferenceCode: string;
 	id: number;
@@ -69,14 +64,16 @@ const SpaceInput = React.forwardRef<HTMLInputElement, ISpaceInputProps>(
 
 const ASSET_LIBRARIES_API_URL = `${location.origin}/o/headless-asset-library/v1.0/asset-libraries?filter=type eq 'Space'`;
 
-const CMSFileUploaderComponent = function ({
+const CMSFileUploaderComponent: FilesUploaderComponent<{
+	parentObjectEntryFolderId?: number | null;
+}> = function ({
 	allowedExtensions,
 	files,
 	groupId: externalGroupId,
 	maxFileSize,
 	onCloseUploadView,
 	parentObjectEntryFolderId,
-}: CMSFileUploaderComponentProps) {
+}) {
 	const [assetLibrary, setAssetLibrary] = useState<
 		AssetLibrary | undefined
 	>();

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector_file_uploader/CMSFileUploaderComponent.tsx
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector_file_uploader/CMSFileUploaderComponent.tsx
@@ -16,6 +16,11 @@ import React, {useId, useState} from 'react';
 import ItemSelector from '../item_selector/ItemSelector';
 import {FilesUploaderComponent} from '../item_selector/ItemSelectorModal';
 
+type CMSFileUploaderComponentProps =
+	React.ComponentProps<FilesUploaderComponent> & {
+		parentObjectEntryFolderId?: number | null;
+	};
+
 type AssetLibrary = {
 	externalReferenceCode: string;
 	id: number;
@@ -64,13 +69,14 @@ const SpaceInput = React.forwardRef<HTMLInputElement, ISpaceInputProps>(
 
 const ASSET_LIBRARIES_API_URL = `${location.origin}/o/headless-asset-library/v1.0/asset-libraries?filter=type eq 'Space'`;
 
-const CMSFileUploaderComponent: FilesUploaderComponent = function ({
+const CMSFileUploaderComponent = function ({
 	allowedExtensions,
 	files,
 	groupId: externalGroupId,
 	maxFileSize,
 	onCloseUploadView,
-}) {
+	parentObjectEntryFolderId,
+}: CMSFileUploaderComponentProps) {
 	const [assetLibrary, setAssetLibrary] = useState<
 		AssetLibrary | undefined
 	>();
@@ -97,6 +103,10 @@ const CMSFileUploaderComponent: FilesUploaderComponent = function ({
 
 		const fileBase64 = await getFileAsBase64(fileData.file);
 
+		const folderRef = parentObjectEntryFolderId
+			? {objectEntryFolderId: parentObjectEntryFolderId}
+			: {objectEntryFolderExternalReferenceCode: 'L_FILES'};
+
 		const response = await Liferay.Util.fetch(
 			`/o/cms/basic-documents/scopes/${resolvedGroupId}`,
 			{
@@ -105,7 +115,7 @@ const CMSFileUploaderComponent: FilesUploaderComponent = function ({
 						fileBase64,
 						name: fileData.name,
 					},
-					objectEntryFolderExternalReferenceCode: 'L_FILES',
+					...folderRef,
 					title: fileData.name,
 				}),
 				headers: {

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/test/openCMSFileSelectorModal.test.tsx
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/test/openCMSFileSelectorModal.test.tsx
@@ -4,32 +4,54 @@
  */
 
 import '@testing-library/jest-dom';
-import {screen, within} from '@testing-library/react';
+import {screen, waitFor, within} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import {fetch} from 'frontend-js-web';
 
 import openCMSFileSelectorModal from '../src/main/resources/META-INF/resources/item_selector/openCMSFileSelectorModal';
 
+const fileItem = {
+	embedded: {id: 1, title: 'File'},
+	id: 1,
+};
+
+function jsonResponse(items: object[]) {
+	return Promise.resolve({
+		json: () =>
+			Promise.resolve({
+				items,
+				lastPage: 1,
+				page: 1,
+				totalCount: items.length,
+			}),
+		ok: true,
+	});
+}
+
 jest.mock('frontend-js-web', () => ({
 	...(jest.requireActual('frontend-js-web') as any),
-	fetch: jest.fn(() =>
-		Promise.resolve({
-			json: () =>
-				Promise.resolve({
-					items: [{embedded: {id: 1, title: 'File'}, id: 1}],
-					lastPage: 1,
-					page: 1,
-					totalCount: 1,
-				}),
-			ok: true,
-		})
-	),
+	fetch: jest.fn(),
 }));
+
+const mockedFetch = fetch as jest.Mock;
+
+function getDecodedSearchURLs() {
+	return mockedFetch.mock.calls
+		.map(([url]) =>
+			decodeURIComponent(url?.toString?.() ?? '').replace(/\+/g, ' ')
+		)
+		.filter((url) => url.includes('/o/search/v1.0/search'));
+}
 
 describe('openCMSFileSelectorModal', () => {
 	beforeAll(() => {
 		Object.assign(Liferay.ThemeDisplay, {
 			isImpersonated: () => false,
 		});
+	});
+
+	beforeEach(() => {
+		mockedFetch.mockImplementation(() => jsonResponse([fileItem]));
 	});
 
 	afterEach(() => {
@@ -65,5 +87,46 @@ describe('openCMSFileSelectorModal', () => {
 		expect(options[0]).toHaveTextContent('cards');
 
 		expect(options[1]).toHaveTextContent('table');
+	});
+
+	it('fetches with a folder-inclusive root filter', async () => {
+		openCMSFileSelectorModal({
+			groupId: 123,
+			onSelect: jest.fn(),
+		});
+
+		await screen.findByRole('dialog');
+
+		await waitFor(() => {
+			expect(getDecodedSearchURLs().length).toBeGreaterThan(0);
+		});
+
+		const [firstURL] = getDecodedSearchURLs();
+
+		expect(firstURL).toContain("(cmsSection eq 'files')");
+
+		expect(firstURL).not.toContain("cmsKind eq 'object'");
+
+		expect(firstURL).not.toContain('folderId eq ');
+	});
+
+	it("widens the extension filter so folders pass through with cmsKind eq 'folder'", async () => {
+		openCMSFileSelectorModal({
+			allowedExtensions: 'jpg,png',
+			groupId: 123,
+			onSelect: jest.fn(),
+		});
+
+		await screen.findByRole('dialog');
+
+		await waitFor(() => {
+			expect(getDecodedSearchURLs().length).toBeGreaterThan(0);
+		});
+
+		const [firstURL] = getDecodedSearchURLs();
+
+		expect(firstURL).toContain("extension in ('jpg','png')");
+
+		expect(firstURL).toContain("cmsKind eq 'folder'");
 	});
 });


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89732

## What is being fixed

The new React Item Selector modal listed CMS items as a flat list and could not drill into folders. The legacy Java selector already supports folder navigation; this branch brings the React version to parity before the legacy version is deprecated.

## How it is being fixed

The CMS opener's `urlBuilder` widens the root filter so folders surface alongside files (drops `cmsKind eq 'object'`, ORs `cmsKind eq 'folder'` into the extension filter, pins the root listing to direct children via `cmsRoot eq true`) and accepts an optional `folderId` that switches the filter to `folderId eq <id>` when the user drills in. The opener exposes a `buildApiURL(folderId)` closure so the wrapper can rebuild the URL per level.

`DetachedCMSFilesItemSelectorModal` owns a `currentFolder` stack, derives the `apiURL` and a clickable breadcrumb from it, and overrides FDS view rendering so folder rows navigate instead of select: the cards branch returns `onClick: navigateToFolder`, `onSelectChange: null`, and `symbol: 'folder'`; the table branch overrides the row's `onClick` and tags the row with a class so a CSS rule hides the selection radio (FDS hardcodes the select cell with no per-row prop to skip it). The title cell renderer mirrors the CMS section's `AssetRenderer` look for both folders and files; folder rows show `--` in the Type and Size columns since folders carry no `embedded.file`. The breadcrumb container gets a bottom border in the cadmin border color so it visually separates from the FDS list, mirroring the management bar. A redundant `fdsRefreshKey` bump on `apiURL` change was removed so the cards/table selection survives folder navigation. The table folder link calls `event.stopPropagation()` so the breadcrumb does not double-push when the click would otherwise bubble to the row's own handler. URL-assertion tests cover the urlBuilder change.

![Uploading Screenshot 2026-05-26 at 10.11.24.png…]()


## Known limitation

Folder rows currently interleave with files in the listing order. The search REST API does not expose a sortable variant of `cms_kind` (the field is declared in the entity model but not indexed with `Field.getSortableFieldName`), so sort by that key is silently ignored. A follow-up backend change indexing `cms_kind_sortable` would let us add `sorts: [{key: 'cmsKind', direction: 'asc'}]` to group folders first (task created https://liferay.atlassian.net/browse/LPD-92085) 