### PR TITLE
LPD-93497 Keep the length input unit picker in sync with the selected unit

### DIFF
--- a/modules/apps/layout/layout-js-components-web/src/main/resources/META-INF/resources/js/components/length_input/LengthInput.tsx
+++ b/modules/apps/layout/layout-js-components-web/src/main/resources/META-INF/resources/js/components/length_input/LengthInput.tsx
@@ -331,11 +331,11 @@ const LengthInput = forwardRef<LengthInputRef, Props>(
 
 					<Picker
 						as={TriggerButton}
-						defaultSelectedKey={defaultUnit || UNITS[0]}
 						defaultUnit={defaultUnit}
 						disabled={Boolean(defaultUnit)}
 						items={[...UNITS]}
 						onSelectionChange={(unit) => onSelectUnit(unit as Unit)}
+						selectedKey={defaultUnit || unit}
 						unit={unit}
 					>
 						{(item) => (


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93497

## What Is Being Fixed

In the Style Book editor's token fields (and the page editor's length/spacing fields), the unit picker fell out of sync with the value. After switching a token's unit to CUSTOM and typing a value with a unit such as `8px`, the value was recognized and the picker's button displayed the resolved unit (`PX`), but the picker itself still had CUSTOM marked as selected. Reopening the picker showed CUSTOM selected, and because the selected option is non-interactive, CUSTOM could not be chosen again.

## How It Is Being Fixed

The `LengthInput` picker was uncontrolled — it received only `defaultSelectedKey`, so its selection was set once and never resynced to the component's actual `unit` state. The fix makes the picker controlled by passing `selectedKey` derived from the live `unit` (which is already kept current through `onSelectionChange` to `onSelectUnit` to `setUnit`). The picker now always reflects the unit shown on the button, so once a custom value resolves it highlights the resolved unit instead of CUSTOM, and every unit, including CUSTOM, can be selected again.

## Why Are There No Tests?

The behavior is already covered by the existing Playwright test `styleBookEditorTokenInput.spec.ts` ("A token with a custom unit identifies the unit from the input"), which switches a token to CUSTOM and re-selects it across units; that flow only passes when the picker stays in sync.
