### PR TITLE
LPD-93325 Refresh live configuration state during group-scope upgrade

### DIFF
--- a/modules/apps/static/portal-configuration/portal-configuration-persistence-impl/src/main/java/com/liferay/portal/configuration/persistence/internal/upgrade/registry/ConfigurationPersistenceUpgradeStepRegistrator.java
+++ b/modules/apps/static/portal-configuration/portal-configuration-persistence-impl/src/main/java/com/liferay/portal/configuration/persistence/internal/upgrade/registry/ConfigurationPersistenceUpgradeStepRegistrator.java
@@ -54,7 +54,8 @@ public class ConfigurationPersistenceUpgradeStepRegistrator
 		registry.register(
 			"2.0.0", "2.0.1",
 			new com.liferay.portal.configuration.persistence.internal.upgrade.
-				v2_0_1.ConfigurationUpgradeProcess(_groupLocalService));
+				v2_0_1.ConfigurationUpgradeProcess(
+					_configurationAdmin, _groupLocalService));
 	}
 
 	@Reference

--- a/modules/apps/static/portal-configuration/portal-configuration-persistence-impl/src/main/java/com/liferay/portal/configuration/persistence/internal/upgrade/v2_0_1/ConfigurationUpgradeProcess.java
+++ b/modules/apps/static/portal-configuration/portal-configuration-persistence-impl/src/main/java/com/liferay/portal/configuration/persistence/internal/upgrade/v2_0_1/ConfigurationUpgradeProcess.java
@@ -6,10 +6,8 @@
 package com.liferay.portal.configuration.persistence.internal.upgrade.v2_0_1;
 
 import com.liferay.petra.io.unsync.UnsyncByteArrayInputStream;
-import com.liferay.petra.io.unsync.UnsyncByteArrayOutputStream;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
-import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
@@ -29,12 +27,19 @@ import java.util.Dictionary;
 
 import org.apache.felix.cm.file.ConfigurationHandler;
 
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+
 /**
  * @author Thiago Buarque
  */
 public class ConfigurationUpgradeProcess extends UpgradeProcess {
 
-	public ConfigurationUpgradeProcess(GroupLocalService groupLocalService) {
+	public ConfigurationUpgradeProcess(
+		ConfigurationAdmin configurationAdmin,
+		GroupLocalService groupLocalService) {
+
+		_configurationAdmin = configurationAdmin;
 		_groupLocalService = groupLocalService;
 	}
 
@@ -44,18 +49,15 @@ public class ConfigurationUpgradeProcess extends UpgradeProcess {
 			return;
 		}
 
-		try (PreparedStatement preparedStatement1 = connection.prepareStatement(
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
 				"select configurationId, dictionary from Configuration_ " +
 					"where dictionary like '%groupId=%'");
-			PreparedStatement preparedStatement2 =
-				AutoBatchPreparedStatementUtil.autoBatch(
-					connection,
-					"update Configuration_ set dictionary = ? where " +
-						"configurationId = ?");
-			ResultSet resultSet = preparedStatement1.executeQuery()) {
+
+			ResultSet resultSet = preparedStatement.executeQuery()) {
 
 			while (resultSet.next()) {
 				String configurationId = resultSet.getString("configurationId");
+
 				Dictionary<String, Object> dictionary = _toDictionary(
 					resultSet.getString("dictionary"));
 
@@ -70,14 +72,11 @@ public class ConfigurationUpgradeProcess extends UpgradeProcess {
 						getPropertyKey(),
 					companyId);
 
-				preparedStatement2.setString(1, _toString(dictionary));
+				Configuration configuration =
+					_configurationAdmin.getConfiguration(configurationId, "?");
 
-				preparedStatement2.setString(2, configurationId);
-
-				preparedStatement2.addBatch();
+				configuration.update(dictionary);
 			}
-
-			preparedStatement2.executeBatch();
 		}
 	}
 
@@ -116,21 +115,10 @@ public class ConfigurationUpgradeProcess extends UpgradeProcess {
 		return ConfigurationHandler.read(unsyncByteArrayInputStream);
 	}
 
-	private String _toString(Dictionary<String, Object> dictionary)
-		throws IOException {
-
-		UnsyncByteArrayOutputStream unsyncByteArrayOutputStream =
-			new UnsyncByteArrayOutputStream();
-
-		ConfigurationHandler.write(unsyncByteArrayOutputStream, dictionary);
-
-		return new String(
-			unsyncByteArrayOutputStream.toByteArray(), StandardCharsets.UTF_8);
-	}
-
 	private static final Log _log = LogFactoryUtil.getLog(
 		ConfigurationUpgradeProcess.class);
 
+	private final ConfigurationAdmin _configurationAdmin;
 	private final GroupLocalService _groupLocalService;
 
 }

--- a/modules/apps/static/portal-configuration/portal-configuration-persistence-test/src/testIntegration/java/com/liferay/portal/configuration/persistence/internal/upgrade/v2_0_1/test/ConfigurationUpgradeProcessTest.java
+++ b/modules/apps/static/portal-configuration/portal-configuration-persistence-test/src/testIntegration/java/com/liferay/portal/configuration/persistence/internal/upgrade/v2_0_1/test/ConfigurationUpgradeProcessTest.java
@@ -7,7 +7,6 @@ package com.liferay.portal.configuration.persistence.internal.upgrade.v2_0_1.tes
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.io.unsync.UnsyncByteArrayInputStream;
-import com.liferay.petra.io.unsync.UnsyncByteArrayOutputStream;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
 import com.liferay.portal.db.partition.util.DBPartitionUtil;
