### PR TITLE
LPD-74696 Improve Enter key handling in Clay autocomplete

### DIFF
--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/js/asset_categories_selector/AssetVocabularyCategoriesSelector.js
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/js/asset_categories_selector/AssetVocabularyCategoriesSelector.js
@@ -202,6 +202,7 @@ function AssetVocabulariesCategoriesSelector({
 				<ClayInput.Group>
 					<ClayInput.GroupItem>
 						<ClayMultiSelect
+							allowsCustomLabel={false}
 							clearAllTitle={Liferay.Language.get('clear-all')}
 							id={inputName + '_MultiSelect'}
 							inputName={inputName}

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-autocomplete/src/Autocomplete.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-autocomplete/src/Autocomplete.tsx
@@ -670,15 +670,52 @@ function AutocompleteInner<T extends Item>(
 							break;
 						}
 						case Keys.Enter: {
+							if (active && activeDescendant) {
+								event.preventDefault();
+
+								setActive(false);
+
+								onPress();
+
+								break;
+							}
+
+							// Typing into the input clears activeDescendant, so
+							// an exact match would otherwise require an extra
+							// arrow-down before Enter to commit it. Select the
+							// match directly when one exists.
+
+							if (active && value) {
+								const lowerValue = value.toLowerCase();
+
+								const matchedKey = collection
+									.getItems()
+									.find(
+										(key) =>
+											collection
+												.getItem(key)
+												?.value?.toLowerCase() ===
+											lowerValue
+									);
+
+								if (matchedKey && menuRef.current) {
+									event.preventDefault();
+
+									setActive(false);
+
+									const matchedElement =
+										menuRef.current.querySelector(
+											`#${CSS.escape(String(matchedKey))}`
+										) as HTMLElement | null;
+
+									matchedElement?.click();
+
+									break;
+								}
+							}
+
 							setActive(false);
 
-							if (active && activeDescendant) {
-								onPress();
-							}
-
-							if (!active && event.key === Keys.Esc) {
-								setValue('');
-							}
 							break;
 						}
 						case Keys.Home:

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-multi-select/src/Labels.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-multi-select/src/Labels.tsx
@@ -411,7 +411,10 @@ export const Labels = React.forwardRef<HTMLInputElement, IProps>(
 									event.preventDefault();
 								}
 
-								if (key === Keys.Enter && activeDescendant) {
+								if (
+									key === Keys.Enter &&
+									(activeDescendant || event.defaultPrevented)
+								) {
 									return;
 								}
 

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-multi-select/src/MultiSelect.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-multi-select/src/MultiSelect.tsx
@@ -501,6 +501,7 @@ export const MultiSelect = React.forwardRef(function MultiSelectInner<
 								? false
 								: allowsCustomLabel
 						}
+						allowsCustomValue
 						ariaDescriptionId={ariaDescriptionId}
 						as={Labels}
 						closeButtonAriaLabel={closeButtonAriaLabel}

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-multi-select/src/__tests__/IncrementalInteractions.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-multi-select/src/__tests__/IncrementalInteractions.tsx
@@ -193,4 +193,87 @@ describe('MultiSelect incremental interactions', () => {
 			);
 		});
 	});
