### PR TITLE
LPD-60781 Do not show search bar when scrolling results but keep it o…

### DIFF
--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/search_results.jsp
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/search_results.jsp
@@ -39,7 +39,7 @@ renderResponse.setTitle(LanguageUtil.get(request, "search-results"));
 	}
 </aui:style>
 
-<div class="configuration-admin--search-results sticky-top">
+<div class="configuration-admin--search-results">
 	<clay:management-toolbar
 		managementToolbarDisplayContext="<%= new ConfigurationScopeManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, configurationEntryIterator.getTotal()) %>"
 	/>


### PR DESCRIPTION
# Summary of Changes

To avoid having "Search Results" float over the results, I chose to not make the Management Toolbar sticky so it scrolls out of view. This is what happens when searching Roles, for instance.

Unlike the example with Roles, the search bar is kept visible even when scrolling before a search, so that a user is encouraged to use it. This choice aims to respect [LPS-139987](https://liferay.atlassian.net/browse/LPS-139987). 

# Motivation / Context

[LPD-60781](https://liferay.atlassian.net/browse/LPD-60781)

The goal is to make sure no piece of text ("Search Results" in particular) overlaps with any other and try to keep UX relatively homogenous.

# Technical Approach

Just remove the CSS class `sticky-top` from the search results JSP (but not from the general view JSP, namely `modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/view.jsp`)

# Validation Performed

**Automated Tests**

- [ ] Unit tests
- [ ] Integration tests
- [ ] Functional / end-to-end tests
- [x] Not applicable (aesthetic fix without functional chages)

**Manual Testing**

- Steps:
  1. Go to Control Panel > System Settings or Instance Settings
  2. Notice that scrolling keeps the search bar visible.
  3. Search for "log" or "t" or some other string with many results.
  4. Scroll down.
- Expected result: The string "Search Results" doesn't overlap with the results. More over the Management Toolbar scrolls out of view.
- Actual result: The string "Search Results" overlaps with the results.

# UI / UX Changes

- [ ] No UI changes
- [x] UI changes included (screenshots/media below)

**Screenshots / Media (Before & After)**

| Before | After |
| ------ | ----- |
|![before](https://github.com/user-attachments/assets/3ecb9c68-2256-4e75-9cb5-7474f3c199d7) |![after](https://github.com/user-attachments/assets/fffc9f05-ed06-4341-9322-082b96f1cae7) |


# Alternatives Considered

One alternative approach might be to add a background color to the element containing "Search Results" but that would require careful changes allowing for custom theme colors, etc.

Another approach would be making "Search Results" non-sticky but that would require going inside `<clay:management-toolbar` which seems overkill and would affect any other search results in the portal.

# Checklist for Author

- [x] Linked to the correct Jira / LPD / related ticket.
- [ ] Relevant unit tests updated/added and passed locally.
- [ ] Relevant integration / functional / Playwright tests updated/added and passed locally (if applicable).
- [ ] ci:test:sf has been run and is green.
- [ ] ci:test:relevant has been run and is green.
- [ ] Any domain‑specific suites (ci:test:security, ci:test:ldap, ci:test:oauth2, ci:test:saml, …) have been run if the change touches those areas.
- [ ] No unique CI failures remain (anything unique is investigated and fixed).
- [x] Self-reviewed the code (style, naming, dead code, logs, etc.).
- [ ] Updated documentation / comments where needed.
- [x] `../gradlew -b util.gradle validateBranch`
