### PR TITLE
LPD-83291 Support an accessible icon-only Feature Indicator variant

### DIFF
--- a/modules/apps/frontend-js/frontend-js-components-sample-web/src/main/resources/META-INF/resources/js/FeatureIndicatorSamples.js
+++ b/modules/apps/frontend-js/frontend-js-components-sample-web/src/main/resources/META-INF/resources/js/FeatureIndicatorSamples.js
@@ -77,6 +77,37 @@ export default function FeatureIndicatorSamples({learnResourceContext}) {
 					<FeatureIndicator type="deprecated" />
 				</ClayLayout.Col>
 			</ClayLayout.Row>
+
+			<ClayLayout.Row className="p-3">
+				<ClayLayout.Col>
+					<h3>Beta Icon Only Interactive</h3>
+
+					<FeatureIndicator
+						iconOnly
+						interactive
+						learnResourceContext={learnResourceContext}
+						type="beta"
+					/>
+				</ClayLayout.Col>
+
+				<ClayLayout.Col>
+					<h3>Beta Icon Only</h3>
+
+					<FeatureIndicator iconOnly type="beta" />
+				</ClayLayout.Col>
+
+				<ClayLayout.Col>
+					<h3>Deprecated Icon Only</h3>
+
+					<FeatureIndicator iconOnly type="deprecated" />
+				</ClayLayout.Col>
+
+				<ClayLayout.Col>
+					<h3>Maintenance Icon Only</h3>
+
+					<FeatureIndicator iconOnly type="maintenance" />
+				</ClayLayout.Col>
+			</ClayLayout.Row>
 		</>
 	);
 }

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/feature_indicator/FeatureIndicator.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/feature_indicator/FeatureIndicator.tsx
@@ -180,14 +180,28 @@ export default function FeatureIndicator({
 						) : null}
 					</ClayPopover>
 				</ClayTooltipProvider>