@@ -27,6 +26,8 @@ import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.upgrade.UpgradeStep;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
@@ -41,8 +42,11 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 
 import java.util.Dictionary;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
+import org.apache.felix.cm.PersistenceManager;
 import org.apache.felix.cm.file.ConfigurationHandler;
 
 import org.junit.After;
@@ -141,40 +145,58 @@ public class ConfigurationUpgradeProcessTest {
 		}
 
 		Assert.assertEquals(1, count);
+
+		String configurationId = _configurationIds.get(companyId);
+
+		Dictionary<?, ?> dictionary = _persistenceManager.load(configurationId);
+
+		Assert.assertEquals(
+			companyId,
+			dictionary.get(
+				ExtendedObjectClassDefinition.Scope.COMPANY.getPropertyKey()));
 	}
 
 	private void _createConfiguration() throws Exception {
+		long companyId = CompanyThreadLocal.getCompanyId();
+
 		Group group = _groupLocalService.getGroup(
-			CompanyThreadLocal.getCompanyId(), GroupConstants.GUEST);
+			companyId, GroupConstants.GUEST);
 
-		try (Connection connection = DataAccess.getConnection();
+		String factoryPid = _CONFIGURATION_ID + ".scoped";
 
-			PreparedStatement preparedStatement = connection.prepareStatement(
-				"insert into Configuration_ (configurationId, dictionary) " +
-					"values(?, ?)")) {
+		String configurationId =
+			factoryPid + "~" + RandomTestUtil.randomString();
 
-			String factoryPid =
-				_CONFIGURATION_ID + "~" + RandomTestUtil.randomString();
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.configuration.admin.web.internal.configuration." +
+					"persistence.listener." +
+						"ConfigurationImportGlobalConfigurationModelListener",
+				LoggerTestUtil.ERROR)) {
 
-			preparedStatement.setString(1, factoryPid);
-			preparedStatement.setString(
-				2,
-				_toString(
-					HashMapDictionaryBuilder.<String, Object>put(
-						"groupId", group.getGroupId()
-					).put(
-						"key", "value"
-					).put(
-						"service.factoryPid", factoryPid
-					).put(
-						"service.pid", _CONFIGURATION_ID + ".scoped"
-					).build()));
-
-			preparedStatement.execute();
+			_persistenceManager.store(
+				configurationId,
+				HashMapDictionaryBuilder.<String, Object>put(
+					"groupId", group.getGroupId()
+				).put(
+					"key", "value"
+				).put(
+					"service.factoryPid", factoryPid
+				).put(
+					"service.pid", configurationId
+				).build());
 		}
+
+		_configurationIds.put(companyId, configurationId);
 	}
 
 	private void _deleteConfiguration() throws IOException, SQLException {
+		String configurationId = _configurationIds.remove(
+			CompanyThreadLocal.getCompanyId());
+
+		if (configurationId != null) {
+			_persistenceManager.delete(configurationId);
+		}
+
 		DB db = DBManagerUtil.getDB();
 
 		db.runSQL(
@@ -218,18 +240,6 @@ public class ConfigurationUpgradeProcessTest {
 		return ConfigurationHandler.read(unsyncByteArrayInputStream);
 	}
 
-	private String _toString(Dictionary<String, Object> dictionary)
-		throws IOException {
-
-		UnsyncByteArrayOutputStream unsyncByteArrayOutputStream =
-			new UnsyncByteArrayOutputStream();
-
-		ConfigurationHandler.write(unsyncByteArrayOutputStream, dictionary);
-
-		return new String(
-			unsyncByteArrayOutputStream.toByteArray(), StandardCharsets.UTF_8);
-	}
-
 	private static final String _CLASS_NAME =
 		"com.liferay.portal.configuration.persistence.internal.upgrade." +
 			"v2_0_1.ConfigurationUpgradeProcess";
@@ -250,7 +260,12 @@ public class ConfigurationUpgradeProcessTest {
 	@Inject
 	private CompanyLocalService _companyLocalService;
 
+	private final Map<Long, String> _configurationIds = new HashMap<>();
+
 	@Inject
 	private GroupLocalService _groupLocalService;
+
+	@Inject
+	private PersistenceManager _persistenceManager;
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93325

## What Is Being Fixed

After an upgrade that runs v2_0_1.ConfigurationUpgradeProcess (e.g. 2025.Q1.20 → 2025.Q1.23), all group/site-scoped configurations render their default values in the UI and through the Settings / ConfigurationProvider APIs for the rest of the upgrade-boot session; a single restart restores them. The Configuration_ table is correct — only the in-memory state is stale.

The upgrade backfills companyId into group-scoped rows with raw SQL (update Configuration_ set dictionary = ?). It never updates ConfigurationAdmin, so the in-memory _dictionaries map populated once at activation keeps the pre-upgrade, companyId-less dictionaries. Because q1.23 group-scope reads require companyId in the filter, the lookup misses, falls back to company/system scope, and renders defaults until the next restart re-reads the corrected rows.

## How It Is Being Fixed

The v2_0_1 upgrade now applies each backfill through ConfigurationAdmin instead of raw SQL: it takes a ConfigurationAdmin reference (as v1_0_3.ConfigurationUpgradeProcess already does) and calls Configuration.update(...) for each group-scoped configuration after adding companyId. This keeps the in-memory _dictionaries map, ConfigurationAdmin's live state, and the database row in sync, and fires ManagedServiceFactory.updated() with the correct companyId, so no restart is needed.

The integration test was extended first to expose the gap: it seeds a group-scoped configuration through the PersistenceManager (populating both the in-memory map and the row) and asserts the in-memory copy carries companyId after the upgrade — which failed before the fix and passes after.