### PR TITLE
LPD-88989 Align the multiple file uploader footer to the bottom

### DIFF
--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/css/components/MultipleFileUploader.scss
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/css/components/MultipleFileUploader.scss
@@ -1,8 +1,16 @@
 @import 'atlas-variables';
 
 .multiple-file-uploader {
+	display: flex;
+	flex: 1;
+	flex-direction: column;
+
 	.modal-body.inline-scroller {
 		max-height: min(600px, calc(100vh - 14rem));
+	}
+
+	.modal-footer {
+		margin-top: auto;
 	}
 
 	.dropzone {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88989

## What is being fixed

In the React Item Selector's full-screen modal, opening the image picker from CKEditor and clicking Upload Files renders the MultipleFileUploader action buttons immediately below the file list instead of at the bottom of the modal, leaving a large empty area underneath.

## How it is being fixed

The shared `MultipleFileUploader` stylesheet now makes the form itself a flex column that stretches inside a flex parent, and the inner modal footer uses `margin-top: auto` to pin it to the bottom. In modals sized to content (the standalone CMS Files and Import Translation uploads), `flex: 1` finds no room to expand and `margin-top: auto` collapses, so those layouts render exactly as before.

<img width="1495" height="1323" alt="image" src="https://github.com/user-attachments/assets/9eca25e2-68d2-444a-aead-839d315398b3" />