### PR TITLE
LPD-83292 Document the ClayBadge icon variant and add a Storybook story

### DIFF
--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-badge/docs/badge.mdx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-badge/docs/badge.mdx
@@ -37,6 +37,37 @@ export default function App() {
 
 We recommend that you review the use cases in the [Storybook](https://storybook.clayui.com/?path=/story/design-system-components-badge--default).
 
+## Icon
+
+A badge can display an optional icon alongside its text by passing the `symbol` attribute with the id of an icon in the spritemap. The icon is rendered after the label, sized relative to the text, and inherits the badge color. The spritemap is resolved from the `spritemap` attribute or inherited from a parent `Provider`.
+
+Use the icon to reinforce the meaning of a short value, such as a status or a trend. Avoid icon-only badges without a `label`, and avoid pairing an icon with long or multi-line text, since badges are meant for short values.
+
+```jsx preview
+import {Provider} from '@clayui/core';
+import Badge from '@clayui/badge';
+import React from 'react';
+
+import '@clayui/css/lib/css/atlas.css';
+
+export default function App() {
+	return (
+		<Provider spritemap="/public/icons.svg">
+			<div className="p-4">
+				<Badge displayType="success" label="100" symbol="check" />
+				<Badge displayType="info" label="100" symbol="info-circle" />
+				<Badge displayType="warning" label="100" symbol="warning-full" />
+				<Badge
+					displayType="danger"
+					label="100"
+					symbol="exclamation-full"
+				/>
+			</div>
+		</Provider>
+	);
+}
+```
+
 ## Translucent
 
 The boolean attribute `translucent` renders a badge with an opaque background color optimized for light backgrounds.

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-badge/stories/Badge.stories.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-badge/stories/Badge.stories.tsx
@@ -28,6 +28,16 @@ export default {
 	component: ClayBadge,
 	title: 'Design System/Components/Badge',
 };
+
+const displayTypes = [
+	'danger',
+	'info',
+	'primary',
+	'secondary',
+	'success',
+	'warning',
+] as const;
+
 export function Default(args: any) {
 	return (
 		<ClayBadge
@@ -63,4 +73,47 @@ WithIcon.args = {
 	label: '100',
 	symbol: 'check',
 	translucent: false,
+};
+
+export function SeeAll(args: any) {
+	return (
+		<>
+			<div className="mb-4">
+				{displayTypes.map((displayType) => (
+					<ClayBadge
+						className="mr-2"
+						displayType={displayType}
+						key={displayType}
+						label={args.label}
+						spritemap={spritemap}
+						symbol={args.symbol}
+					/>
+				))}
+			</div>
+
+			<div className="bg-dark p-3">
+				{displayTypes.map((displayType) => (
+					<ClayBadge
+						className="mr-2"
+						dark
+						displayType={displayType}
+						key={displayType}
+						label={args.label}
+						spritemap={spritemap}
+						symbol={args.symbol}
+						translucent
+					/>
+				))}
+			</div>
+		</>
+	);
+}
+
+SeeAll.args = {
+	label: '100',
+	symbol: 'check',
+};
+
+SeeAll.argTypes = {
+	displayType: {table: {disable: true}},
 };

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-badge/stories/Badge.stories.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-badge/stories/Badge.stories.tsx
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+const spritemap = require('@clayui/css/src/images/icons/icons.svg');
 import React from 'react';
 
 import ClayBadge from '../src';
@@ -19,6 +20,9 @@ export default {
 				'success',
 				'warning',
 			],
+		},
+		symbol: {
+			control: {type: 'text'},
 		},
 	},
 	component: ClayBadge,
@@ -37,5 +41,26 @@ export function Default(args: any) {
 Default.args = {
 	displayType: 'primary',
 	label: '100',
+	translucent: false,
+};
+
+export function WithIcon(args: any) {
+	return (
+		<ClayBadge
+			dark={args.dark}
+			displayType={args.displayType}
+			label={args.label}
+			spritemap={spritemap}
+			symbol={args.symbol}
+			translucent={args.translucent}
+		/>
+	);
+}
+
+WithIcon.args = {
+	dark: false,
+	displayType: 'primary',
+	label: '100',
+	symbol: 'check',
 	translucent: false,
 };


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-83292

## What Is Being Fixed

ClayBadge gained optional icon support (the `symbol`/`spritemap` props) under LPD-83029, but the variant was undocumented and had no Storybook coverage, so neither developers nor designers could easily discover or review it.

## How It Is Being Fixed

Adds an Icon section to the Badge documentation page with a live example and guidance on supported and unsupported use, and adds a WithIcon Storybook story (with a symbol control) that renders the icon variant across display types for visual review. No component or CSS changes were needed — the existing `.badge-item` / `.badge-item-after` / `.lexicon-icon` rules already define the icon sizing, spacing, and alignment.

## Why Are There No Tests?

This PR adds only a Storybook story and documentation — no production code. The ClayBadge icon behaviour landed in LPD-83029 and is already covered by a unit test.

<img width="875" height="904" alt="image" src="https://github.com/user-attachments/assets/626c499f-697f-4fb2-8e85-2d82ec12daf4" />

<img width="750" height="567" alt="image" src="https://github.com/user-attachments/assets/abb16caa-a307-40ca-887a-adb0344e6acd" />
