### PR TITLE
LPD-92478 Change color border in Table component in Clay

### DIFF
--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_tables.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_tables.scss
@@ -29,7 +29,7 @@ $table-responsive-margin-bottom: var(
 // Table
 
 $table-bg: var(--table-background-color, $white) !default;
-$table-border-color: var(--table-border-color, $secondary-l2) !default;
+$table-border-color: var(--table-border-color, $gray-400) !default;
 $table-border-width: var(--table-border-width, $border-width) !default;
 $table-color: var(--table-color, $body-color) !default;
 $table-font-size: var(--table-font-size, 14px) !default;
@@ -773,10 +773,7 @@ $table-border-level: -6 !default;
 // Table List
 
 $table-list-bg: var(--table-list-background-color, $white) !default;
-$table-list-border-color: var(
-	--table-list-border-color,
-	$secondary-l2
-) !default;
+$table-list-border-color: var(--table-list-border-color, $gray-400) !default;
 $table-list-border-radius: var(
 	--table-list-border-radius,
 	$border-radius

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_tables.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_tables.scss
@@ -29,7 +29,7 @@ $table-responsive-margin-bottom: var(
 // Table
 
 $table-bg: var(--table-background-color, $white) !default;
-$table-border-color: var(--table-border-color, $gray-300) !default;
+$table-border-color: var(--table-border-color, $secondary-l2) !default;
 $table-border-width: var(--table-border-width, $border-width) !default;
 $table-color: var(--table-color, $body-color) !default;
 $table-font-size: var(--table-font-size, 14px) !default;
@@ -773,7 +773,10 @@ $table-border-level: -6 !default;
 // Table List
 
 $table-list-bg: var(--table-list-background-color, $white) !default;
-$table-list-border-color: var(--table-list-border-color, $gray-300) !default;
+$table-list-border-color: var(
+	--table-list-border-color,
+	$secondary-l2
+) !default;
 $table-list-border-radius: var(
 	--table-list-border-radius,
 	$border-radius

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas/variables/_tables.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas/variables/_tables.scss
@@ -1,5 +1,5 @@
 $table-bg: $white !default;
-$table-border-color: $gray-300 !default;
+$table-border-color: $secondary-l2 !default;
 $table-font-size: 0.875rem !default;
 
 $table-accent-bg: $light-l1 !default;
@@ -173,7 +173,7 @@ $c-tr-table-focus: map-deep-merge(
 
 // Table List
 
-$table-list-border-color: $gray-300 !default;
+$table-list-border-color: $secondary-l2 !default;
 $table-list-color: $body-color !default;
 
 $table-list-accent-bg: $gray-100 !default;

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas/variables/_tables.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas/variables/_tables.scss
@@ -1,5 +1,5 @@
 $table-bg: $white !default;
-$table-border-color: $secondary-l2 !default;
+$table-border-color: $gray-400 !default;
 $table-font-size: 0.875rem !default;
 
 $table-accent-bg: $light-l1 !default;
@@ -173,7 +173,7 @@ $c-tr-table-focus: map-deep-merge(
 
 // Table List
 
-$table-list-border-color: $secondary-l2 !default;
+$table-list-border-color: $gray-400 !default;
 $table-list-color: $body-color !default;
 
 $table-list-accent-bg: $gray-100 !default;

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/variables/_tables.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/variables/_tables.scss
@@ -26,7 +26,7 @@ $cadmin-table-responsive-margin-bottom: 24px !default;
 // Table
 
 $cadmin-table-bg: $cadmin-white !default;
-$cadmin-table-border-color: $cadmin-gray-300 !default;
+$cadmin-table-border-color: $cadmin-secondary-l2 !default;
 $cadmin-table-border-width: $cadmin-border-width !default;
 $cadmin-table-color: $cadmin-body-color !default;
 $cadmin-table-font-size: 14px !default;
@@ -691,7 +691,7 @@ $cadmin-table-border-level: -6 !default;
 // Table List
 
 $cadmin-table-list-bg: $cadmin-white !default;
-$cadmin-table-list-border-color: $cadmin-gray-300 !default;
+$cadmin-table-list-border-color: $cadmin-secondary-l2 !default;
 $cadmin-table-list-border-x-width: 1px !default;
 $cadmin-table-list-border-y-width: 1px !default;
 

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/variables/_tables.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/variables/_tables.scss
@@ -26,7 +26,7 @@ $cadmin-table-responsive-margin-bottom: 24px !default;
 // Table
 
 $cadmin-table-bg: $cadmin-white !default;
-$cadmin-table-border-color: $cadmin-secondary-l2 !default;
+$cadmin-table-border-color: $cadmin-gray-400 !default;
 $cadmin-table-border-width: $cadmin-border-width !default;
 $cadmin-table-color: $cadmin-body-color !default;
 $cadmin-table-font-size: 14px !default;
@@ -691,7 +691,7 @@ $cadmin-table-border-level: -6 !default;
 // Table List
 
 $cadmin-table-list-bg: $cadmin-white !default;
-$cadmin-table-list-border-color: $cadmin-secondary-l2 !default;
+$cadmin-table-list-border-color: $cadmin-gray-400 !default;
 $cadmin-table-list-border-x-width: 1px !default;
 $cadmin-table-list-border-y-width: 1px !default;
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92478

## What is being fixed

Clay's Table component rendered cell borders as `$gray-300` (`#e7e7ed`), which matches `$secondary-l3` in hex but breaks visual contrast when a theme overrides `$secondary` for High-Contrast or Dark Mode. The Lexicon design spec calls for `$secondary-l2` (`#cdced9`) so the border tracks the brand secondary ramp across themes.

## How it is being fixed

Updated `$table-border-color` and `$table-list-border-color` to reference `$secondary-l2` in all three Clay CSS scopes: legacy `atlas/`, admin `cadmin/`, and the modern `atlas-custom-properties/` (CSS-variable fallback). Both tokens needed updating because `<ClayTable>` renders `<table class="table table-list ...">` by default — without both, the `.table-list` rule overrides `.table` via the cascade and the border keeps the old color. `$table-data-border-color`, `.table-head-bordered`, and `.table-bordered` all inherit from `$table-border-color` and follow automatically. `.table-dark` is a separate Bootstrap-derived variant whose border is intentionally derived from its own dark background, and is left untouched.