### PR TITLE
LPD-78768 Paginate the headless-admin-configuration list endpoints

### DIFF
--- a/modules/apps/headless/headless-admin-configuration/headless-admin-configuration-api/src/main/java/com/liferay/headless/admin/configuration/resource/v1_0/InstanceConfigurationResource.java
+++ b/modules/apps/headless/headless-admin-configuration/headless-admin-configuration-api/src/main/java/com/liferay/headless/admin/configuration/resource/v1_0/InstanceConfigurationResource.java
@@ -17,6 +17,7 @@ import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineExportTaskResource;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
 
 import jakarta.annotation.Generated;
 
@@ -49,7 +50,8 @@ public interface InstanceConfigurationResource {
 			String instanceConfigurationExternalReferenceCode)
 		throws Exception;
 
-	public Page<InstanceConfiguration> getInstanceConfigurationsPage()
+	public Page<InstanceConfiguration> getInstanceConfigurationsPage(
+			Pagination pagination)
 		throws Exception;
 
 	public InstanceConfiguration postInstanceConfiguration(
@@ -169,4 +171,4 @@ public interface InstanceConfigurationResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:225235347
+// LIFERAY-REST-BUILDER-HASH:10559665

--- a/modules/apps/headless/headless-admin-configuration/headless-admin-configuration-api/src/main/java/com/liferay/headless/admin/configuration/resource/v1_0/SiteConfigurationResource.java
+++ b/modules/apps/headless/headless-admin-configuration/headless-admin-configuration-api/src/main/java/com/liferay/headless/admin/configuration/resource/v1_0/SiteConfigurationResource.java
@@ -17,6 +17,7 @@ import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineExportTaskResource;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
 
 import jakarta.annotation.Generated;
 
@@ -51,7 +52,7 @@ public interface SiteConfigurationResource {
 		throws Exception;
 
 	public Page<SiteConfiguration> getSiteSiteConfigurationsPage(
-			String siteExternalReferenceCode)
+			String siteExternalReferenceCode, Pagination pagination)
 		throws Exception;
 
 	public SiteConfiguration postSiteSiteConfiguration(
@@ -170,4 +171,4 @@ public interface SiteConfigurationResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1183923030
+// LIFERAY-REST-BUILDER-HASH:1256662644

--- a/modules/apps/headless/headless-admin-configuration/headless-admin-configuration-api/src/main/java/com/liferay/headless/admin/configuration/resource/v1_0/SystemConfigurationResource.java
+++ b/modules/apps/headless/headless-admin-configuration/headless-admin-configuration-api/src/main/java/com/liferay/headless/admin/configuration/resource/v1_0/SystemConfigurationResource.java
@@ -17,6 +17,7 @@ import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineExportTaskResource;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
 
 import jakarta.annotation.Generated;
 
@@ -49,7 +50,8 @@ public interface SystemConfigurationResource {
 			String systemConfigurationExternalReferenceCode)
 		throws Exception;
 
-	public Page<SystemConfiguration> getSystemConfigurationsPage()
+	public Page<SystemConfiguration> getSystemConfigurationsPage(
+			Pagination pagination)
 		throws Exception;
 
 	public SystemConfiguration postSystemConfiguration(
@@ -169,4 +171,4 @@ public interface SystemConfigurationResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-79502249
+// LIFERAY-REST-BUILDER-HASH:-787878027

--- a/modules/apps/headless/headless-admin-configuration/headless-admin-configuration-client/src/main/java/com/liferay/headless/admin/configuration/client/resource/v1_0/InstanceConfigurationResource.java
+++ b/modules/apps/headless/headless-admin-configuration/headless-admin-configuration-client/src/main/java/com/liferay/headless/admin/configuration/client/resource/v1_0/InstanceConfigurationResource.java
@@ -8,6 +8,7 @@ package com.liferay.headless.admin.configuration.client.resource.v1_0;
 import com.liferay.headless.admin.configuration.client.dto.v1_0.InstanceConfiguration;
 import com.liferay.headless.admin.configuration.client.http.HttpInvoker;
 import com.liferay.headless.admin.configuration.client.pagination.Page;
+import com.liferay.headless.admin.configuration.client.pagination.Pagination;
 import com.liferay.headless.admin.configuration.client.problem.Problem;
 import com.liferay.headless.admin.configuration.client.serdes.v1_0.InstanceConfigurationSerDes;
 
@@ -41,10 +42,12 @@ public interface InstanceConfigurationResource {
 			String instanceConfigurationExternalReferenceCode)
 		throws Exception;
 
-	public Page<InstanceConfiguration> getInstanceConfigurationsPage()
+	public Page<InstanceConfiguration> getInstanceConfigurationsPage(
+			Pagination pagination)
 		throws Exception;
 
-	public HttpInvoker.HttpResponse getInstanceConfigurationsPageHttpResponse()
+	public HttpInvoker.HttpResponse getInstanceConfigurationsPageHttpResponse(
+			Pagination pagination)
 		throws Exception;
 
 	public InstanceConfiguration postInstanceConfiguration(
@@ -307,11 +310,12 @@ public interface InstanceConfigurationResource {
 			return httpInvoker.invoke();
 		}
 
-		public Page<InstanceConfiguration> getInstanceConfigurationsPage()
+		public Page<InstanceConfiguration> getInstanceConfigurationsPage(
+				Pagination pagination)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				getInstanceConfigurationsPageHttpResponse();
+				getInstanceConfigurationsPageHttpResponse(pagination);
 
 			String content = httpResponse.getContent();
 
@@ -373,7 +377,7 @@ public interface InstanceConfigurationResource {
 		}
 
 		public HttpInvoker.HttpResponse
-				getInstanceConfigurationsPageHttpResponse()
+				getInstanceConfigurationsPageHttpResponse(Pagination pagination)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
@@ -396,6 +400,13 @@ public interface InstanceConfigurationResource {
 			}
 
 			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+
+			if (pagination != null) {
+				httpInvoker.parameter(
+					"page", String.valueOf(pagination.getPage()));
+				httpInvoker.parameter(
+					"pageSize", String.valueOf(pagination.getPageSize()));
+			}
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
@@ -957,4 +968,4 @@ public interface InstanceConfigurationResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:180577652
+// LIFERAY-REST-BUILDER-HASH:1249140031

--- a/modules/apps/headless/headless-admin-configuration/headless-admin-configuration-client/src/main/java/com/liferay/headless/admin/configuration/client/resource/v1_0/SiteConfigurationResource.java
+++ b/modules/apps/headless/headless-admin-configuration/headless-admin-configuration-client/src/main/java/com/liferay/headless/admin/configuration/client/resource/v1_0/SiteConfigurationResource.java
@@ -8,6 +8,7 @@ package com.liferay.headless.admin.configuration.client.resource.v1_0;
 import com.liferay.headless.admin.configuration.client.dto.v1_0.SiteConfiguration;
 import com.liferay.headless.admin.configuration.client.http.HttpInvoker;
 import com.liferay.headless.admin.configuration.client.pagination.Page;
+import com.liferay.headless.admin.configuration.client.pagination.Pagination;
 import com.liferay.headless.admin.configuration.client.problem.Problem;
 import com.liferay.headless.admin.configuration.client.serdes.v1_0.SiteConfigurationSerDes;
 
@@ -44,11 +45,11 @@ public interface SiteConfigurationResource {
 		throws Exception;
 
 	public Page<SiteConfiguration> getSiteSiteConfigurationsPage(
-			String siteExternalReferenceCode)
+			String siteExternalReferenceCode, Pagination pagination)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse getSiteSiteConfigurationsPageHttpResponse(
-			String siteExternalReferenceCode)
+			String siteExternalReferenceCode, Pagination pagination)
 		throws Exception;
 
 	public SiteConfiguration postSiteSiteConfiguration(
@@ -316,12 +317,12 @@ public interface SiteConfigurationResource {
 		}
 
 		public Page<SiteConfiguration> getSiteSiteConfigurationsPage(
-				String siteExternalReferenceCode)
+				String siteExternalReferenceCode, Pagination pagination)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
 				getSiteSiteConfigurationsPageHttpResponse(
-					siteExternalReferenceCode);
+					siteExternalReferenceCode, pagination);
 
 			String content = httpResponse.getContent();
 
@@ -384,7 +385,7 @@ public interface SiteConfigurationResource {
 
 		public HttpInvoker.HttpResponse
 				getSiteSiteConfigurationsPageHttpResponse(
-					String siteExternalReferenceCode)
+					String siteExternalReferenceCode, Pagination pagination)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
@@ -407,6 +408,13 @@ public interface SiteConfigurationResource {
 			}
 
 			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+
+			if (pagination != null) {
+				httpInvoker.parameter(
+					"page", String.valueOf(pagination.getPage()));
+				httpInvoker.parameter(
+					"pageSize", String.valueOf(pagination.getPageSize()));
+			}
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
@@ -890,4 +898,4 @@ public interface SiteConfigurationResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:1991796871
+// LIFERAY-REST-BUILDER-HASH:16524724

--- a/modules/apps/headless/headless-admin-configuration/headless-admin-configuration-client/src/main/java/com/liferay/headless/admin/configuration/client/resource/v1_0/SystemConfigurationResource.java
+++ b/modules/apps/headless/headless-admin-configuration/headless-admin-configuration-client/src/main/java/com/liferay/headless/admin/configuration/client/resource/v1_0/SystemConfigurationResource.java
@@ -8,6 +8,7 @@ package com.liferay.headless.admin.configuration.client.resource.v1_0;
 import com.liferay.headless.admin.configuration.client.dto.v1_0.SystemConfiguration;
 import com.liferay.headless.admin.configuration.client.http.HttpInvoker;
 import com.liferay.headless.admin.configuration.client.pagination.Page;
+import com.liferay.headless.admin.configuration.client.pagination.Pagination;
 import com.liferay.headless.admin.configuration.client.problem.Problem;
 import com.liferay.headless.admin.configuration.client.serdes.v1_0.SystemConfigurationSerDes;
 
@@ -41,10 +42,12 @@ public interface SystemConfigurationResource {
 			String systemConfigurationExternalReferenceCode)
 		throws Exception;
 
-	public Page<SystemConfiguration> getSystemConfigurationsPage()
+	public Page<SystemConfiguration> getSystemConfigurationsPage(
+			Pagination pagination)
 		throws Exception;
 
-	public HttpInvoker.HttpResponse getSystemConfigurationsPageHttpResponse()
+	public HttpInvoker.HttpResponse getSystemConfigurationsPageHttpResponse(
+			Pagination pagination)
 		throws Exception;
 
 	public SystemConfiguration postSystemConfiguration(
@@ -306,11 +309,12 @@ public interface SystemConfigurationResource {
 			return httpInvoker.invoke();
 		}
 
-		public Page<SystemConfiguration> getSystemConfigurationsPage()
+		public Page<SystemConfiguration> getSystemConfigurationsPage(
+				Pagination pagination)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
-				getSystemConfigurationsPageHttpResponse();
+				getSystemConfigurationsPageHttpResponse(pagination);
 
 			String content = httpResponse.getContent();
 
@@ -371,8 +375,8 @@ public interface SystemConfigurationResource {
 			}
 		}
 
-		public HttpInvoker.HttpResponse
-				getSystemConfigurationsPageHttpResponse()
+		public HttpInvoker.HttpResponse getSystemConfigurationsPageHttpResponse(
+				Pagination pagination)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
@@ -395,6 +399,13 @@ public interface SystemConfigurationResource {
 			}
 
 			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+
+			if (pagination != null) {
+				httpInvoker.parameter(
+					"page", String.valueOf(pagination.getPage()));
+				httpInvoker.parameter(
+					"pageSize", String.valueOf(pagination.getPageSize()));
+			}
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
@@ -955,4 +966,4 @@ public interface SystemConfigurationResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:1122831048
+// LIFERAY-REST-BUILDER-HASH:817223635

--- a/modules/apps/headless/headless-admin-configuration/headless-admin-configuration-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-configuration/headless-admin-configuration-impl/rest-openapi.yaml
@@ -35,6 +35,15 @@ paths:
     "/instance-configurations":
         get:
             operationId: getInstanceConfigurationsPage
+            parameters:
+                -   in: query
+                    name: page
+                    schema:
+                        type: integer
+                -   in: query
+                    name: pageSize
+                    schema:
+                        type: integer
             responses:
                 200:
                     content:
@@ -123,6 +132,14 @@ paths:
                     required: true
                     schema:
                         type: string
+                -   in: query
+                    name: page
+                    schema:
+                        type: integer
+                -   in: query
+                    name: pageSize
+                    schema:
+                        type: integer
             responses:
                 200:
                     content:
@@ -221,6 +238,15 @@ paths:
     "/system-configurations":
         get:
             operationId: getSystemConfigurationsPage
+            parameters:
+                -   in: query
+                    name: page
+                    schema:
+                        type: integer
+                -   in: query
+                    name: pageSize
+                    schema:
+                        type: integer
             responses:
                 200:
                     content:

--- a/modules/apps/headless/headless-admin-configuration/headless-admin-configuration-impl/src/main/java/com/liferay/headless/admin/configuration/internal/resource/v1_0/BaseInstanceConfigurationResourceImpl.java
+++ b/modules/apps/headless/headless-admin-configuration/headless-admin-configuration-impl/src/main/java/com/liferay/headless/admin/configuration/internal/resource/v1_0/BaseInstanceConfigurationResourceImpl.java
@@ -112,6 +112,18 @@ public abstract class BaseInstanceConfigurationResourceImpl
 	 *
 	 * curl -X 'GET' 'http://localhost:8080/o/headless-admin-configuration/v1.0/instance-configurations'  -u 'test@liferay.com:test'
 	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "page"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "pageSize"
+			)
+		}
+	)
 	@io.swagger.v3.oas.annotations.tags.Tags(
 		value = {
 			@io.swagger.v3.oas.annotations.tags.Tag(
@@ -123,7 +135,8 @@ public abstract class BaseInstanceConfigurationResourceImpl
 	@jakarta.ws.rs.Path("/instance-configurations")
 	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<InstanceConfiguration> getInstanceConfigurationsPage()
+	public Page<InstanceConfiguration> getInstanceConfigurationsPage(
+			@jakarta.ws.rs.core.Context Pagination pagination)
 		throws Exception {
 
 		return Page.of(Collections.emptyList());
@@ -458,7 +471,7 @@ public abstract class BaseInstanceConfigurationResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return getInstanceConfigurationsPage();
+		return getInstanceConfigurationsPage(pagination);
 	}
 
 	@Override
@@ -1067,4 +1080,4 @@ public abstract class BaseInstanceConfigurationResourceImpl
 		LogFactoryUtil.getLog(BaseInstanceConfigurationResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:1558029167
+// LIFERAY-REST-BUILDER-HASH:-420267825

--- a/modules/apps/headless/headless-admin-configuration/headless-admin-configuration-impl/src/main/java/com/liferay/headless/admin/configuration/internal/resource/v1_0/BaseSiteConfigurationResourceImpl.java
+++ b/modules/apps/headless/headless-admin-configuration/headless-admin-configuration-impl/src/main/java/com/liferay/headless/admin/configuration/internal/resource/v1_0/BaseSiteConfigurationResourceImpl.java
@@ -121,6 +121,14 @@ public abstract class BaseSiteConfigurationResourceImpl
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
 				name = "siteExternalReferenceCode"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "page"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "pageSize"
 			)
 		}
 	)
@@ -139,7 +147,8 @@ public abstract class BaseSiteConfigurationResourceImpl
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.validation.constraints.NotNull
 			@jakarta.ws.rs.PathParam("siteExternalReferenceCode")
-			String siteExternalReferenceCode)
+			String siteExternalReferenceCode,
+			@jakarta.ws.rs.core.Context Pagination pagination)
 		throws Exception {
 
 		return Page.of(Collections.emptyList());
@@ -469,7 +478,8 @@ public abstract class BaseSiteConfigurationResourceImpl
 
 		if (parameters.containsKey("siteExternalReferenceCode")) {
 			return getSiteSiteConfigurationsPage(
-				(String)parameters.get("siteExternalReferenceCode"));
+				(String)parameters.get("siteExternalReferenceCode"),
+				pagination);
 		}
 		else {
 			throw new NotSupportedException(
@@ -1081,4 +1091,4 @@ public abstract class BaseSiteConfigurationResourceImpl
 		LogFactoryUtil.getLog(BaseSiteConfigurationResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:33431862
+// LIFERAY-REST-BUILDER-HASH:1621532209

--- a/modules/apps/headless/headless-admin-configuration/headless-admin-configuration-impl/src/main/java/com/liferay/headless/admin/configuration/internal/resource/v1_0/BaseSystemConfigurationResourceImpl.java
+++ b/modules/apps/headless/headless-admin-configuration/headless-admin-configuration-impl/src/main/java/com/liferay/headless/admin/configuration/internal/resource/v1_0/BaseSystemConfigurationResourceImpl.java
@@ -110,6 +110,18 @@ public abstract class BaseSystemConfigurationResourceImpl
 	 *
 	 * curl -X 'GET' 'http://localhost:8080/o/headless-admin-configuration/v1.0/system-configurations'  -u 'test@liferay.com:test'
 	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "page"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "pageSize"
+			)
+		}
+	)
 	@io.swagger.v3.oas.annotations.tags.Tags(
 		value = {
 			@io.swagger.v3.oas.annotations.tags.Tag(
@@ -121,7 +133,8 @@ public abstract class BaseSystemConfigurationResourceImpl
 	@jakarta.ws.rs.Path("/system-configurations")
 	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<SystemConfiguration> getSystemConfigurationsPage()
+	public Page<SystemConfiguration> getSystemConfigurationsPage(
+			@jakarta.ws.rs.core.Context Pagination pagination)
 		throws Exception {
 
 		return Page.of(Collections.emptyList());
@@ -451,7 +464,7 @@ public abstract class BaseSystemConfigurationResourceImpl
 			Map<String, Serializable> parameters, String search)
 		throws Exception {
 
-		return getSystemConfigurationsPage();
+		return getSystemConfigurationsPage(pagination);
 	}
 
 	@Override
@@ -1059,4 +1072,4 @@ public abstract class BaseSystemConfigurationResourceImpl
 		LogFactoryUtil.getLog(BaseSystemConfigurationResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:-800449693
+// LIFERAY-REST-BUILDER-HASH:1851373891

--- a/modules/apps/headless/headless-admin-configuration/headless-admin-configuration-impl/src/main/java/com/liferay/headless/admin/configuration/internal/resource/v1_0/InstanceConfigurationResourceImpl.java
+++ b/modules/apps/headless/headless-admin-configuration/headless-admin-configuration-impl/src/main/java/com/liferay/headless/admin/configuration/internal/resource/v1_0/InstanceConfigurationResourceImpl.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
 
 import jakarta.validation.ValidationException;
 
@@ -81,7 +82,8 @@ public class InstanceConfigurationResourceImpl
 	}
 
 	@Override
-	public Page<InstanceConfiguration> getInstanceConfigurationsPage()
+	public Page<InstanceConfiguration> getInstanceConfigurationsPage(
+			Pagination pagination)
 		throws Exception {
 
 		_checkFeatureFlag();
@@ -94,7 +96,11 @@ public class InstanceConfigurationResourceImpl
 
 		_addConfigurationScreenInstanceConfigurations(instanceConfigurations);
 
-		return Page.of(instanceConfigurations);
+		return Page.of(
+			ListUtil.subList(
+				instanceConfigurations, pagination.getStartPosition(),
+				pagination.getEndPosition()),
+			pagination, instanceConfigurations.size());
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-configuration/headless-admin-configuration-impl/src/main/java/com/liferay/headless/admin/configuration/internal/resource/v1_0/SiteConfigurationResourceImpl.java
+++ b/modules/apps/headless/headless-admin-configuration/headless-admin-configuration-impl/src/main/java/com/liferay/headless/admin/configuration/internal/resource/v1_0/SiteConfigurationResourceImpl.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
 
 import jakarta.validation.ValidationException;
 
@@ -90,7 +91,7 @@ public class SiteConfigurationResourceImpl
 
 	@Override
 	public Page<SiteConfiguration> getSiteSiteConfigurationsPage(
-			String siteExternalReferenceCode)
+			String siteExternalReferenceCode, Pagination pagination)
 		throws Exception {
 
 		_checkFeatureFlag();
@@ -115,7 +116,10 @@ public class SiteConfigurationResourceImpl
 					ActionKeys.UPDATE, "postSiteSiteConfigurationBatch",
 					Group.class.getName(), group.getGroupId())
 			).build(),
-			siteConfigurations);
+			ListUtil.subList(
+				siteConfigurations, pagination.getStartPosition(),
+				pagination.getEndPosition()),
+			pagination, siteConfigurations.size());
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-configuration/headless-admin-configuration-impl/src/main/java/com/liferay/headless/admin/configuration/internal/resource/v1_0/SystemConfigurationResourceImpl.java
+++ b/modules/apps/headless/headless-admin-configuration/headless-admin-configuration-impl/src/main/java/com/liferay/headless/admin/configuration/internal/resource/v1_0/SystemConfigurationResourceImpl.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
 
 import jakarta.validation.ValidationException;
 
