### PR TITLE
LPD-34943 Keep parent overlay accessible when nested overlay opens

### DIFF
--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-drop-down/src/__tests__/index.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-drop-down/src/__tests__/index.tsx
@@ -480,6 +480,44 @@ describe('ClayDropDown', () => {
 		expect(vegetable3).toBeDefined();
 	});
 
+	it('keeps the outer dropdown accessible when a nested dropdown inside one of its items opens', async () => {
+		const {getByText} = render(
+			<div>
+				<ClayDropDown trigger={<button>Outer Trigger</button>}>
+					<ClayDropDown.ItemList>
+						<ClayDropDown.Item>Outer Item</ClayDropDown.Item>
+
+						<ClayDropDown.Item>
+							<ClayDropDown
+								trigger={<button>Inner Trigger</button>}
+							>
+								<ClayDropDown.ItemList>
+									<ClayDropDown.Item>
+										Inner Item
+									</ClayDropDown.Item>
+								</ClayDropDown.ItemList>
+							</ClayDropDown>
+						</ClayDropDown.Item>
+					</ClayDropDown.ItemList>
+				</ClayDropDown>
+			</div>
+		);
+
+		await userEvent.click(getByText('Outer Trigger'));
+
+		await userEvent.click(getByText('Inner Trigger'));
+
+		const outerItem = getByText('Outer Item');
+		const innerItem = getByText('Inner Item');
+
+		expect(
+			outerItem.closest('[aria-hidden="true"], [data-aria-hidden="true"]')
+		).toBeNull();
+		expect(
+			innerItem.closest('[aria-hidden="true"], [data-aria-hidden="true"]')
+		).toBeNull();
+	});
+
 	it('render dynamic content with group and search', () => {
 		const {getAllByRole: cGetAllByRole, getByRole} = render(
 			<ClayDropDown trigger={<button>Click Me</button>}>

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-drop-down/src/__tests__/index.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-drop-down/src/__tests__/index.tsx
@@ -481,8 +481,13 @@ describe('ClayDropDown', () => {
 	});
 
 	it('keeps the outer dropdown accessible when a nested dropdown inside one of its items opens', async () => {
+		const HIDDEN_SELECTOR =
+			'[aria-hidden="true"], [data-aria-hidden="true"]';
+
 		const {getByText} = render(
 			<div>
+				<p>Baseline</p>
+
 				<ClayDropDown trigger={<button>Outer Trigger</button>}>
 					<ClayDropDown.ItemList>
 						<ClayDropDown.Item>Outer Item</ClayDropDown.Item>
@@ -507,15 +512,13 @@ describe('ClayDropDown', () => {
 
 		await userEvent.click(getByText('Inner Trigger'));
 
-		const outerItem = getByText('Outer Item');
-		const innerItem = getByText('Inner Item');
+		expect(getByText('Outer Item').closest(HIDDEN_SELECTOR)).toBeNull();
+		expect(getByText('Inner Item').closest(HIDDEN_SELECTOR)).toBeNull();
 
-		expect(
-			outerItem.closest('[aria-hidden="true"], [data-aria-hidden="true"]')
-		).toBeNull();
-		expect(
-			innerItem.closest('[aria-hidden="true"], [data-aria-hidden="true"]')
-		).toBeNull();
+		// Baseline: content outside the overlay chain must end up suppressed,
+		// proving the aria-hidden library actually ran.
+
+		expect(getByText('Baseline').closest(HIDDEN_SELECTOR)).not.toBeNull();
 	});
 
 	it('render dynamic content with group and search', () => {

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-shared/src/Overlay.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-shared/src/Overlay.tsx
@@ -180,9 +180,19 @@ export function Overlay({
 			) >= 0;
 
 		if (currentMenuRef && isOpen) {
-			const elements = suppress
-				? suppress.map((ref) => ref.current!)
-				: [currentMenuRef];
+			const parentMenuElements = previousOverlayStacks
+				.map(({menu}) => menu.current)
+				.filter(
+					(element): element is Element =>
+						!!element && element !== currentMenuRef
+				);
+
+			const elements = [
+				...(suppress
+					? suppress.map((ref) => ref.current!)
+					: [currentMenuRef]),
+				...parentMenuElements,
+			];
 
 			const hiddenElement =
 				currentMenuRef.closest('[aria-hidden]') ||

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-shared/src/Overlay.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-shared/src/Overlay.tsx
@@ -182,17 +182,14 @@ export function Overlay({
 		if (currentMenuRef && isOpen) {
 			const parentMenuElements = previousOverlayStacks
 				.map(({menu}) => menu.current)
-				.filter(
-					(element): element is Element =>
-						!!element && element !== currentMenuRef
-				);
+				.filter((element): element is HTMLElement => Boolean(element))
+				.filter((element) => element !== currentMenuRef);
 
-			const elements = [
-				...(suppress
-					? suppress.map((ref) => ref.current!)
-					: [currentMenuRef]),
-				...parentMenuElements,
-			];
+			const primaryElements = suppress
+				? suppress.map((ref) => ref.current!)
+				: [currentMenuRef];
+
+			const elements = primaryElements.concat(parentMenuElements);
 
 			const hiddenElement =
 				currentMenuRef.closest('[aria-hidden]') ||


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPD-34943

## What is being fixed

When a Clay dropdown contained a nested dropdown, opening the inner menu marked the outer menu's items as `aria-hidden="true"`, breaking screen-reader access to the contextual trigger and surrounding items.

## How it is being fixed
  
The Overlay component already keeps an `overlayStack` of open overlays. When the inner overlay calls `hideOthers` / `suppressOthers`, the list of elements to keep visible now also includes every parent overlay's menu element pulled from that stack, so the entire open-overlay chain stays exposed to assistive tech. The undo callbacks already restore prior state on close, so no other behavior changes.

A regression test in `clay-drop-down/__tests__/index.tsx` opens a nested dropdown inside an outer dropdown item, asserts that neither item ends up under an `aria-hidden="true"` / `data-aria-hidden="true"` ancestor, and uses an outside-the-overlay baseline to confirm the `aria-hidden` library actually ran.
