### PR TITLE
  LPD-31376 Fix ClayTreeView findDOMNode warning under StrictMode

### DIFF
--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/tree-view/TreeViewGroup.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/tree-view/TreeViewGroup.tsx
@@ -43,6 +43,8 @@ export function Group<T extends Record<any, any>>({
 
 	const item = useItem();
 
+	const nodeRef = React.useRef<HTMLDivElement>(null);
+
 	return (
 		<CSSTransition
 			className={classNames('collapse', className, {
@@ -62,21 +64,36 @@ export function Group<T extends Record<any, any>>({
 			}
 			id={item.key}
 			in={expandedKeys.has(item.key)}
-			onEnter={(element: HTMLElement) =>
-				element.setAttribute('style', 'height: 0px')
-			}
-			onEntered={(element: HTMLElement) =>
-				element.removeAttribute('style')
-			}
-			onEntering={(element: HTMLElement) => setElementFullHeight(element)}
-			onExit={(element) => setElementFullHeight(element)}
-			onExiting={(element) =>
-				element.setAttribute('style', 'height: 0px')
-			}
+			nodeRef={nodeRef}
+			onEnter={() => {
+				if (nodeRef.current) {
+					nodeRef.current.setAttribute('style', 'height: 0px');
+				}
+			}}
+			onEntered={() => {
+				if (nodeRef.current) {
+					nodeRef.current.removeAttribute('style');
+				}
+			}}
+			onEntering={() => {
+				if (nodeRef.current) {
+					setElementFullHeight(nodeRef.current);
+				}
+			}}
+			onExit={() => {
+				if (nodeRef.current) {
+					setElementFullHeight(nodeRef.current);
+				}
+			}}
+			onExiting={() => {
+				if (nodeRef.current) {
+					nodeRef.current.setAttribute('style', 'height: 0px');
+				}
+			}}
 			timeout={prefersReducedMotion ? 0 : 250}
 			unmountOnExit
 		>
-			<div>
+			<div ref={nodeRef}>
 				<Collection<T> as={List} items={items} {...otherProps}>
 					{children}
 				</Collection>

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/tree-view/TreeViewGroup.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/tree-view/TreeViewGroup.tsx
@@ -45,6 +45,20 @@ export function Group<T extends Record<any, any>>({
 
 	const nodeRef = React.useRef<HTMLDivElement>(null);
 
+	const setNodeHeightZero = () => {
+		nodeRef.current?.setAttribute('style', 'height: 0px');
+	};
+
+	const setNodeFullHeight = () => {
+		if (nodeRef.current) {
+			setElementFullHeight(nodeRef.current);
+		}
+	};
+
+	const removeStyleAttribute = () => {
+		nodeRef.current?.removeAttribute('style');
+	};
+
 	return (
 		<CSSTransition
 			className={classNames('collapse', className, {
@@ -65,31 +79,11 @@ export function Group<T extends Record<any, any>>({
 			id={item.key}
 			in={expandedKeys.has(item.key)}
 			nodeRef={nodeRef}
-			onEnter={() => {
-				if (nodeRef.current) {
-					nodeRef.current.setAttribute('style', 'height: 0px');
-				}
-			}}
-			onEntered={() => {
-				if (nodeRef.current) {
-					nodeRef.current.removeAttribute('style');
-				}
-			}}
-			onEntering={() => {
-				if (nodeRef.current) {
-					setElementFullHeight(nodeRef.current);
-				}
-			}}
-			onExit={() => {
-				if (nodeRef.current) {
-					setElementFullHeight(nodeRef.current);
-				}
-			}}
-			onExiting={() => {
-				if (nodeRef.current) {
-					nodeRef.current.setAttribute('style', 'height: 0px');
-				}
-			}}
+			onEnter={setNodeHeightZero}
+			onEntered={removeStyleAttribute}
+			onEntering={setNodeFullHeight}
+			onExit={setNodeFullHeight}
+			onExiting={setNodeHeightZero}
 			timeout={prefersReducedMotion ? 0 : 250}
 			unmountOnExit
 		>


### PR DESCRIPTION
Ticket https://liferay.atlassian.net/browse/LPD-31376

## What is being fixed

ClayTreeView emits a React deprecation warning when rendered inside `React.StrictMode`:

> Warning: findDOMNode is deprecated in StrictMode. findDOMNode was passed an instance of Transition2 which is inside StrictMode.

The warning originates from the `CSSTransition` wrapper around each `ClayTreeViewGroup`. `CSSTransition` (from `react-transition-group@4.4.1`) defaults to resolving its animated child via `findDOMNode`, which React deprecates under StrictMode.

## How it is being fixed

`CSSTransition` exposes a `nodeRef` prop so callers can supply their own ref to the wrapped element instead of relying on `findDOMNode`. `TreeViewGroup` now creates a `useRef`, attaches it to the wrapping `<div>`, and passes it as `nodeRef`. When `nodeRef` is provided, `react-transition-group` strips the element argument from the enter and exit callbacks, so each transition callback reads from `nodeRef.current`. The rendered DOM and animation behavior are unchanged.

## Why are there no tests?

The `findDOMNode` warning is emitted by React only in development builds and only when `React.StrictMode` is active. The Liferay portal does not wrap its React tree in StrictMode, so reproducing the warning inside the portal's test setup would require adding a StrictMode harness that does not otherwise exist in the codebase. The change is a documented `react-transition-group` migration; the existing TreeView test suite (58 tests, 7 snapshots) continues to pass unchanged, confirming that the rendered DOM and behavior are preserved.