+			) : iconOnly ? (
+				<span
+					aria-label={label}
+					className={classNames(
+						'badge',
+						`badge-${displayType}`,
+						'badge-translucent',
+						className,
+						{'clay-dark': dark}
+					)}
+					role="img"
+				>
+					<span className="badge-item">
+						<ClayIcon symbol={symbol} />
+					</span>
+				</span>
 			) : (
 				<ClayBadge
-					aria-label={iconOnly ? label : undefined}
 					className={classNames('text-uppercase', className)}
 					dark={dark}
 					displayType={displayType}
-					label={iconOnly ? undefined : label}
-					role={iconOnly ? 'img' : undefined}
+					label={label}
 					symbol={symbol}
 					translucent
 				/>

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/feature_indicator/FeatureIndicator.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/feature_indicator/FeatureIndicator.tsx
@@ -134,6 +134,7 @@ export default function FeatureIndicator({
 								dark={dark}
 								data-tooltip-align={tooltipAlign}
 								displayType={displayType}
+								monospaced={iconOnly}
 								rounded
 								size="xs"
 								title={tooltipTitle}

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/feature_indicator/FeatureIndicator.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/feature_indicator/FeatureIndicator.tsx
@@ -47,6 +47,7 @@ type featureIndicatorProps = (
 ) & {
 	className?: string;
 	dark?: boolean;
+	iconOnly?: boolean;
 	tooltipAlign?: (typeof ALIGN_POSITIONS)[number];
 };
 
@@ -56,6 +57,7 @@ const ENTERPRISE_URL =
 export default function FeatureIndicator({
 	className,
 	dark,
+	iconOnly,
 	interactive,
 	learnResourceContext,
 	tooltipAlign = 'top',
@@ -110,8 +112,6 @@ export default function FeatureIndicator({
 		tooltipTitle = Liferay.Language.get('open-maintenance-mode-definition');
 	}
 
-	const showLabel = type !== 'maintenance';
-
 	return (
 		<LearnResourcesContext.Provider value={learnResourceContext}>
 			{interactive ? (
@@ -129,6 +129,7 @@ export default function FeatureIndicator({
 								aria-controls={ariaControlsId}
 								aria-expanded={show}
 								aria-haspopup="dialog"
+								aria-label={iconOnly ? label : undefined}
 								className={className}
 								dark={dark}
 								data-tooltip-align={tooltipAlign}
@@ -138,7 +139,7 @@ export default function FeatureIndicator({
 								title={tooltipTitle}
 								translucent
 							>
-								{showLabel && (
+								{!iconOnly && (
 									<span className="inline-item text-uppercase">
 										{label}
 									</span>
@@ -147,7 +148,7 @@ export default function FeatureIndicator({
 								{symbol && (
 									<span
 										className={classNames('inline-item', {
-											'inline-item-after ml-2': showLabel,
+											'inline-item-after ml-2': !iconOnly,
 										})}
 									>
 										<ClayIcon symbol={symbol} />
@@ -181,10 +182,12 @@ export default function FeatureIndicator({
 				</ClayTooltipProvider>
 			) : (
 				<ClayBadge
+					aria-label={iconOnly ? label : undefined}
 					className={classNames('text-uppercase', className)}
 					dark={dark}
 					displayType={displayType}
-					label={showLabel ? label : undefined}
+					label={iconOnly ? undefined : label}
+					role={iconOnly ? 'img' : undefined}
 					symbol={symbol}
 					translucent
 				/>

--- a/modules/apps/frontend-js/frontend-js-components-web/test/feature_indicator/FeatureIndicator.test.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/test/feature_indicator/FeatureIndicator.test.tsx
@@ -11,46 +11,77 @@ import '@testing-library/jest-dom';
 import {FeatureIndicator} from '../../src/main/resources/META-INF/resources';
 
 describe('FeatureIndicator', () => {
-	describe('Type: Maintenance', () => {
-		it('does NOT render the text label when type is maintenance', () => {
+	describe('Icon only', () => {
+		it('does NOT render the text label when iconOnly', () => {
 			render(
 				<FeatureIndicator
+					iconOnly
 					interactive={true}
 					learnResourceContext="https://learn.liferay.com/test-url"
-					type="maintenance"
+					type="beta"
 				/>
 			);
 
-			const label = screen.queryByText('maintenance');
-			expect(label).not.toBeInTheDocument();
+			expect(screen.queryByText('beta')).not.toBeInTheDocument();
 		});
 
-		it('renders the info icon when type is maintenance', () => {
+		it('still renders the icon when iconOnly', () => {
 			const {container} = render(
-				<FeatureIndicator
-					interactive={true}
-					learnResourceContext="https://learn.liferay.com/test-url"
-					type="maintenance"
-				/>
+				<FeatureIndicator iconOnly type="beta" />
 			);
 
-			const icon = container.querySelector(
-				'svg.lexicon-icon-info-circle-open'
-			);
-			expect(icon).toBeInTheDocument();
+			expect(
+				container.querySelector('svg.lexicon-icon-info-circle-open')
+			).toBeInTheDocument();
 		});
 
-		it('does NOT have "inline-item-after" class on the icon span when maintenance', () => {
+		it('does NOT have "inline-item-after" class on the icon span when iconOnly', () => {
 			const {container} = render(
 				<FeatureIndicator
+					iconOnly
 					interactive={true}
 					learnResourceContext="https://learn.liferay.com/test-url"
-					type="maintenance"
+					type="beta"
 				/>
 			);
 
-			const iconSpan = container.querySelector('.inline-item');
-			expect(iconSpan).not.toHaveClass('inline-item-after');
+			expect(container.querySelector('.inline-item')).not.toHaveClass(
+				'inline-item-after'
+			);
+		});
+
+		it('exposes an accessible name on the non-interactive icon-only badge', () => {
+			const {container} = render(
+				<FeatureIndicator iconOnly type="beta" />
+			);
+
+			const badge = container.querySelector('.badge[role="img"]');
+
+			expect(badge).toBeInTheDocument();
+			expect(badge).toHaveAttribute('aria-label', 'beta');
+		});
+
+		it('exposes an accessible name on the interactive icon-only button', () => {
+			render(
+				<FeatureIndicator
+					iconOnly
+					interactive={true}
+					learnResourceContext="https://learn.liferay.com/test-url"
+					type="beta"
+				/>
+			);
+
+			expect(
+				screen.getByRole('button', {name: 'beta'})
+			).toBeInTheDocument();
+		});
+	});
+
+	describe('Type: Maintenance', () => {
+		it('renders the text label when not iconOnly', () => {
+			render(<FeatureIndicator type="maintenance" />);
+
+			expect(screen.getByText('maintenance')).toBeInTheDocument();
 		});
 	});
 
@@ -65,6 +96,7 @@ describe('FeatureIndicator', () => {
 			);
 
 			const label = screen.getByText('beta');
+
 			expect(label).toBeInTheDocument();
 			expect(label).toHaveClass('inline-item');
 		});
@@ -78,8 +110,23 @@ describe('FeatureIndicator', () => {
 				/>
 			);
 
-			const iconSpan = container.querySelector('span.inline-item-after');
-			expect(iconSpan).toBeInTheDocument();
+			expect(
+				container.querySelector('span.inline-item-after')
+			).toBeInTheDocument();
+		});
+
+		it('does NOT set a redundant aria-label when the label is visible', () => {
+			render(
+				<FeatureIndicator
+					interactive={true}
+					learnResourceContext="https://learn.liferay.com/test-url"
+					type="beta"
+				/>
+			);
+
+			expect(screen.getByRole('button')).not.toHaveAttribute(
+				'aria-label'
+			);
 		});
 	});
 
@@ -89,21 +136,19 @@ describe('FeatureIndicator', () => {
 				<FeatureIndicator
 					interactive={true}
 					learnResourceContext="https://learn.liferay.com/test-url"
-					type="maintenance"
+					type="beta"
 				/>
 			);
 
-			const button = screen.getByRole('button');
-			expect(button).toBeInTheDocument();
+			expect(screen.getByRole('button')).toBeInTheDocument();
 		});
 
 		it('renders a badge when interactive is false', () => {
 			const {container} = render(
-				<FeatureIndicator interactive={false} type="maintenance" />
+				<FeatureIndicator interactive={false} type="beta" />
 			);
 
-			const badge = container.querySelector('.badge');
-			expect(badge).toBeInTheDocument();
+			expect(container.querySelector('.badge')).toBeInTheDocument();
 		});
 	});
 });

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/FeatureIndicatorTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/FeatureIndicatorTag.java
@@ -20,6 +20,10 @@ public class FeatureIndicatorTag extends IncludeTag {
 		return _dark;
 	}
 
+	public boolean getIconOnly() {
+		return _iconOnly;
+	}
+
 	public boolean getInteractive() {
 		return _interactive;
 	}
@@ -34,6 +38,10 @@ public class FeatureIndicatorTag extends IncludeTag {
 
 	public void setDark(boolean dark) {
 		_dark = dark;
+	}
+
+	public void setIconOnly(boolean iconOnly) {
+		_iconOnly = iconOnly;
 	}
 
 	public void setInteractive(boolean interactive) {
@@ -60,6 +68,7 @@ public class FeatureIndicatorTag extends IncludeTag {
 		super.cleanUp();
 
 		_dark = false;
+		_iconOnly = false;
 		_interactive = false;
 		_tooltipAlign = null;
 		_type = null;
@@ -75,6 +84,8 @@ public class FeatureIndicatorTag extends IncludeTag {
 		httpServletRequest.setAttribute(
 			"liferay-frontend:feature-indicator:dark", _dark);
 		httpServletRequest.setAttribute(
+			"liferay-frontend:feature-indicator:iconOnly", _iconOnly);
+		httpServletRequest.setAttribute(
 			"liferay-frontend:feature-indicator:interactive", _interactive);
 		httpServletRequest.setAttribute(
 			"liferay-frontend:feature-indicator:tooltipAlign", _tooltipAlign);
@@ -85,6 +96,7 @@ public class FeatureIndicatorTag extends IncludeTag {
 	private static final String _PAGE = "/feature_indicator/page.jsp";
 
 	private boolean _dark;
+	private boolean _iconOnly;
 	private boolean _interactive;
 	private String _tooltipAlign;
 	private String _type;

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/liferay-frontend.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/liferay-frontend.tld
@@ -400,6 +400,12 @@
 			<type>boolean</type>
 		</attribute>
 		<attribute>
+			<name>iconOnly</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+			<type>boolean</type>
+		</attribute>
+		<attribute>
 			<name>interactive</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/feature_indicator/page.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/feature_indicator/page.jsp
@@ -9,6 +9,7 @@
 
 <%
 boolean dark = GetterUtil.getBoolean(request.getAttribute("liferay-frontend:feature-indicator:dark"));
+boolean iconOnly = GetterUtil.getBoolean(request.getAttribute("liferay-frontend:feature-indicator:iconOnly"));
 boolean interactive = GetterUtil.getBoolean(request.getAttribute("liferay-frontend:feature-indicator:interactive"));
 String tooltipAlign = (String)request.getAttribute("liferay-frontend:feature-indicator:tooltipAlign");
 String type = (String)request.getAttribute("liferay-frontend:feature-indicator:type");
@@ -20,6 +21,8 @@ String type = (String)request.getAttribute("liferay-frontend:feature-indicator:t
 		props='<%=
 			HashMapBuilder.<String, Object>put(
 				"dark", dark
+			).put(
+				"iconOnly", iconOnly
 			).put(
 				"interactive", interactive
 			).put(

--- a/modules/apps/product-navigation/product-navigation-control-menu-api/src/main/java/com/liferay/product/navigation/control/menu/BaseInfoMessageProductNavigationControlMenuEntry.java
+++ b/modules/apps/product-navigation/product-navigation-control-menu-api/src/main/java/com/liferay/product/navigation/control/menu/BaseInfoMessageProductNavigationControlMenuEntry.java
@@ -10,6 +10,7 @@ import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.product.navigation.control.menu.constants.InfoMessageProductNavigationControlMenuEntryTypeConstants;
 import com.liferay.taglib.servlet.PageContextFactoryUtil;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -46,6 +47,11 @@ public abstract class BaseInfoMessageProductNavigationControlMenuEntry
 		FeatureIndicatorTag featureIndicatorTag = new FeatureIndicatorTag();
 
 		featureIndicatorTag.setDark(isDark());
+		featureIndicatorTag.setIconOnly(
+			Objects.equals(
+				getType(),
+				InfoMessageProductNavigationControlMenuEntryTypeConstants.
+					MAINTENANCE));
 		featureIndicatorTag.setInteractive(true);
 		featureIndicatorTag.setPageContext(
 			PageContextFactoryUtil.create(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-83291

## What Is Being Fixed

The Feature Indicator only rendered icon-only as a hardcoded exception for the `maintenance` type, and that icon-only rendering had no accessible name — screen readers announced nothing for the non-interactive badge, and the interactive button tripped Clay's icon-only accessibility warning. There was also no way to request icon-only for any other type, or from JSP consumers.

## How It Is Being Fixed

Introduces an opt-in `iconOnly` prop on the Feature Indicator so any type can render without its text label, and gives the icon-only control a proper accessible name (`aria-label` plus `role="img"` on the badge, `aria-label` on the interactive button). The hardcoded `maintenance` exception is replaced by this unified prop. The option is exposed through the JSP taglib (tag attribute, TLD, and page) so server-side consumers can use it, and the maintenance info-message control menu entry now passes `iconOnly` so the existing icon-only flag is preserved. A sample and unit tests cover the new behavior.