### PR TITLE
LPD-92126 Remove underline from MultiSelect labels on hover and focus

### DIFF
--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/mixins/_labels.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/mixins/_labels.scss
@@ -758,10 +758,17 @@
 			}
 
 			@if (length($href) != 0) {
-				&[href],
+				&[href] {
+					@include clay-link($href);
+				}
+			}
+
+			$_tabindex: map-get($map, tabindex);
+
+			@if (length($_tabindex) != 0) {
 				&[type],
 				&[tabindex] {
-					@include clay-link($href);
+					@include clay-link($_tabindex);
 				}
 			}
 


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPD-92126

## Summary

ClayMultiSelect value chips are focusable labels (`.label[tabindex]`), so `clay-link` adds a link-style underline on hover and keyboard focus. The chips are not links. This removes that underline, scoped to the MultiSelect wrapper (`.form-control-tag-group`) to avoid a platform-wide label-mixin change.

## Changes

Adds `text-decoration: none` on `.label[tabindex]` for `:hover`/`:focus` (and `.hover`/`.focus`) inside `.form-control-tag-group`, in both `_forms.scss` layers (base + cadmin). The focus ring is untouched.

Before the fix:
https://github.com/user-attachments/assets/9458fb80-6d67-4a23-adb4-ecba34bbb31f

After the fix:
https://github.com/user-attachments/assets/693a34fb-c3a3-48b2-a2ed-b787752e900e

## How to test it

1. Run Clay Storybook from `frontend-js-clay-web`: `yarn run storybook`.
2. Open **Design System → Components → MultiSelect → Default**.
3. Hover the "one" chip -> no underline.
4. Tab to focus the chip -> no underline; focus ring still visible.