### PR TITLE
  LPD-93019 Fix CMS Theme border radius for inverse and bold labels

### DIFF
--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_labels.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_labels.scss
@@ -254,7 +254,7 @@ $label-item-after: map-merge(
 $label-lg: () !default;
 $label-lg: map-deep-merge(
 	(
-		border-radius: var(--label-lg-border-radius, $border-radius-lg),
+		border-radius: var(--label-lg-border-radius, $label-border-radius),
 		font-size: var(--label-lg-font-size, 0.875rem),
 		height: var(--label-lg-height, auto),
 		min-height: var(--label-lg-min-height, 1.5rem),

--- a/modules/apps/frontend-theme/frontend-theme-classic/src/css/_deprecated_clay_variables.scss
+++ b/modules/apps/frontend-theme/frontend-theme-classic/src/css/_deprecated_clay_variables.scss
@@ -479,7 +479,7 @@ $label-font-size: 0.75rem;
 $label-lg: () !default;
 $label-lg: map-deep-merge(
 	(
-		border-radius: $border-radius-lg,
+		border-radius: $label-border-radius,
 	),
 	$label-lg
 );

--- a/modules/apps/frontend-theme/frontend-theme-cms/src/css/_clay_variables.scss
+++ b/modules/apps/frontend-theme/frontend-theme-cms/src/css/_clay_variables.scss
@@ -25,6 +25,8 @@ $btn-sizes: map-deep-merge(
 
 $custom-checkbox-indicator-border-radius: 0.25rem;
 
+$label-border-radius: 0.25rem;
+
 $nav-divider-color: $secondary-l1;
 
 $sticker-sm-border-radius: 0.25rem;


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPD-93019
  
## What Is Being Fixed

In CMS > Content Structure, inverse/bold labels render with corners that are too round. The CMS theme flattens the Clay border radius scale to 0.5rem, so labels inherit an oversized radius instead of the -md value (0.25rem / 4px) the updated Lexicon spec calls for.

## How It Is Being Fixed

Pin the label border radius to 0.25rem in the CMS theme via `$label-border-radius`, leaving the global `$border-radius: 0.5rem` untouched so buttons and cards keep their radius. In addition, align the large-label radius to the base label radius in Clay (atlas-custom-properties) and the Classic theme so both label variants share the revised radius rather than defaulting to the larger `-lg` token.

## Why Are There No Tests?

This change only adjusts a SCSS border-radius token value, which is not meaningfully unit-testable. The result is verified visually in CMS > Content Structure (labels render at 4px / -md). Regression coverage, if desired, belongs at the Playwright visual level.