### PR TITLE
LPD-93267 Investigate test failure  frontend-taglib-clay/main/managementToolbar.spec.ts > Management Toolbar Using Display Context › Assert the order button can display the correct icons

### DIFF
--- a/modules/test/playwright/tests/frontend-taglib-clay/main/managementToolbar.spec.ts
+++ b/modules/test/playwright/tests/frontend-taglib-clay/main/managementToolbar.spec.ts
@@ -348,6 +348,8 @@ test.describe('Management Toolbar Using Display Context', () => {
 
 			await test.step('Click on descending', async () => {
 				await page.getByRole('menuitem', {name: 'Descending'}).click();
+
+				await claySamplePage.waitFor();
 			});
 
 			await test.step('Navigate to management toolbar tab', async () => {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93267

## What Is Being Fixed

The Playwright test "Assert the order button can display the correct icons" (managementToolbar.spec.ts) intermittently timed out after 90s. Clicking the "Descending" order item triggers a full SennaJS page reload that resets the clay sample to its default "Alerts" tab. The test immediately re-selected the "Management Toolbars" tab, racing the in-flight navigation: when the tab selection ran against the still-loading page the browser ended up on the portal Home page, and selectTab retried against a tablist that no longer existed until the timeout.

## How It Is Being Fixed

After clicking "Descending", wait for the reload to finish before selecting a tab again, using the page object's waitFor() (which waits for the default "Alerts" tab heading — hidden before the reload, visible only once it completes). This is a deterministic barrier, unlike waitForLoadState('networkidle'), which resolves on network lulls before the DOM swap and stayed flaky in testing.