### PR TITLE
LPD-93554 Fix Space and Category filters in the CMS item selector

### DIFF
--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/getCMSItemSelectorFilters.ts
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/getCMSItemSelectorFilters.ts
@@ -15,7 +15,7 @@ export function getCMSItemSelectorFilters(
 	return [
 		{
 			apiURL: "/o/headless-asset-library/v1.0/asset-libraries?filter=type eq 'Space'",
-			entityFieldType: EEntityFieldType.COLLECTION,
+			entityFieldType: EEntityFieldType.COLLECTION_INTEGER,
 			id: 'groupIds',
 			itemKey: 'siteId',
 			itemLabel: 'name',
@@ -35,7 +35,7 @@ export function getCMSItemSelectorFilters(
 		},
 		{
 			apiURL: `/o/headless-admin-taxonomy/v1.0/sites/${groupId}/taxonomy-categories`,
-			entityFieldType: EEntityFieldType.COLLECTION,
+			entityFieldType: EEntityFieldType.COLLECTION_INTEGER,
 			id: 'taxonomyCategoryIds',
 			itemKey: 'id',
 			itemLabel: 'name',
@@ -45,7 +45,7 @@ export function getCMSItemSelectorFilters(
 		},
 		{
 			apiURL: `/o/headless-admin-taxonomy/v1.0/sites/${groupId}/keywords`,
-			entityFieldType: EEntityFieldType.COLLECTION,
+			entityFieldType: EEntityFieldType.COLLECTION_STRING,
 			id: 'keywords',
 			itemKey: 'name',
 			itemLabel: 'name',

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/types.ts
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/item_selector/types.ts
@@ -7,6 +7,8 @@ import {IItemSelectorModalProps} from './ItemSelectorModal';
 
 export enum EEntityFieldType {
 	COLLECTION = 'collection',
+	COLLECTION_INTEGER = 'collection-integer',
+	COLLECTION_STRING = 'collection-string',
 	DATE = 'date',
 	DATE_TIME = 'date-time',
 	INTEGER = 'integer',

--- a/modules/apps/frontend-js/frontend-js-item-selector-web/test/getCMSItemSelectorFilters.test.ts
+++ b/modules/apps/frontend-js/frontend-js-item-selector-web/test/getCMSItemSelectorFilters.test.ts
@@ -46,6 +46,9 @@ describe('getCMSItemSelectorFilters', () => {
 		) as ISelectionFilterConfig;
 
 		expect(spaceFilter?.apiURL).toContain("filter=type eq 'Space'");
+		expect(spaceFilter?.entityFieldType).toBe(
+			EEntityFieldType.COLLECTION_INTEGER
+		);
 
 		const typeFilter = filters.find(
 			(f) => f.id === 'objectDefinitionExternalReferenceCode'
@@ -61,7 +64,14 @@ describe('getCMSItemSelectorFilters', () => {
 			(f) => f.id === 'taxonomyCategoryIds'
 		) as ISelectionFilterConfig;
 		expect(categoryFilter?.entityFieldType).toBe(
-			EEntityFieldType.COLLECTION
+			EEntityFieldType.COLLECTION_INTEGER
+		);
+
+		const tagsFilter = filters.find(
+			(f) => f.id === 'keywords'
+		) as ISelectionFilterConfig;
+		expect(tagsFilter?.entityFieldType).toBe(
+			EEntityFieldType.COLLECTION_STRING
 		);
 
 		const authorFilter = filters.find(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93554

## What Is Being Fixed

The Space and Category filters in the CMS file item selector stopped working: applying either one sent a malformed request to /o/search/v1.0/search and returned HTTP 400, leaving the previously loaded (unfiltered) results on screen. This affects every surface that opens the CMS file item selector — the CKEditor "insert CMS file" flow, the fragment file-upload input, the object Attachment form field, and DSR document selection — and is what broke the itemSelectorModalForCMS.spec.ts "Space filter functionality" test.

The regression came from LPD-92485 (commit 2a1e413), which routed the ambiguous bare COLLECTION entity field type through the string-quoting branch of the data set filter's OData serializer. The CMS item selector declared its Space (groupIds) and Category (taxonomyCategoryIds) filters as bare COLLECTION with integer values, so their ids were quoted as strings (groupIds/any(x:(x eq '38016'))) and rejected against the integer search field. The CMS "Contents" admin view was unaffected because it declares those filters server-side as COLLECTION_INTEGER.

## How It Is Being Fixed

The CMS item selector filters now declare their precise types instead of the ambiguous COLLECTION: Space and Category use COLLECTION_INTEGER, and Tags (keywords) uses COLLECTION_STRING. This mirrors how the CMS Contents view already declares the same filters and produces unquoted integer predicates the search endpoint accepts. The item selector's local EEntityFieldType enum gained the COLLECTION_INTEGER and COLLECTION_STRING members (with string values matching the data set module it feeds), and the unit test now asserts the entity field type of the Space, Category, and Tags filters so the regression cannot recur silently. The shared SelectionFilter serializer is intentionally left untouched.