### PR TITLE
LPD-93331 Investigate test failures in style-book-web/main/styleBookSelection.spec.ts 

### DIFF
--- a/modules/test/playwright/tests/style-book-web/main/styleBookSelection.spec.ts
+++ b/modules/test/playwright/tests/style-book-web/main/styleBookSelection.spec.ts
@@ -52,7 +52,7 @@ test.beforeEach(async ({site, styleBooksPage}) => {
 
 	await styleBooksPage.create(STYLE_BOOK_NAME);
 
-	await styleBooksPage.updateTokenInputColor('Brand Color 4', TEST_COLOR);
+	await styleBooksPage.updateTokenInput('Brand Color 4', TEST_COLOR);
 
 	await styleBooksPage.waitForAutoSave();
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93331

The `styleBookSelection` Playwright tests were timing out (90s) in CI on the `beforeEach`, where `StyleBooksPage.updateTokenInputColor` sets a color token before publishing the style book.

The color input was located with `getByLabel('Brand Color 4', {exact: true}).getByLabel('Color selection is')`. The outer label lives as an `aria-label` on the field's wrapping `<div class="form-group">`, but Playwright's `getByLabel` only matches labelable form controls, not a generic `<div>` with an `aria-label`. As a result the chained locator resolved to no element, and every action on it (the leading `click` in `fillAndClickOutside`) waited out the test timeout instead of failing. The color token was never set, so the field showed its default value.

This replaces the locator with the same `.form-group` + label-text + first `input` pattern already used by the sibling `updateTokenInput` helper, which resolves cleanly to the single hex input.
