### PR TITLE
LPD-91533 Center horizontal card indicator in form-check-middle variants

### DIFF
--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-card/stories/Card.stories.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-card/stories/Card.stories.tsx
@@ -214,6 +214,7 @@ CardWithInfoImage.args = {
 };
 export function CardWithHorizontal(args: any) {
 	const [value, setValue] = useState<boolean>(false);
+	const [longTextValue, setLongTextValue] = useState<boolean>(false);
 	const [radioValue, setRadioValue] = useState<string>('');
 
 	return (
@@ -246,6 +247,17 @@ export function CardWithHorizontal(args: any) {
 						onSelectChange={setValue}
 						selected={value}
 						title="Selectable Folder"
+					/>
+				</div>
+
+				<div className="col-md-4">
+					<ClayCardWithHorizontal
+						disabled={args.disabled}
+						href="#"
+						onSelectChange={setLongTextValue}
+						selected={longTextValue}
+						title="This Folder Has an Extremely Long Name That Wraps Onto Multiple Lines Instead of Being Truncated With an Ellipsis"
+						truncate={false}
 					/>
 				</div>
 			</div>
@@ -296,6 +308,30 @@ export function CardWithHorizontal(args: any) {
 							selectableType="radio"
 							selected={radioValue === 'radio2'}
 							title="Radio Selectable Folder 2"
+						/>
+
+						<ClayCardWithHorizontal
+							actions={[
+								{
+									label: 'clickable',
+									onClick: () => {
+										alert('you clicked!');
+									},
+								},
+								{type: 'divider'},
+								{
+									href: '#',
+									label: 'linkable',
+								},
+							]}
+							disabled={args.disabled}
+							href="#"
+							onSelectChange={setRadioValue}
+							radioProps={{name: 'cards', value: 'radio3'}}
+							selectableType="radio"
+							selected={radioValue === 'radio3'}
+							title="This Radio Folder Has an Extremely Long Name That Wraps Onto Multiple Lines Instead of Being Truncated With an Ellipsis"
+							truncate={false}
 						/>
 					</ClayCard.Group>
 				</div>

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-card/stories/Card.stories.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-card/stories/Card.stories.tsx
@@ -23,6 +23,22 @@ export default {
 	title: 'Design System/Components/Card',
 };
 
+const cardActions: React.ComponentProps<
+	typeof ClayCardWithHorizontal
+>['actions'] = [
+	{
+		label: 'clickable',
+		onClick: () => {
+			alert('you clicked!');
+		},
+	},
+	{type: 'divider'},
+	{
+		href: '#',
+		label: 'linkable',
+	},
+];
+
 function ClayCheckboxWithState(props: any) {
 	const [value, setValue] = React.useState<boolean>(false);
 	const checked = props.value || value;
@@ -65,19 +81,7 @@ export function CardWithInfo(args: {disabled?: boolean}) {
 
 				<div className="col-md-4">
 					<ClayCardWithInfo
-						actions={[
-							{
-								label: 'clickable',
-								onClick: () => {
-									alert('you clicked!');
-								},
-							},
-							{type: 'divider'},
-							{
-								href: '#',
-								label: 'linkable',
-							},
-						]}
+						actions={cardActions}
 						description="A cool description"
 						disabled={args.disabled}
 						href="#"
@@ -229,19 +233,7 @@ export function CardWithHorizontal(args: any) {
 
 				<div className="col-md-4">
 					<ClayCardWithHorizontal
-						actions={[
-							{
-								label: 'clickable',
-								onClick: () => {
-									alert('you clicked!');
-								},
-							},
-							{type: 'divider'},
-							{
-								href: '#',
-								label: 'linkable',
-							},
-						]}
+						actions={cardActions}
 						disabled={args.disabled}
 						href="#"
 						onSelectChange={setValue}
@@ -265,19 +257,7 @@ export function CardWithHorizontal(args: any) {
 				<div className="col-md-12">
 					<ClayCard.Group label="Radio Card Group">
 						<ClayCardWithHorizontal
-							actions={[
-								{
-									label: 'clickable',
-									onClick: () => {
-										alert('you clicked!');
-									},
-								},
-								{type: 'divider'},
-								{
-									href: '#',
-									label: 'linkable',
-								},
-							]}
+							actions={cardActions}
 							disabled={args.disabled}
 							href="#"
 							onSelectChange={setRadioValue}
@@ -288,19 +268,7 @@ export function CardWithHorizontal(args: any) {
 						/>
 
 						<ClayCardWithHorizontal
-							actions={[
-								{
-									label: 'clickable',
-									onClick: () => {
-										alert('you clicked!');
-									},
-								},
-								{type: 'divider'},
-								{
-									href: '#',
-									label: 'linkable',
-								},
-							]}
+							actions={cardActions}
 							disabled={args.disabled}
 							href="#"
 							onSelectChange={setRadioValue}
@@ -311,19 +279,7 @@ export function CardWithHorizontal(args: any) {
 						/>
 
 						<ClayCardWithHorizontal
-							actions={[
-								{
-									label: 'clickable',
-									onClick: () => {
-										alert('you clicked!');
-									},
-								},
-								{type: 'divider'},
-								{
-									href: '#',
-									label: 'linkable',
-								},
-							]}
+							actions={cardActions}
 							disabled={args.disabled}
 							href="#"
 							onSelectChange={setRadioValue}
@@ -384,19 +340,7 @@ export function CardWithUser(args: any) {
 			<div className="row">
 				<div className="col-md-4">
 					<ClayCardWithUser
-						actions={[
-							{
-								label: 'clickable',
-								onClick: () => {
-									alert('you clicked!');
-								},
-							},
-							{type: 'divider'},
-							{
-								href: '#',
-								label: 'linkable',
-							},
-						]}
+						actions={cardActions}
 						description="Assistant to the regional manager"
 						disabled={args.disabled}
 						href="#"

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_cards.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_cards.scss
@@ -597,6 +597,15 @@ $form-check-middle-left: map-deep-merge(
 			),
 
 			custom-control-label: (
+				after: (
+					top: 50%,
+					transform: translateY(-50%),
+				),
+
+				before: (
+					top: 0,
+				),
+
 				left: $checkbox-position,
 				margin-top: 0rem,
 				opacity: 1,
@@ -632,6 +641,15 @@ $form-check-middle-right: map-deep-merge(
 			),
 
 			custom-control-label: (
+				after: (
+					top: 50%,
+					transform: translateY(-50%),
+				),
+
+				before: (
+					top: 0,
+				),
+
 				left: auto,
 				margin-top: 0rem,
 				opacity: 1,

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/components/_cards.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/components/_cards.scss
@@ -389,6 +389,20 @@
 	}
 }
 
+.form-check-middle-left,
+.form-check-middle-right {
+	.custom-control-label {
+		&::after {
+			top: 50%;
+			transform: translateY(-50%);
+		}
+
+		&::before {
+			top: 0;
+		}
+	}
+}
+
 .form-check-top-left {
 	.custom-control-input,
 	.custom-control-label,

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/variables/_cards.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/variables/_cards.scss
@@ -571,6 +571,15 @@ $form-check-middle-left: map-deep-merge(
 			),
 
 			custom-control-label: (
+				after: (
+					top: 50%,
+					transform: translateY(-50%),
+				),
+
+				before: (
+					top: 0,
+				),
+
 				left: $checkbox-position,
 				margin-top: 0rem,
 				opacity: 1,
@@ -606,6 +615,15 @@ $form-check-middle-right: map-deep-merge(
 			),
 
 			custom-control-label: (
+				after: (
+					top: 50%,
+					transform: translateY(-50%),
+				),
+
+				before: (
+					top: 0,
+				),
+
 				left: auto,
 				margin-top: 0rem,
 				opacity: 1,


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPD-91533

#### Summary
The checkbox/radio indicator in the `form-check-middle-left` / `-right` (horizontal card) variants was top-anchored instead of vertically centered, so it floated near the top on taller cards. This centers the indicator glyph (`::after`) at `top: 50%` / `translateY(-50%)` and pins the box (`::before`) to `top: 0`. Scoped to the `-middle-*` variants only.

#### Changes
- Base + atlas-custom-properties variables `_cards.scss`: add `after` / `before` sub-maps to the `custom-control-label` map for both middle variants.
- cadmin `_cards.scss`: same intent as literal CSS (cadmin middle blocks are hand-written, not mixin-generated).

#### How to test it
- Open the `CardWithHorizontal` Storybook story.
- Confirm the checkbox/radio indicator is vertically centered for both `-middle-left` and `-middle-right`, including on taller / wrapping cards.

Before fix:
<img width="720" height="610" alt="Screenshot From 2026-05-27 09-45-48" src="https://github.com/user-attachments/assets/a6d7053d-9097-482e-9ec4-8f1725fbece9" />

After fix:
<img width="720" height="610" alt="Screenshot From 2026-05-27 09-48-00" src="https://github.com/user-attachments/assets/98cc4d5b-c70f-4c53-8c01-4c5335fbddc3" />
