### PR TITLE
LPD-87424 Fix $mark-bg color discrepancy between atlas and classic

### DIFF
--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_globals.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_globals.scss
@@ -721,7 +721,7 @@ $hr-border-color: var(--hr-border-color) !default;
 $hr-border-width: var(--hr-border-width) !default;
 $hr-margin-y: var(--hr-margin-y) !default;
 
-$mark-bg: #fcf8e3 !default;
+$mark-bg: $yellow-l3 !default;
 $mark-color: null !default;
 $mark-padding: 0.2em !default;
 

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas/variables/_globals.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas/variables/_globals.scss
@@ -707,7 +707,7 @@ $hr-border-color: rgba($black, 0.1) !default;
 $hr-border-width: $border-width !default;
 $hr-margin-y: $spacer !default;
 
-$mark-bg: #ffe399 !default;
+$mark-bg: $yellow-l3 !default;
 
 $dt-font-weight: $font-weight-bold !default;
 

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/variables/_globals.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/variables/_globals.scss
@@ -999,7 +999,7 @@ $cadmin-hr-border-color: rgba($cadmin-black, 0.1) !default;
 $cadmin-hr-border-width: $cadmin-border-width !default;
 $cadmin-hr-margin-y: $cadmin-spacer !default;
 
-$cadmin-mark-bg: #ffe399 !default;
+$cadmin-mark-bg: $cadmin-yellow-l3 !default;
 $cadmin-mark-color: null !default;
 $cadmin-mark-padding: null !default;
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/Search.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/Search.testcase
@@ -250,7 +250,7 @@ definition {
 			key_searchAssetTitle = "Home",
 			locator1 = "SearchPage#RESULT_TITLE_SPECIFIC_HIGHLIGHT",
 			locator2 = "background-color",
-			value1 = "rgba(252, 248, 227, 1)");
+			value1 = "rgba(255, 228, 153, 1)");
 	}
 
 	@priority = 4
@@ -614,13 +614,13 @@ definition {
 			key_searchAssetTitle = "WC",
 			locator1 = "SearchPage#RESULT_TITLE_SPECIFIC_HIGHLIGHT",
 			locator2 = "background-color",
-			value1 = "rgba(252, 248, 227, 1)");
+			value1 = "rgba(255, 228, 153, 1)");
 
 		AssertCssValue(
 			key_searchAssetTitle = "Title",
 			locator1 = "SearchPage#RESULT_TITLE_SPECIFIC_HIGHLIGHT",
 			locator2 = "background-color",
-			value1 = "rgba(252, 248, 227, 1)");
+			value1 = "rgba(255, 228, 153, 1)");
 
 		SearchResults.configureSearchResults(disableHighlighting = "true");
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/search/searchexperiences/Blueprints.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/search/searchexperiences/Blueprints.testcase
@@ -1436,13 +1436,13 @@ definition {
 			key_searchAssetTitle = "WC",
 			locator1 = "SearchPage#RESULT_TITLE_SPECIFIC_HIGHLIGHT",
 			locator2 = "background-color",
-			value1 = "rgba(252, 248, 227, 1)");
+			value1 = "rgba(255, 228, 153, 1)");
 
 		AssertCssValue(
 			key_searchAssetTitle = "Title",
 			locator1 = "SearchPage#RESULT_TITLE_SPECIFIC_HIGHLIGHT",
 			locator2 = "background-color",
-			value1 = "rgba(252, 248, 227, 1)");
+			value1 = "rgba(255, 228, 153, 1)");
 	}
 
 	@priority = 3


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87424

## What is being fixed

The HTML `<mark>` element (used by search highlighting) renders cream `#fcf8e3` instead of an atlas yellow whenever the Classic theme is built through its `clay-atlas-custom-properties.scss` entry point. When LPD-71471 added the atlas-custom-properties Clay variant in April, `$mark-bg` was scaffolded from the base defaults instead of from atlas, and once LPD-83172 routed Classic to that variant, the wrong color became visible. The atlas and cadmin variants were also hardcoding `#ffe399`, one digit off from the `$yellow-l3` palette token (`#ffe499`) they were meant to reference.

## How it is being fixed

Sets `$mark-bg` to the `$yellow-l3` token (and `$cadmin-mark-bg` to `$cadmin-yellow-l3`) in atlas, atlas-custom-properties, and cadmin, so all three Clay variants render `<mark>` with `#ffe499`. The Poshi assertions in `Search.testcase` and `Blueprints.testcase` are updated to `rgba(255, 228, 153, 1)` to match.