+
+	it('pressing enter on an exact label match adds the source item and clears the input', () => {
+		const onItemsChange = jest.fn();
+		const sourceItems = [
+			{label: 'one', value: '1'},
+			{label: 'two', value: '2'},
+		];
+
+		const {getByRole} = render(
+			<MultiSelect
+				onItemsChange={onItemsChange}
+				sourceItems={sourceItems}
+				spritemap="/foo/bar"
+			/>
+		);
+
+		const combobox = getByRole('combobox') as HTMLInputElement;
+
+		userEvent.type(combobox, 'one');
+
+		userEvent.keyboard('[Enter]');
+
+		expect(onItemsChange).toHaveBeenLastCalledWith([sourceItems[0]]);
+
+		expect(combobox.value).toBe('');
+	});
+
+	it('pressing enter on a non-matching value with allowsCustomLabel false preserves the input', () => {
+		const onItemsChange = jest.fn();
+		const sourceItems = [
+			{label: 'one', value: '1'},
+			{label: 'two', value: '2'},
+		];
+
+		const {getByRole} = render(
+			<MultiSelect
+				allowsCustomLabel={false}
+				onItemsChange={onItemsChange}
+				sourceItems={sourceItems}
+				spritemap="/foo/bar"
+			/>
+		);
+
+		const combobox = getByRole('combobox') as HTMLInputElement;
+
+		userEvent.type(combobox, 'foo');
+
+		userEvent.keyboard('[Enter]');
+
+		expect(onItemsChange).not.toHaveBeenCalled();
+
+		expect(combobox.value).toBe('foo');
+	});
+
+	it('pressing enter on a non-matching value with allowsCustomLabel true adds it as a custom label', () => {
+		const onItemsChange = jest.fn();
+		const sourceItems = [
+			{label: 'one', value: '1'},
+			{label: 'two', value: '2'},
+		];
+
+		const {getByRole} = render(
+			<MultiSelect
+				onItemsChange={onItemsChange}
+				sourceItems={sourceItems}
+				spritemap="/foo/bar"
+			/>
+		);
+
+		const combobox = getByRole('combobox') as HTMLInputElement;
+
+		userEvent.type(combobox, 'foo');
+
+		userEvent.keyboard('[Enter]');
+
+		expect(onItemsChange).toHaveBeenCalledTimes(1);
+
+		expect(onItemsChange).toHaveBeenLastCalledWith([
+			expect.objectContaining({label: 'foo', value: 'foo'}),
+		]);
+
+		expect(combobox.value).toBe('');
+	});
 });

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-multi-select/stories/MultiSelect.stories.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-multi-select/stories/MultiSelect.stories.tsx
@@ -76,6 +76,39 @@ Default.args = {
 	isValid: false,
 	size: null,
 };
+export function AllowsCustomLabel(args: any) {
+	const [value, setValue] = useState('');
+	const [items, setItems] = useState([
+		{
+			label: 'one',
+			value: '1',
+		},
+	]);
+
+	return (
+		<>
+			<label htmlFor="multiSelect" id="multi-select-label">
+				Multi Select
+			</label>
+
+			<ClayMultiSelect
+				allowsCustomLabel={args.allowsCustomLabel}
+				aria-labelledby="multi-select-label"
+				id="multiSelect"
+				inputName="myInput"
+				items={items}
+				onChange={setValue}
+				onItemsChange={(val) => setItems(val as any)}
+				sourceItems={sourceItems}
+				value={value}
+			/>
+		</>
+	);
+}
+
+AllowsCustomLabel.args = {
+	allowsCustomLabel: true,
+};
 export function ComparingItems() {
 	const [items, setItems] = useState([
 		{


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-74696

## What is being fixed

The multi-select autocomplete in the "Add Category" field of the Categorization panel misbehaved on Enter:

- Typing an exact category name and pressing Enter did nothing — the item was not added as a tag.
- Typing a string that did not match any category and pressing Enter cleared the input and lost focus, forcing the user to retype the entire string to correct a typo.

The same bug surfaces in any other `ClayMultiSelect` consumer.

## How it is being fixed

Two interacting issues live inside the Clay primitives, not the asset consumers. Both are fixed in `clay-autocomplete` and `clay-multi-select`.

The `Autocomplete` Enter handler only fired `onPress()` when a dropdown item was highlighted (`activeDescendant`), but typing into the input clears `activeDescendant` on every keystroke — so an exact match required an arrow-down before Enter would commit it. The handler now looks up the typed value in the rendered collection and, on an exact match, clicks that DOM option directly, going through the same path as a real click and adding the source item with its proper value. The dead `Keys.Esc` branch inside the `Keys.Enter` case is removed at the same time.

`Autocomplete` also has a validate-on-close effect that reverts the typed value to the last selected one whenever `active` flips to `false`. That makes sense for a single-select Autocomplete, but in `MultiSelect` the input is search text, not a single value to validate, so the revert is wrong. `MultiSelect` now forwards `allowsCustomValue` to its inner Autocomplete unconditionally and the effect short-circuits.

The Labels Enter handler that adds typed text as a custom label is gated to skip when Autocomplete already handled the Enter (signalled via `event.preventDefault()`), so the two paths cannot double-fire.

On the consumer side, `AssetVocabularyCategoriesSelector` sets `allowsCustomLabel={false}`. Categories must be pre-existing — that is the right semantic for the consumer and lets the no-match scenario preserve the typed text the user typed.