### PR TITLE
LPD-90757 Stabilize Style Book Playwright tests around the editor sidebar

### DIFF
--- a/modules/apps/style-book/style-book-web/src/main/resources/META-INF/resources/js/style-book-editor/Sidebar.js
+++ b/modules/apps/style-book/style-book-web/src/main/resources/META-INF/resources/js/style-book-editor/Sidebar.js
@@ -29,7 +29,10 @@ export default React.memo(function Sidebar() {
 
 	return (
 		<div className="style-book-editor__sidebar" ref={sidebarRef}>
-			<div className="panel-group-sm style-book-editor__sidebar-content">
+			<div
+				className="panel-group-sm style-book-editor__sidebar-content"
+				data-qa-id="styleBookEditorSidebarContent"
+			>
 				{!!config.frontendTokenDefinitions.length && (
 					<TokenDefinitionSelector
 						activeDefinitionId={activeDefinitionId}

--- a/modules/test/playwright/pages/style-book-web/StyleBooksPage.ts
+++ b/modules/test/playwright/pages/style-book-web/StyleBooksPage.ts
@@ -63,6 +63,10 @@ export class StyleBooksPage {
 		await this.page.getByRole('button', {name: 'Save'}).click();
 
 		await waitForAlert(this.page);
+
+		await expect(
+			this.page.locator('.style-book-editor__sidebar-content').first()
+		).toBeVisible();
 	}
 
 	getStyleBookCard(styleBookName: string) {

--- a/modules/test/playwright/pages/style-book-web/StyleBooksPage.ts
+++ b/modules/test/playwright/pages/style-book-web/StyleBooksPage.ts
@@ -65,7 +65,7 @@ export class StyleBooksPage {
 		await waitForAlert(this.page);
 
 		await expect(
-			this.page.locator('.style-book-editor__sidebar-content').first()
+			this.page.getByTestId('styleBookEditorSidebarContent')
 		).toBeVisible();
 	}
 

--- a/modules/test/playwright/tests/style-book-web/main/styleBookSelection.spec.ts
+++ b/modules/test/playwright/tests/style-book-web/main/styleBookSelection.spec.ts
@@ -13,7 +13,6 @@ import {pagesAdminPagesTest} from '../../../fixtures/pagesAdminPagesTest';
 import {styleBookPageTest} from '../../../fixtures/styleBookPageTest';
 import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
 import {doAndGoBack} from '../../../utils/doAndGoBack';
-import fillAndClickOutside from '../../../utils/fillAndClickOutside';
 import getRandomString from '../../../utils/getRandomString';
 
 const STYLE_BOOK_NAME = getRandomString();
@@ -48,16 +47,12 @@ const test = mergeTests(
 	styleBookPageTest
 );
 
-test.beforeEach(async ({page, site, styleBooksPage}) => {
+test.beforeEach(async ({site, styleBooksPage}) => {
 	await styleBooksPage.goto(site.friendlyUrlPath);
 
 	await styleBooksPage.create(STYLE_BOOK_NAME);
 
-	await fillAndClickOutside(
-		page,
-		page.getByLabel('Brand Color 4', {exact: true}).getByRole('textbox'),
-		TEST_COLOR
-	);
+	await styleBooksPage.updateTokenInputColor('Brand Color 4', TEST_COLOR);
 
 	await styleBooksPage.waitForAutoSave();
 


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPD-90757

## Summary

- `StyleBooksPage.create()` returned as soon as `waitForAlert` resolved, but the editor SPA can still be mounting when the alert fires. Subsequent steps then race the sidebar's first render and intermittently fail.
- The Style Book selection spec drove the Brand Color input through an ad-hoc `fillAndClickOutside(page, ...)` call instead of the Page Object method that already exists for this interaction, duplicating logic and tying the spec to an unused `page` parameter.
- The sidebar visibility assertion this PR introduces was originally keyed off the BEM class `.style-book-editor__sidebar-content`, which is a styling concern. Coupling a stability check to CSS structure is fragile.

## Changes

- `StyleBooksPage.create()` now also asserts that the editor sidebar is visible after the save alert. This turns the method into a single "creation is fully done" gate so callers no longer have to add their own readiness wait, and existing callers inherit the stronger signal automatically.
- `styleBookSelection.spec.ts` swaps the inline `fillAndClickOutside(...)` call for `styleBooksPage.updateTokenInputColor('Brand Color 4', TEST_COLOR)`. The unused `page` parameter is dropped from `beforeEach` as a result. `updateTokenInputColor` already wraps the same fill + click-outside sequence, so behavior is preserved.
- `Sidebar.js` exposes the editor sidebar through a stable `data-qa-id="styleBookEditorSidebarContent"` attribute. The BEM class stays in place because `Undo.js` relies on it for outside-click detection. The Playwright assertion now targets the `data-qa-id` attribute, decoupling test stability from CSS structure.

## How to test it

1. Build and deploy `style-book-web`, then run `modules/test/playwright`:
   ```
   cd modules/test/playwright
   yarn test tests/style-book-web/main/styleBookSelection.spec.ts
   ```
2. Confirm the spec passes consistently across several consecutive runs — the new sidebar-visibility gate should eliminate the prior intermittent failure where the test moved on before the editor finished mounting.
3. Inspect the rendered Style Book editor in a browser (`/group/<site>/~/control_panel/manage?p_p_id=com_liferay_style_book_web_internal_portlet_StyleBookPortlet`). The sidebar's content `<div>` should carry both the original `style-book-editor__sidebar-content` class and the new `data-qa-id="styleBookEditorSidebarContent"` attribute.