### PR TITLE
LPD-92149 Stabilize configuration-admin-web/main/siteSettings.spec.ts

### DIFF
--- a/modules/test/playwright/helpers/json-web-services/JSONWebServicesLayoutSetPrototypeApiHelper.ts
+++ b/modules/test/playwright/helpers/json-web-services/JSONWebServicesLayoutSetPrototypeApiHelper.ts
@@ -7,6 +7,7 @@ import {liferayConfig} from '../../liferay.config';
 import {ApiHelpers} from '../ApiHelpers';
 
 export type LayoutSetPrototype = {
+	active: boolean;
 	companyId: string;
 	layoutSetPrototypeId: string;
 	nameCurrentValue: string;

--- a/modules/test/playwright/tests/configuration-admin-web/main/siteSettings.spec.ts
+++ b/modules/test/playwright/tests/configuration-admin-web/main/siteSettings.spec.ts
@@ -246,20 +246,28 @@ test('LPD-87025 Assert that the Pages screen shows the Open Pages link when the 
 	).toBeHidden();
 });
 
-test('LPD-87025 Assert that the Pages screen shows the no-pages message when the site has no pages', async ({
-	page,
-	site,
-	siteSettingsPage,
-}) => {
-	await siteSettingsPage.goToSiteSetting(
-		'Pages',
-		'Pages',
-		site.friendlyUrlPath
-	);
+test(
+	'LPD-87025 Assert that the Pages screen hides the Open Pages link when the site has no pages',
+	{tag: '@LPD-87025'},
+	async ({apiHelpers, page, site, siteSettingsPage}) => {
+		await siteSettingsPage.goToSiteSetting(
+			'Pages',
+			'Pages',
+			site.friendlyUrlPath
+		);
 
-	await expect(
-		page.getByText('This site does not have any pages.')
-	).toBeVisible();
+		const layoutSetPrototypes =
+			await apiHelpers.jsonWebServicesLayoutSetPrototype.getLayoutSetPrototypes();
 
-	await expect(page.getByRole('link', {name: 'Open Pages'})).toBeHidden();
-});
+		const hasActiveLayoutSetPrototype = layoutSetPrototypes.some(
+			({active}) => active
+		);
+
+		const locator = hasActiveLayoutSetPrototype
+			? page.getByRole('combobox', {name: 'Site Template'})
+			: page.getByText('This site does not have any pages.');
+
+		await expect(locator).toBeVisible();
+		await expect(page.getByRole('link', {name: 'Open Pages'})).toBeHidden();
+	}
+);


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPD-92149

## Summary

- The Playwright test `LPD-87025 Assert that the Pages screen shows the no-pages message when the site has no pages` (`modules/test/playwright/tests/configuration-admin-web/main/siteSettings.spec.ts:249`) was an intermittent CI flake — 4 failures across 27 recent `test-portal-acceptance-upstream-dxp` runs, non-consecutive.
- **Possible root cause**: the test asserted that the literal `"This site does not have any pages."` was visible, but `modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/site_settings/pages.jsp:58` only renders that copy when the company has **zero** active `LayoutSetPrototype` records. Whenever any active LSP exists anywhere in the company, the JSP renders a Site Template dropdown instead. Several sibling Playwright specs (`siteTemplatesConfiguration.spec.ts`, `siteTemplatesWithPage.spec.ts`, `connectSiteTemplates.spec.ts`, and others) create LSPs during their own runs — occasional cleanup latency or failure leaves an active LSP in the company at the wrong moment, flipping the JSP branch under the failing test.
- **Fix**: query the LSP service before asserting, then branch the assertion to match whichever JSP branch is actually reachable for the current company state. The user-visible invariant the test really protects — no "Open Pages" link when the site has no pages — is kept and is what the renamed title now reflects.

## How to test it

Prereqs: a running Liferay bundle with the Playwright tests directory installed (`cd modules/test/playwright && yarn install`).

**Path 1 — clean company (the normal CI passing path):**
1. From the portal root, ensure no active LSPs exist in the test company:
   ```bash
   curl -u test@liferay.com:test -X POST \
     "http://localhost:8080/api/jsonws/layoutsetprototype/get-layout-set-prototypes" \
     -d "companyId=<your-company-id>"
   ```
   Expect `[]`.
2. Run:
   ```bash
   cd modules/test/playwright
   yarn playwright test --project=configuration-admin-web.main \
     -g "hides the Open Pages link when the site has no pages"
   ```
3. Expect `1 passed`. The test asserts branch B (no-pages text).

**Path 2 — dirty company (the regression scenario the fix targets):**
1. Seed one active LSP to mimic a leaked site template:
   ```bash
   curl -u test@liferay.com:test -X POST \
     "http://localhost:8080/api/jsonws/layoutsetprototype/add-layout-set-prototype" \
     -d "name=SiteTemplate-flake-sim" \
     -d "description=" \
     -d "active=true" \
     -d "layoutsUpdateable=true"
   ```
   Note the returned `layoutSetPrototypeId`.
2. Run the same test command as above.
3. Expect `1 passed`. The test asserts branch A (Site Template combobox).
4. Clean up:
   ```bash
   curl -u test@liferay.com:test -X POST \
     "http://localhost:8080/api/jsonws/layoutsetprototype/delete-layout-set-prototype" \
     -d "layoutSetPrototypeId=<id-from-step-1>"
   ```

Local validation captured 10 consecutive runs (5 clean + 5 dirty), all green.