@@ -83,7 +84,8 @@ public class SystemConfigurationResourceImpl
 	}
 
 	@Override
-	public Page<SystemConfiguration> getSystemConfigurationsPage()
+	public Page<SystemConfiguration> getSystemConfigurationsPage(
+			Pagination pagination)
 		throws Exception {
 
 		_checkFeatureFlag();
@@ -98,7 +100,11 @@ public class SystemConfigurationResourceImpl
 
 		_addConfigurationScreenSystemConfigurations(systemConfigurations);
 
-		return Page.of(systemConfigurations);
+		return Page.of(
+			ListUtil.subList(
+				systemConfigurations, pagination.getStartPosition(),
+				pagination.getEndPosition()),
+			pagination, systemConfigurations.size());
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-configuration/headless-admin-configuration-test/src/testIntegration/java/com/liferay/headless/admin/configuration/resource/v1_0/test/BaseInstanceConfigurationResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-configuration/headless-admin-configuration-test/src/testIntegration/java/com/liferay/headless/admin/configuration/resource/v1_0/test/BaseInstanceConfigurationResourceTestCase.java
@@ -16,6 +16,7 @@ import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 import com.liferay.headless.admin.configuration.client.dto.v1_0.InstanceConfiguration;
 import com.liferay.headless.admin.configuration.client.http.HttpInvoker;
 import com.liferay.headless.admin.configuration.client.pagination.Page;
+import com.liferay.headless.admin.configuration.client.pagination.Pagination;
 import com.liferay.headless.admin.configuration.client.resource.v1_0.InstanceConfigurationResource;
 import com.liferay.headless.admin.configuration.client.serdes.v1_0.InstanceConfigurationSerDes;
 import com.liferay.petra.function.transform.TransformUtil;
@@ -31,6 +32,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropsValues;
@@ -209,7 +211,8 @@ public abstract class BaseInstanceConfigurationResourceTestCase {
 	@Test
 	public void testGetInstanceConfigurationsPage() throws Exception {
 		Page<InstanceConfiguration> page =
-			instanceConfigurationResource.getInstanceConfigurationsPage();
+			instanceConfigurationResource.getInstanceConfigurationsPage(
+				Pagination.of(1, 10));
 
 		long totalCount = page.getTotalCount();
 
@@ -221,7 +224,8 @@ public abstract class BaseInstanceConfigurationResourceTestCase {
 			testGetInstanceConfigurationsPage_addInstanceConfiguration(
 				randomInstanceConfiguration());
 
-		page = instanceConfigurationResource.getInstanceConfigurationsPage();
+		page = instanceConfigurationResource.getInstanceConfigurationsPage(
+			Pagination.of(1, 10));
 
 		Assert.assertEquals(totalCount + 2, page.getTotalCount());
 
@@ -242,6 +246,106 @@ public abstract class BaseInstanceConfigurationResourceTestCase {
 		Map<String, Map<String, String>> expectedActions = new HashMap<>();
 
 		return expectedActions;
+	}
+
+	@Test
+	public void testGetInstanceConfigurationsPageWithPagination()
+		throws Exception {
+
+		Page<InstanceConfiguration> instanceConfigurationsPage =
+			instanceConfigurationResource.getInstanceConfigurationsPage(null);
+
+		int totalCount = GetterUtil.getInteger(
+			instanceConfigurationsPage.getTotalCount());
+
+		InstanceConfiguration instanceConfiguration1 =
+			testGetInstanceConfigurationsPage_addInstanceConfiguration(
+				randomInstanceConfiguration());
+
+		InstanceConfiguration instanceConfiguration2 =
+			testGetInstanceConfigurationsPage_addInstanceConfiguration(
+				randomInstanceConfiguration());
+
+		InstanceConfiguration instanceConfiguration3 =
+			testGetInstanceConfigurationsPage_addInstanceConfiguration(
+				randomInstanceConfiguration());
+
+		// See com.liferay.portal.vulcan.internal.configuration.HeadlessAPICompanyConfiguration#pageSizeLimit
+
+		int pageSizeLimit = 500;
+
+		if (totalCount >= (pageSizeLimit - 2)) {
+			Page<InstanceConfiguration> page1 =
+				instanceConfigurationResource.getInstanceConfigurationsPage(
+					Pagination.of(
+						(int)Math.ceil((totalCount + 1.0) / pageSizeLimit),
+						pageSizeLimit));
+
+			Assert.assertEquals(totalCount + 3, page1.getTotalCount());
+
+			assertContains(
+				instanceConfiguration1,
+				(List<InstanceConfiguration>)page1.getItems());
+
+			Page<InstanceConfiguration> page2 =
+				instanceConfigurationResource.getInstanceConfigurationsPage(
+					Pagination.of(
+						(int)Math.ceil((totalCount + 2.0) / pageSizeLimit),
+						pageSizeLimit));
+
+			assertContains(
+				instanceConfiguration2,
+				(List<InstanceConfiguration>)page2.getItems());
+
+			Page<InstanceConfiguration> page3 =
+				instanceConfigurationResource.getInstanceConfigurationsPage(
+					Pagination.of(
+						(int)Math.ceil((totalCount + 3.0) / pageSizeLimit),
+						pageSizeLimit));
+
+			assertContains(
+				instanceConfiguration3,
+				(List<InstanceConfiguration>)page3.getItems());
+		}
+		else {
+			Page<InstanceConfiguration> page1 =
+				instanceConfigurationResource.getInstanceConfigurationsPage(
+					Pagination.of(1, totalCount + 2));
+
+			List<InstanceConfiguration> instanceConfigurations1 =
+				(List<InstanceConfiguration>)page1.getItems();
+
+			Assert.assertEquals(
+				instanceConfigurations1.toString(), totalCount + 2,
+				instanceConfigurations1.size());
+
+			Page<InstanceConfiguration> page2 =
+				instanceConfigurationResource.getInstanceConfigurationsPage(
+					Pagination.of(2, totalCount + 2));
+
+			Assert.assertEquals(totalCount + 3, page2.getTotalCount());
+
+			List<InstanceConfiguration> instanceConfigurations2 =
+				(List<InstanceConfiguration>)page2.getItems();
+
+			Assert.assertEquals(
+				instanceConfigurations2.toString(), 1,
+				instanceConfigurations2.size());
+
+			Page<InstanceConfiguration> page3 =
+				instanceConfigurationResource.getInstanceConfigurationsPage(
+					Pagination.of(1, (int)totalCount + 3));
+
+			assertContains(
+				instanceConfiguration1,
+				(List<InstanceConfiguration>)page3.getItems());
+			assertContains(
+				instanceConfiguration2,
+				(List<InstanceConfiguration>)page3.getItems());
+			assertContains(
+				instanceConfiguration3,
+				(List<InstanceConfiguration>)page3.getItems());
+		}
 	}
 
 	protected InstanceConfiguration
@@ -1008,4 +1112,4 @@ public abstract class BaseInstanceConfigurationResourceTestCase {
 		InstanceConfigurationResource _instanceConfigurationResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:38308911
+// LIFERAY-REST-BUILDER-HASH:-1055139650

--- a/modules/apps/headless/headless-admin-configuration/headless-admin-configuration-test/src/testIntegration/java/com/liferay/headless/admin/configuration/resource/v1_0/test/BaseSiteConfigurationResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-configuration/headless-admin-configuration-test/src/testIntegration/java/com/liferay/headless/admin/configuration/resource/v1_0/test/BaseSiteConfigurationResourceTestCase.java
@@ -16,6 +16,7 @@ import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 import com.liferay.headless.admin.configuration.client.dto.v1_0.SiteConfiguration;
 import com.liferay.headless.admin.configuration.client.http.HttpInvoker;
 import com.liferay.headless.admin.configuration.client.pagination.Page;
+import com.liferay.headless.admin.configuration.client.pagination.Pagination;
 import com.liferay.headless.admin.configuration.client.resource.v1_0.SiteConfigurationResource;
 import com.liferay.headless.admin.configuration.client.serdes.v1_0.SiteConfigurationSerDes;
 import com.liferay.petra.function.transform.TransformUtil;
@@ -31,6 +32,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropsValues;
@@ -217,7 +219,7 @@ public abstract class BaseSiteConfigurationResourceTestCase {
 
 		Page<SiteConfiguration> page =
 			siteConfigurationResource.getSiteSiteConfigurationsPage(
-				siteExternalReferenceCode);
+				siteExternalReferenceCode, Pagination.of(1, 10));
 
 		long totalCount = page.getTotalCount();
 
@@ -228,7 +230,8 @@ public abstract class BaseSiteConfigurationResourceTestCase {
 					randomIrrelevantSiteConfiguration());
 
 			page = siteConfigurationResource.getSiteSiteConfigurationsPage(
-				irrelevantSiteExternalReferenceCode);
+				irrelevantSiteExternalReferenceCode,
+				Pagination.of(1, (int)totalCount + 1));
 
 			Assert.assertEquals(totalCount + 1, page.getTotalCount());
 
@@ -250,7 +253,7 @@ public abstract class BaseSiteConfigurationResourceTestCase {
 				siteExternalReferenceCode, randomSiteConfiguration());
 
 		page = siteConfigurationResource.getSiteSiteConfigurationsPage(
-			siteExternalReferenceCode);
+			siteExternalReferenceCode, Pagination.of(1, 10));
 
 		Assert.assertEquals(totalCount + 2, page.getTotalCount());
 
@@ -284,6 +287,109 @@ public abstract class BaseSiteConfigurationResourceTestCase {
 		expectedActions.put("createBatch", createBatchAction);
 
 		return expectedActions;
+	}
+
+	@Test
+	public void testGetSiteSiteConfigurationsPageWithPagination()
+		throws Exception {
+
+		String siteExternalReferenceCode =
+			testGetSiteSiteConfigurationsPage_getSiteExternalReferenceCode();
+
+		Page<SiteConfiguration> siteConfigurationsPage =
+			siteConfigurationResource.getSiteSiteConfigurationsPage(
+				siteExternalReferenceCode, null);
+
+		int totalCount = GetterUtil.getInteger(
+			siteConfigurationsPage.getTotalCount());
+
+		SiteConfiguration siteConfiguration1 =
+			testGetSiteSiteConfigurationsPage_addSiteConfiguration(
+				siteExternalReferenceCode, randomSiteConfiguration());
+
+		SiteConfiguration siteConfiguration2 =
+			testGetSiteSiteConfigurationsPage_addSiteConfiguration(
+				siteExternalReferenceCode, randomSiteConfiguration());
+
+		SiteConfiguration siteConfiguration3 =
+			testGetSiteSiteConfigurationsPage_addSiteConfiguration(
+				siteExternalReferenceCode, randomSiteConfiguration());
+
+		// See com.liferay.portal.vulcan.internal.configuration.HeadlessAPICompanyConfiguration#pageSizeLimit
+
+		int pageSizeLimit = 500;
+
+		if (totalCount >= (pageSizeLimit - 2)) {
+			Page<SiteConfiguration> page1 =
+				siteConfigurationResource.getSiteSiteConfigurationsPage(
+					siteExternalReferenceCode,
+					Pagination.of(
+						(int)Math.ceil((totalCount + 1.0) / pageSizeLimit),
+						pageSizeLimit));
+
+			Assert.assertEquals(totalCount + 3, page1.getTotalCount());
+
+			assertContains(
+				siteConfiguration1, (List<SiteConfiguration>)page1.getItems());
+
+			Page<SiteConfiguration> page2 =
+				siteConfigurationResource.getSiteSiteConfigurationsPage(
+					siteExternalReferenceCode,
+					Pagination.of(
+						(int)Math.ceil((totalCount + 2.0) / pageSizeLimit),
+						pageSizeLimit));
+
+			assertContains(
+				siteConfiguration2, (List<SiteConfiguration>)page2.getItems());
+
+			Page<SiteConfiguration> page3 =
+				siteConfigurationResource.getSiteSiteConfigurationsPage(
+					siteExternalReferenceCode,
+					Pagination.of(
+						(int)Math.ceil((totalCount + 3.0) / pageSizeLimit),
+						pageSizeLimit));
+
+			assertContains(
+				siteConfiguration3, (List<SiteConfiguration>)page3.getItems());
+		}
+		else {
+			Page<SiteConfiguration> page1 =
+				siteConfigurationResource.getSiteSiteConfigurationsPage(
+					siteExternalReferenceCode,
+					Pagination.of(1, totalCount + 2));
+
+			List<SiteConfiguration> siteConfigurations1 =
+				(List<SiteConfiguration>)page1.getItems();
+
+			Assert.assertEquals(
+				siteConfigurations1.toString(), totalCount + 2,
+				siteConfigurations1.size());
+
+			Page<SiteConfiguration> page2 =
+				siteConfigurationResource.getSiteSiteConfigurationsPage(
+					siteExternalReferenceCode,
+					Pagination.of(2, totalCount + 2));
+
+			Assert.assertEquals(totalCount + 3, page2.getTotalCount());
+
+			List<SiteConfiguration> siteConfigurations2 =
+				(List<SiteConfiguration>)page2.getItems();
+
+			Assert.assertEquals(
+				siteConfigurations2.toString(), 1, siteConfigurations2.size());
+
+			Page<SiteConfiguration> page3 =
+				siteConfigurationResource.getSiteSiteConfigurationsPage(
+					siteExternalReferenceCode,
+					Pagination.of(1, (int)totalCount + 3));
+
+			assertContains(
+				siteConfiguration1, (List<SiteConfiguration>)page3.getItems());
+			assertContains(
+				siteConfiguration2, (List<SiteConfiguration>)page3.getItems());
+			assertContains(
+				siteConfiguration3, (List<SiteConfiguration>)page3.getItems());
+		}
 	}
 
 	protected SiteConfiguration
@@ -1060,4 +1166,4 @@ public abstract class BaseSiteConfigurationResourceTestCase {
 		SiteConfigurationResource _siteConfigurationResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:933747821
+// LIFERAY-REST-BUILDER-HASH:634462901

--- a/modules/apps/headless/headless-admin-configuration/headless-admin-configuration-test/src/testIntegration/java/com/liferay/headless/admin/configuration/resource/v1_0/test/BaseSystemConfigurationResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-configuration/headless-admin-configuration-test/src/testIntegration/java/com/liferay/headless/admin/configuration/resource/v1_0/test/BaseSystemConfigurationResourceTestCase.java
@@ -16,6 +16,7 @@ import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 import com.liferay.headless.admin.configuration.client.dto.v1_0.SystemConfiguration;
 import com.liferay.headless.admin.configuration.client.http.HttpInvoker;
 import com.liferay.headless.admin.configuration.client.pagination.Page;
+import com.liferay.headless.admin.configuration.client.pagination.Pagination;
 import com.liferay.headless.admin.configuration.client.resource.v1_0.SystemConfigurationResource;
 import com.liferay.headless.admin.configuration.client.serdes.v1_0.SystemConfigurationSerDes;
 import com.liferay.petra.function.transform.TransformUtil;
@@ -31,6 +32,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropsValues;
@@ -204,7 +206,8 @@ public abstract class BaseSystemConfigurationResourceTestCase {
 	@Test
 	public void testGetSystemConfigurationsPage() throws Exception {
 		Page<SystemConfiguration> page =
-			systemConfigurationResource.getSystemConfigurationsPage();
+			systemConfigurationResource.getSystemConfigurationsPage(
+				Pagination.of(1, 10));
 
 		long totalCount = page.getTotalCount();
 
@@ -216,7 +219,8 @@ public abstract class BaseSystemConfigurationResourceTestCase {
 			testGetSystemConfigurationsPage_addSystemConfiguration(
 				randomSystemConfiguration());
 
-		page = systemConfigurationResource.getSystemConfigurationsPage();
+		page = systemConfigurationResource.getSystemConfigurationsPage(
+			Pagination.of(1, 10));
 
 		Assert.assertEquals(totalCount + 2, page.getTotalCount());
 
@@ -234,6 +238,106 @@ public abstract class BaseSystemConfigurationResourceTestCase {
 		Map<String, Map<String, String>> expectedActions = new HashMap<>();
 
 		return expectedActions;
+	}
+
+	@Test
+	public void testGetSystemConfigurationsPageWithPagination()
+		throws Exception {
+
+		Page<SystemConfiguration> systemConfigurationsPage =
+			systemConfigurationResource.getSystemConfigurationsPage(null);
+
+		int totalCount = GetterUtil.getInteger(
+			systemConfigurationsPage.getTotalCount());
+
+		SystemConfiguration systemConfiguration1 =
+			testGetSystemConfigurationsPage_addSystemConfiguration(
+				randomSystemConfiguration());
+
+		SystemConfiguration systemConfiguration2 =
+			testGetSystemConfigurationsPage_addSystemConfiguration(
+				randomSystemConfiguration());
+
+		SystemConfiguration systemConfiguration3 =
+			testGetSystemConfigurationsPage_addSystemConfiguration(
+				randomSystemConfiguration());
+
+		// See com.liferay.portal.vulcan.internal.configuration.HeadlessAPICompanyConfiguration#pageSizeLimit
+
+		int pageSizeLimit = 500;
+
+		if (totalCount >= (pageSizeLimit - 2)) {
+			Page<SystemConfiguration> page1 =
+				systemConfigurationResource.getSystemConfigurationsPage(
+					Pagination.of(
+						(int)Math.ceil((totalCount + 1.0) / pageSizeLimit),
+						pageSizeLimit));
+
+			Assert.assertEquals(totalCount + 3, page1.getTotalCount());
+
+			assertContains(
+				systemConfiguration1,
+				(List<SystemConfiguration>)page1.getItems());
+
+			Page<SystemConfiguration> page2 =
+				systemConfigurationResource.getSystemConfigurationsPage(
+					Pagination.of(
+						(int)Math.ceil((totalCount + 2.0) / pageSizeLimit),
+						pageSizeLimit));
+
+			assertContains(
+				systemConfiguration2,
+				(List<SystemConfiguration>)page2.getItems());
+
+			Page<SystemConfiguration> page3 =
+				systemConfigurationResource.getSystemConfigurationsPage(
+					Pagination.of(
+						(int)Math.ceil((totalCount + 3.0) / pageSizeLimit),
+						pageSizeLimit));
+
+			assertContains(
+				systemConfiguration3,
+				(List<SystemConfiguration>)page3.getItems());
+		}
+		else {
+			Page<SystemConfiguration> page1 =
+				systemConfigurationResource.getSystemConfigurationsPage(
+					Pagination.of(1, totalCount + 2));
+
+			List<SystemConfiguration> systemConfigurations1 =
+				(List<SystemConfiguration>)page1.getItems();
+
+			Assert.assertEquals(
+				systemConfigurations1.toString(), totalCount + 2,
+				systemConfigurations1.size());
+
+			Page<SystemConfiguration> page2 =
+				systemConfigurationResource.getSystemConfigurationsPage(
+					Pagination.of(2, totalCount + 2));
+
+			Assert.assertEquals(totalCount + 3, page2.getTotalCount());
+
+			List<SystemConfiguration> systemConfigurations2 =
+				(List<SystemConfiguration>)page2.getItems();
+
+			Assert.assertEquals(
+				systemConfigurations2.toString(), 1,
+				systemConfigurations2.size());
+
+			Page<SystemConfiguration> page3 =
+				systemConfigurationResource.getSystemConfigurationsPage(
+					Pagination.of(1, (int)totalCount + 3));
+
+			assertContains(
+				systemConfiguration1,
+				(List<SystemConfiguration>)page3.getItems());
+			assertContains(
+				systemConfiguration2,
+				(List<SystemConfiguration>)page3.getItems());
+			assertContains(
+				systemConfiguration3,
+				(List<SystemConfiguration>)page3.getItems());
+		}
 	}
 
 	protected SystemConfiguration
@@ -994,4 +1098,4 @@ public abstract class BaseSystemConfigurationResourceTestCase {
 		SystemConfigurationResource _systemConfigurationResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1114677225
+// LIFERAY-REST-BUILDER-HASH:1979538580

--- a/modules/apps/headless/headless-admin-configuration/headless-admin-configuration-test/src/testIntegration/java/com/liferay/headless/admin/configuration/resource/v1_0/test/InstanceConfigurationResourceTest.java
+++ b/modules/apps/headless/headless-admin-configuration/headless-admin-configuration-test/src/testIntegration/java/com/liferay/headless/admin/configuration/resource/v1_0/test/InstanceConfigurationResourceTest.java
@@ -7,6 +7,8 @@ package com.liferay.headless.admin.configuration.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.headless.admin.configuration.client.dto.v1_0.InstanceConfiguration;
+import com.liferay.headless.admin.configuration.client.pagination.Page;
+import com.liferay.headless.admin.configuration.client.pagination.Pagination;
 import com.liferay.headless.admin.configuration.client.problem.Problem;
 import com.liferay.headless.admin.configuration.test.configuration.TestConfiguration;
 import com.liferay.headless.admin.configuration.test.configuration.TestFactoryConfiguration;
@@ -66,6 +68,38 @@ public class InstanceConfigurationResourceTest
 
 		_testGetInstanceConfigurationFromConfigurationScreen();
 		_testGetInstanceConfigurationWithPasswordKey();
+	}
+
+	@Override
+	@Test
+	public void testGetInstanceConfigurationsPage() throws Exception {
+		Page<InstanceConfiguration> page =
+			instanceConfigurationResource.getInstanceConfigurationsPage(
+				Pagination.of(1, 10));
+
+		long totalCount = page.getTotalCount();
+
+		InstanceConfiguration instanceConfiguration1 =
+			testGetInstanceConfigurationsPage_addInstanceConfiguration(
+				randomInstanceConfiguration());
+
+		InstanceConfiguration instanceConfiguration2 =
+			testGetInstanceConfigurationsPage_addInstanceConfiguration(
+				randomInstanceConfiguration());
+
+		page = instanceConfigurationResource.getInstanceConfigurationsPage(
+			Pagination.of(1, (int)totalCount + 10));
+
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
+
+		assertContains(
+			instanceConfiguration1,
+			(List<InstanceConfiguration>)page.getItems());
+		assertContains(
+			instanceConfiguration2,
+			(List<InstanceConfiguration>)page.getItems());
+		assertValid(
+			page, testGetInstanceConfigurationsPage_getExpectedActions());
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-configuration/headless-admin-configuration-test/src/testIntegration/java/com/liferay/headless/admin/configuration/resource/v1_0/test/SystemConfigurationResourceTest.java
+++ b/modules/apps/headless/headless-admin-configuration/headless-admin-configuration-test/src/testIntegration/java/com/liferay/headless/admin/configuration/resource/v1_0/test/SystemConfigurationResourceTest.java
@@ -7,6 +7,8 @@ package com.liferay.headless.admin.configuration.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.headless.admin.configuration.client.dto.v1_0.SystemConfiguration;
+import com.liferay.headless.admin.configuration.client.pagination.Page;
+import com.liferay.headless.admin.configuration.client.pagination.Pagination;
 import com.liferay.headless.admin.configuration.client.problem.Problem;
 import com.liferay.headless.admin.configuration.test.configuration.TestConfiguration;
 import com.liferay.headless.admin.configuration.test.configuration.TestFactoryConfiguration;
@@ -66,6 +68,35 @@ public class SystemConfigurationResourceTest
 
 		_testGetSystemConfigurationFromConfigurationScreen();
 		_testGetSystemConfigurationWithPasswordKey();
+	}
+
+	@Override
+	@Test
+	public void testGetSystemConfigurationsPage() throws Exception {
+		Page<SystemConfiguration> page =
+			systemConfigurationResource.getSystemConfigurationsPage(
+				Pagination.of(1, 10));
+
+		long totalCount = page.getTotalCount();
+
+		SystemConfiguration systemConfiguration1 =
+			testGetSystemConfigurationsPage_addSystemConfiguration(
+				randomSystemConfiguration());
+
+		SystemConfiguration systemConfiguration2 =
+			testGetSystemConfigurationsPage_addSystemConfiguration(
+				randomSystemConfiguration());
+
+		page = systemConfigurationResource.getSystemConfigurationsPage(
+			Pagination.of(1, (int)totalCount + 10));
+
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
+
+		assertContains(
+			systemConfiguration1, (List<SystemConfiguration>)page.getItems());
+		assertContains(
+			systemConfiguration2, (List<SystemConfiguration>)page.getItems());
+		assertValid(page, testGetSystemConfigurationsPage_getExpectedActions());
 	}
 
 	@Override


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-78768

## What is being fixed

The three list endpoints in the `headless-admin-configuration` API returned every configuration in a single response, ignoring the standard Vulcan `page` and `pageSize` query parameters:

- `GET /o/headless-admin-configuration/v1.0/instance-configurations`
- `GET /o/headless-admin-configuration/v1.0/system-configurations`
- `GET /o/headless-admin-configuration/v1.0/sites/{siteExternalReferenceCode}/site-configurations`

Every other headless API caps results to 20 per page by default and honors `page`/`pageSize`; this one did not. The root cause sat in the OpenAPI spec: the three list operations declared no pagination parameters, so the generated base resource methods took no `Pagination` argument and the impl methods handed the full list to the single-argument `Page.of(items)` factory, which does not slice.

## How it is being fixed

The OpenAPI spec now declares `page` and `pageSize` query parameters on the three list operations. After regenerating the API, client, and test scaffolding with `buildREST`, the base resource method signatures inject `Pagination pagination` and the three impl methods slice the in-memory list with `ListUtil.subList(items, pagination.getStartPosition(), pagination.getEndPosition())` and return `Page.of(items, pagination, totalCount)` — the same in-memory pattern already used elsewhere in the headless modules.

The regenerated `Base*ResourceTestCase` for each resource gains a `testGet*PageWithPagination` case that exercises page navigation. The pre-existing `testGet*ConfigurationsPage` was also regenerated and now queries with `Pagination.of(1, 10)`. Because any non-trivial bundle already has more than 10 baseline instance or system configurations, the two newly created configurations would not land on page 1 and the assertion would fail. The concrete tests for instance and system override that case to re-query with a `pageSize` wide enough to capture the full list. The site test needs no override because each run scopes to a fresh site whose configuration set starts empty.