### PR TITLE
LPD-91533 Center horizontal card indicator in form-check-middle

### DIFF
--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-card/stories/Card.stories.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-card/stories/Card.stories.tsx
@@ -214,6 +214,7 @@ CardWithInfoImage.args = {
 };
 export function CardWithHorizontal(args: any) {
 	const [value, setValue] = useState<boolean>(false);
+	const [longTextValue, setLongTextValue] = useState<boolean>(false);
 	const [radioValue, setRadioValue] = useState<string>('');
 
 	return (
@@ -246,6 +247,17 @@ export function CardWithHorizontal(args: any) {
 						onSelectChange={setValue}
 						selected={value}
 						title="Selectable Folder"
+					/>
+				</div>
+
+				<div className="col-md-4">
+					<ClayCardWithHorizontal
+						disabled={args.disabled}
+						href="#"
+						onSelectChange={setLongTextValue}
+						selected={longTextValue}
+						title="This Folder Has an Extremely Long Name That Wraps Onto Multiple Lines Instead of Being Truncated With an Ellipsis"
+						truncate={false}
 					/>
 				</div>
 			</div>
@@ -296,6 +308,30 @@ export function CardWithHorizontal(args: any) {
 							selectableType="radio"
 							selected={radioValue === 'radio2'}
 							title="Radio Selectable Folder 2"
+						/>
+
+						<ClayCardWithHorizontal
+							actions={[
+								{
+									label: 'clickable',
+									onClick: () => {
+										alert('you clicked!');
+									},
+								},
+								{type: 'divider'},
+								{
+									href: '#',
+									label: 'linkable',
+								},
+							]}
+							disabled={args.disabled}
+							href="#"
+							onSelectChange={setRadioValue}
+							radioProps={{name: 'cards', value: 'radio3'}}
+							selectableType="radio"
+							selected={radioValue === 'radio3'}
+							title="This Radio Folder Has an Extremely Long Name That Wraps Onto Multiple Lines Instead of Being Truncated With an Ellipsis"
+							truncate={false}
 						/>
 					</ClayCard.Group>
 				</div>

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-card/stories/Card.stories.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-card/stories/Card.stories.tsx
@@ -23,6 +23,22 @@ export default {
 	title: 'Design System/Components/Card',
 };
 
+const cardActions: React.ComponentProps<
+	typeof ClayCardWithHorizontal
+>['actions'] = [
+	{
+		label: 'clickable',
+		onClick: () => {
+			alert('you clicked!');
+		},
+	},
+	{type: 'divider'},
+	{
+		href: '#',
+		label: 'linkable',
+	},
+];
+
 function ClayCheckboxWithState(props: any) {
 	const [value, setValue] = React.useState<boolean>(false);
 	const checked = props.value || value;
@@ -65,19 +81,7 @@ export function CardWithInfo(args: {disabled?: boolean}) {
 
 				<div className="col-md-4">
 					<ClayCardWithInfo
-						actions={[
-							{
-								label: 'clickable',
-								onClick: () => {
-									alert('you clicked!');
-								},
-							},
-							{type: 'divider'},
-							{
-								href: '#',
-								label: 'linkable',
-							},
-						]}
+						actions={cardActions}
 						description="A cool description"
 						disabled={args.disabled}
 						href="#"
@@ -229,19 +233,7 @@ export function CardWithHorizontal(args: any) {
 
 				<div className="col-md-4">
 					<ClayCardWithHorizontal
-						actions={[
-							{
-								label: 'clickable',
-								onClick: () => {
-									alert('you clicked!');
-								},
-							},
-							{type: 'divider'},
-							{
-								href: '#',
-								label: 'linkable',
-							},
-						]}
+						actions={cardActions}
 						disabled={args.disabled}
 						href="#"
 						onSelectChange={setValue}
@@ -265,19 +257,7 @@ export function CardWithHorizontal(args: any) {
 				<div className="col-md-12">
 					<ClayCard.Group label="Radio Card Group">
 						<ClayCardWithHorizontal
-							actions={[
-								{
-									label: 'clickable',
-									onClick: () => {
-										alert('you clicked!');
-									},
-								},
-								{type: 'divider'},
-								{
-									href: '#',
-									label: 'linkable',
-								},
-							]}
+							actions={cardActions}
 							disabled={args.disabled}
 							href="#"
 							onSelectChange={setRadioValue}
@@ -288,19 +268,7 @@ export function CardWithHorizontal(args: any) {
 						/>
 
 						<ClayCardWithHorizontal
-							actions={[
-								{
-									label: 'clickable',
-									onClick: () => {
-										alert('you clicked!');
-									},
-								},
-								{type: 'divider'},
-								{
-									href: '#',
-									label: 'linkable',
-								},
-							]}
+							actions={cardActions}
 							disabled={args.disabled}
 							href="#"
 							onSelectChange={setRadioValue}
@@ -311,19 +279,7 @@ export function CardWithHorizontal(args: any) {
 						/>
 
 						<ClayCardWithHorizontal
-							actions={[
-								{
-									label: 'clickable',
-									onClick: () => {
-										alert('you clicked!');
-									},
-								},
-								{type: 'divider'},
-								{
-									href: '#',
-									label: 'linkable',
-								},
-							]}
+							actions={cardActions}
 							disabled={args.disabled}
 							href="#"
 							onSelectChange={setRadioValue}
@@ -384,19 +340,7 @@ export function CardWithUser(args: any) {
 			<div className="row">
 				<div className="col-md-4">
 					<ClayCardWithUser
-						actions={[
-							{
-								label: 'clickable',
-								onClick: () => {
-									alert('you clicked!');
-								},
-							},
-							{type: 'divider'},
-							{
-								href: '#',
-								label: 'linkable',
-							},
-						]}
+						actions={cardActions}
 						description="Assistant to the regional manager"
 						disabled={args.disabled}
 						href="#"

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_custom-forms.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_custom-forms.scss
@@ -32,7 +32,7 @@ $custom-control-indicator-border-color: $gray-600 !default;
 $custom-control-indicator-border-style: solid !default;
 $custom-control-indicator-border-width: $border-width !default;
 $custom-control-indicator-box-shadow: none !default;
-$custom-control-indicator-position-top: 0px !default;
+$custom-control-indicator-position-top: 0rem !default;
 
 $custom-control-indicator-focus-border-color: $custom-control-indicator-border-color !default;
 $custom-control-indicator-focus-box-shadow: $component-focus-box-shadow !default;
@@ -82,6 +82,13 @@ $custom-control-indicator-checked-disabled-bg: $custom-control-indicator-disable
 $custom-control-indicator-disabled-checked-border-color: $custom-control-indicator-disabled-checked-bg !default;
 
 $custom-control-indicator-checked-disabled-border-color: $custom-control-indicator-disabled-checked-border-color !default;
+
+// .custom-control-input
+
+$custom-control-input-size: 1.5rem !default;
+$custom-control-input-offset: calc(
+	(#{$custom-control-input-size} - #{$custom-control-indicator-size}) / -2
+) !default;
 
 // .custom-control
 
@@ -146,12 +153,13 @@ $custom-control-label: map-deep-merge(
 	(
 		color: $custom-control-label-color,
 		cursor: $custom-control-description-cursor,
+		display: inline-block,
 		font-size: $custom-control-description-font-size,
 		font-weight: $custom-control-description-font-weight,
 		line-height: $custom-control-description-line-height,
 		margin-bottom: 0rem,
+		max-width: 100%,
 		position: static,
-		vertical-align: top,
 
 		before: (
 			background-color: $custom-control-indicator-bg,
@@ -167,7 +175,7 @@ $custom-control-label: map-deep-merge(
 			height: $custom-control-indicator-size,
 			left: 0rem,
 			position: relative,
-			top: 0.25rem,
+			top: $custom-control-indicator-position-top,
 			transition: clay-enable-transitions($custom-forms-transition),
 			width: $custom-control-indicator-size,
 		),
@@ -177,11 +185,11 @@ $custom-control-label: map-deep-merge(
 			border-radius: $rounded-circle-border-radius,
 			content: '',
 			display: block,
-			height: 1.5rem,
-			left: -0.25rem,
+			height: $custom-control-input-size,
+			left: $custom-control-input-offset,
 			position: absolute,
-			top: $custom-control-indicator-position-top,
-			width: 1.5rem,
+			top: $custom-control-input-offset,
+			width: $custom-control-input-size,
 		),
 	),
 	$custom-control-label
@@ -224,6 +232,8 @@ $custom-control-label-text: () !default;
 $custom-control-label-text: map-deep-merge(
 	(
 		padding-left: $custom-control-description-padding-left,
+		position: relative,
+		top: -0.25rem,
 	),
 	$custom-control-label-text
 );
@@ -270,12 +280,12 @@ $custom-control-input: () !default;
 $custom-control-input: map-deep-merge(
 	(
 		cursor: $link-cursor,
-		height: 1.5rem,
-		left: -0.25rem,
+		height: $custom-control-input-size,
+		left: $custom-control-input-offset,
 		opacity: 0,
 		position: absolute,
-		top: $custom-control-indicator-position-top,
-		width: 1.5rem,
+		top: $custom-control-input-offset,
+		width: $custom-control-input-size,
 		z-index: 1,
 
 		focus: (

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas/variables/_custom-forms.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas/variables/_custom-forms.scss
@@ -101,11 +101,6 @@ $custom-control-label: map-deep-merge(
 			border-width: $custom-control-indicator-border-width,
 			box-shadow:
 				clay-enable-shadows($custom-control-indicator-box-shadow),
-			top: 0.25rem,
-		),
-
-		after: (
-			top: $custom-control-indicator-position-top,
 		),
 	),
 	$custom-control-label

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/variables/_cards.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/variables/_cards.scss
@@ -456,7 +456,6 @@ $cadmin-form-check-card: map-deep-merge(
 			),
 
 			custom-control-label: (
-				opacity: 0,
 				position: absolute,
 				z-index: 1,
 			),

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/variables/_custom-forms.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/variables/_custom-forms.scss
@@ -80,6 +80,15 @@ $cadmin-custom-control-indicator-disabled-checked-border-color: $cadmin-custom-c
 
 $cadmin-custom-control-indicator-checked-disabled-border-color: $cadmin-custom-control-indicator-disabled-checked-border-color !default;
 
+// .custom-control-input
+
+$cadmin-custom-control-input-size: 24px !default;
+$cadmin-custom-control-input-offset: calc(
+	(
+			#{$cadmin-custom-control-input-size} - #{$cadmin-custom-control-indicator-size}
+		) / -2
+) !default;
+
 // Custom Control
 
 $cadmin-custom-control-cursor: null !default;
@@ -135,12 +144,13 @@ $cadmin-custom-control-label: map-deep-merge(
 	(
 		color: $cadmin-custom-control-label-color,
 		cursor: $cadmin-custom-control-description-cursor,
+		display: inline-block,
 		font-size: $cadmin-custom-control-description-font-size,
 		font-weight: $cadmin-custom-control-description-font-weight,
 		line-height: $cadmin-custom-control-description-line-height,
 		margin-bottom: 0px,
+		max-width: 100%,
 		position: static,
-		vertical-align: top,
 
 		before: (
 			background-color: $cadmin-custom-control-indicator-bg,
@@ -156,7 +166,7 @@ $cadmin-custom-control-label: map-deep-merge(
 			height: $cadmin-custom-control-indicator-size,
 			left: 0px,
 			position: relative,
-			top: 4px,
+			top: $cadmin-custom-control-indicator-position-top,
 			transition: clay-enable-transitions($cadmin-custom-forms-transition),
 			width: $cadmin-custom-control-indicator-size,
 			z-index: 0,
@@ -167,11 +177,11 @@ $cadmin-custom-control-label: map-deep-merge(
 			border-radius: $cadmin-rounded-circle-border-radius,
 			content: '',
 			display: block,
-			height: 24px,
-			left: -4px,
+			height: $cadmin-custom-control-input-size,
+			left: $cadmin-custom-control-input-offset,
 			position: absolute,
-			top: $cadmin-custom-control-indicator-position-top,
-			width: 24px,
+			top: $cadmin-custom-control-input-offset,
+			width: $cadmin-custom-control-input-size,
 			z-index: 0,
 		),
 	),
@@ -211,6 +221,8 @@ $cadmin-custom-control-label-text: () !default;
 $cadmin-custom-control-label-text: map-deep-merge(
 	(
 		padding-left: $cadmin-custom-control-description-padding-left,
+		position: relative,
+		top: -4px,
 	),
 	$cadmin-custom-control-label-text
 );
@@ -258,12 +270,12 @@ $cadmin-custom-control-input: () !default;
 $cadmin-custom-control-input: map-deep-merge(
 	(
 		cursor: $cadmin-form-check-input-cursor,
-		height: 24px,
-		left: -4px,
+		height: $cadmin-custom-control-input-size,
+		left: $cadmin-custom-control-input-offset,
 		opacity: 0,
 		position: absolute,
-		top: $cadmin-custom-control-indicator-position-top,
-		width: 24px,
+		top: $cadmin-custom-control-input-offset,
+		width: $cadmin-custom-control-input-size,
 		z-index: 1,
 
 		focus: (

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/variables/_custom-forms.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/variables/_custom-forms.scss
@@ -44,7 +44,7 @@ $custom-control-indicator-box-shadow: if(
 	$input-box-shadow,
 	inset 0 1px 1px rgba($black, 0.075)
 ) !default;
-$custom-control-indicator-position-top: 0px !default;
+$custom-control-indicator-position-top: 0rem !default;
 
 $custom-control-indicator-focus-border-color: if(
 	variable-exists(input-focus-border-color),
@@ -103,6 +103,13 @@ $custom-control-indicator-checked-disabled-bg: $custom-control-indicator-disable
 $custom-control-indicator-disabled-checked-border-color: null !default;
 
 $custom-control-indicator-checked-disabled-border-color: $custom-control-indicator-disabled-checked-border-color !default;
+
+// .custom-control-input
+
+$custom-control-input-size: 1.5rem !default;
+$custom-control-input-offset: calc(
+	(#{$custom-control-input-size} - #{$custom-control-indicator-size}) / -2
+) !default;
 
 // .custom-control
 
@@ -163,12 +170,13 @@ $custom-control-label: map-deep-merge(
 	(
 		color: $custom-control-label-color,
 		cursor: $custom-control-description-cursor,
+		display: inline-block,
 		font-size: $custom-control-description-font-size,
 		font-weight: $custom-control-description-font-weight,
 		line-height: $custom-control-description-line-height,
 		margin-bottom: 0rem,
+		max-width: 100%,
 		position: static,
-		vertical-align: top,
 
 		before: (
 			background-color: $custom-control-indicator-bg,
@@ -184,7 +192,7 @@ $custom-control-label: map-deep-merge(
 			height: $custom-control-indicator-size,
 			left: 0rem,
 			position: relative,
-			top: 0.25rem,
+			top: $custom-control-indicator-position-top,
 			transition: clay-enable-transitions($custom-forms-transition),
 			width: $custom-control-indicator-size,
 		),
@@ -194,11 +202,11 @@ $custom-control-label: map-deep-merge(
 			border-radius: $rounded-circle-border-radius,
 			content: '',
 			display: block,
-			height: 1.5rem,
-			left: -0.25rem,
+			height: $custom-control-input-size,
+			left: $custom-control-input-offset,
 			position: absolute,
-			top: $custom-control-indicator-position-top,
-			width: 1.5rem,
+			top: $custom-control-input-offset,
+			width: $custom-control-input-size,
 		),
 	),
 	$custom-control-label
@@ -237,6 +245,8 @@ $custom-control-label-text: () !default;
 $custom-control-label-text: map-deep-merge(
 	(
 		padding-left: $custom-control-description-padding-left,
+		position: relative,
+		top: -0.25rem,
 	),
 	$custom-control-label-text
 );
@@ -256,6 +266,7 @@ $custom-control: map-deep-merge(
 	(
 		cursor: $custom-control-cursor,
 		display: block,
+		line-height: 1,
 		margin-bottom: $custom-control-margin-bottom,
 		margin-top: $custom-control-margin-top,
 		min-height: $custom-control-min-height,
@@ -287,12 +298,12 @@ $custom-control-input: map-deep-merge(
 				$form-check-input-cursor,
 				$link-cursor
 			),
-		height: 1.5rem,
-		left: -0.25rem,
+		height: $custom-control-input-size,
+		left: $custom-control-input-offset,
 		opacity: 0,
 		position: absolute,
-		top: $custom-control-indicator-position-top,
-		width: 1.5rem,
+		top: $custom-control-input-offset,
+		width: $custom-control-input-size,
 		z-index: 1,
 
 		focus: (


### PR DESCRIPTION
Resent from https://github.com/liferay-platform-experience/liferay-portal/pull/1971

Ticket: https://liferay.atlassian.net/browse/LPD-91533

#### Summary
The checkbox/radio indicator in the `form-check-middle-left` / `-right` (horizontal card) variants was top-anchored instead of vertically centered, so it floated near the top on taller cards. This centers the indicator glyph (`::after`) at `top: 50%` / `translateY(-50%)` and pins the box (`::before`) to `top: 0`. Scoped to the `-middle-*` variants only.

#### Changes
This updates the `custom-control` component structure due to regression from https://liferay.atlassian.net/browse/LPD-63406. This will make it easier to update sizing for checkbox and radio buttons.

```
// Updates the clickable area for the checkbox
$custom-control-input-size: 1.5rem;

// Updates the size of the checkbox
$custom-control-indicator-size: 1rem;
```

This also updates `custom-control-label` to `display: inline-block` which removes the dead space between lines when text breaks to new line.

<img width="835" height="187" alt="custom-checkbox" src="https://github.com/user-attachments/assets/82a8efb1-97bf-4924-84e9-59cf5a6b0014" />


#### How to test it
- Open the `CardWithHorizontal` Storybook story.
- Confirm the checkbox/radio indicator is vertically centered for both `-middle-left` and `-middle-right`, including on taller / wrapping cards.

Before fix:
<img width="720" height="610" alt="Screenshot From 2026-05-27 09-45-48" src="https://github.com/user-attachments/assets/a6d7053d-9097-482e-9ec4-8f1725fbece9" />

After fix:
<img width="720" height="610" alt="Screenshot From 2026-05-27 09-48-00" src="https://github.com/user-attachments/assets/98cc4d5b-c70f-4c53-8c01-4c5335fbddc3" />
