### PR TITLE
LPD-85611 Setting system feature flags via envvars is broken

### DIFF
--- a/modules/apps/feature-flag/feature-flag-test/src/testIntegration/java/com/liferay/feature/flag/test/CompanyModelListenerTest.java
+++ b/modules/apps/feature-flag/feature-flag-test/src/testIntegration/java/com/liferay/feature/flag/test/CompanyModelListenerTest.java
@@ -82,6 +82,37 @@ public class CompanyModelListenerTest {
 		}
 	}
 
+	@Test
+	public void testSystemDeprecationFeatureFlagIsEnabledForNewCompany()
+		throws Exception {
+
+		Company company = CompanyTestUtil.addCompany();
+
+		List<FeatureFlag> systemDeprecationFeatureFlags =
+			_featureFlagManager.getFeatureFlags(
+				CompanyConstants.SYSTEM,
+				FeatureFlagType.DEPRECATION.getPredicate());
+
+		Assert.assertFalse(systemDeprecationFeatureFlags.isEmpty());
+
+		boolean anyEnabled = false;
+
+		for (FeatureFlag systemDeprecationFeatureFlag :
+				systemDeprecationFeatureFlags) {
+
+			if (_featureFlagManager.isEnabled(
+					company.getCompanyId(),
+					systemDeprecationFeatureFlag.getKey())) {
+
+				anyEnabled = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(anyEnabled);
+	}
+
 	@Inject
 	private FeatureFlagManager _featureFlagManager;
 

--- a/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/model/listener/CompanyModelListener.java
+++ b/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/model/listener/CompanyModelListener.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portlet.PortalPreferencesWrapper;
 
 import java.util.List;
+import java.util.function.Predicate;
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -41,7 +42,8 @@ public class CompanyModelListener extends BaseModelListener<Company> {
 	public void onAfterCreate(Company company) throws ModelListenerException {
 		TransactionCommitCallbackUtil.registerCallback(
 			() -> {
-				_processDeprecationFeatureFlags(company.getCompanyId());
+				_processDeprecationFeatureFlagsForCompany(
+					company.getCompanyId());
 
 				return null;
 			});
@@ -50,11 +52,11 @@ public class CompanyModelListener extends BaseModelListener<Company> {
 	@Activate
 	protected void activate() {
 		if (StartupHelperUtil.isDBNew()) {
-			_processDeprecationFeatureFlags(CompanyConstants.SYSTEM);
+			_processDeprecationFeatureFlagsForSystem();
 		}
 
 		_companyLocalService.forEachCompanyId(
-			this::_processDeprecationFeatureFlags);
+			this::_processDeprecationFeatureFlagsForCompany);
 	}
 
 	private PortalPreferences _getPortalPreferences(long companyId) {
@@ -66,7 +68,9 @@ public class CompanyModelListener extends BaseModelListener<Company> {
 		return portalPreferencesWrapper.getPortalPreferencesImpl();
 	}
 
-	private void _processDeprecationFeatureFlags(long companyId) {
+	private void _processDeprecationFeatureFlags(
+		long companyId, Predicate<FeatureFlag> enabledPredicate) {
+
 		PortalPreferences portalPreferences = _getPortalPreferences(companyId);
 
 		boolean processed = GetterUtil.getBoolean(
@@ -87,7 +91,8 @@ public class CompanyModelListener extends BaseModelListener<Company> {
 
 		for (FeatureFlag deprecationFeatureFlag : deprecationFeatureFlags) {
 			_featureFlagsBagProvider.setEnabled(
-				companyId, deprecationFeatureFlag.getKey(), false);
+				companyId, deprecationFeatureFlag.getKey(),
+				enabledPredicate.test(deprecationFeatureFlag));
 		}
 
 		portalPreferences = _getPortalPreferences(companyId);
@@ -98,6 +103,16 @@ public class CompanyModelListener extends BaseModelListener<Company> {
 
 		_portalPreferencesLocalService.updatePreferences(
 			companyId, PortletKeys.PREFS_OWNER_TYPE_COMPANY, portalPreferences);
+	}
+
+	private void _processDeprecationFeatureFlagsForCompany(long companyId) {
+		_processDeprecationFeatureFlags(
+			companyId, deprecationFeatureFlag -> false);
+	}
+
+	private void _processDeprecationFeatureFlagsForSystem() {
+		_processDeprecationFeatureFlags(
+			CompanyConstants.SYSTEM, FeatureFlag::isEnabled);
 	}
 
 	@Reference


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-85611

## What is being fixed

LPD-80539 added a fresh-DB-only call to `_processDeprecationFeatureFlags(SYSTEM)` so that system-scoped deprecation feature flags would start disabled in a brand-new Liferay environment. The call wrote a hardcoded `false` into `PortalPreferences` for every deprecation flag, which then took precedence over the PropsUtil-derived default at read time. Any `LIFERAY_FEATURE_PERIOD_FLAG_PERIOD_..._=true` env override (or matching `portal-ext.properties` entry) was silently masked, while non-deprecation flags continued to honor the same env vars — exactly the instance-vs-system divergence reported in the bug.

## How it is being fixed

The deprecation processor is split into two scope-specific variants. The per-company variant keeps the existing semantics so new companies always start with their deprecation flags off. The system variant now writes `featureFlag.isEnabled()`, which reflects the current PropsUtil value — so the `portal.properties` default, any `portal-ext.properties` override, and any `LIFERAY_*` env override all flow through to `PortalPreferences` instead of being clobbered. The shared body is factored behind a `Predicate<FeatureFlag>` to avoid duplication.

A new integration test asserts that every SYSTEM-scoped deprecation flag's effective enabled state matches what PropsUtil reports.