### PR TITLE
LPD-93647 Fix the missing Control Panel side navigation divider

### DIFF
--- a/modules/apps/application-list/application-list-taglib/src/main/resources/META-INF/resources/css/side_navigation.scss
+++ b/modules/apps/application-list/application-list-taglib/src/main/resources/META-INF/resources/css/side_navigation.scss
@@ -1,19 +1,23 @@
-@import 'cadmin-variables';
+@import 'atlas-custom-properties/_variables';
 
 .side-navigation-container {
 	--skeleton-shimmer-color: 247, 248, 249;
 
 	input:not(:focus-within) {
-		background-image: clay-icon(search, $cadmin-secondary);
+		background-image: clay-icon(search, #6b6c7e);
 		background-position: 15px;
 		background-repeat: no-repeat;
 		background-size: 16px;
 		padding-left: 40px;
+
+		@media (prefers-color-scheme: dark) {
+			background-image: clay-icon(search, #a2a2b9);
+		}
 	}
 
 	.c-slideout-start .sidebar-light {
-		background-color: $cadmin-light-l1;
-		border-right: 0.5px solid $cadmin-secondary-l0;
+		background-color: $light-l1;
+		border-right: 0.5px solid $secondary-l0;
 		box-shadow: none;
 
 		&.skeleton {

--- a/modules/test/playwright/tests/application-list-taglib/main/sideNavigation.spec.ts
+++ b/modules/test/playwright/tests/application-list-taglib/main/sideNavigation.spec.ts
@@ -211,6 +211,39 @@ test(
 );
 
 test(
+	'The side navigation shows a visible divider separating it from the content',
+	{tag: '@LPD-93647'},
+	async ({globalMenuPage, page}) => {
+		await test.step('Go to an Applications Panel page', async () => {
+			await globalMenuPage.goToApplications();
+
+			await expect(
+				page.getByLabel('Applications Menu', {exact: true})
+			).toBeVisible();
+		});
+
+		await test.step('Assert the divider border is actually rendered', async () => {
+			const {borderRightColor, borderRightStyle, borderRightWidth} =
+				await page.getByTestId('sideNavigation').evaluate((element) => {
+					const computedStyle = window.getComputedStyle(element);
+
+					return {
+						borderRightColor: computedStyle.borderRightColor,
+						borderRightStyle: computedStyle.borderRightStyle,
+						borderRightWidth: computedStyle.borderRightWidth,
+					};
+				});
+
+			expect(borderRightStyle).toBe('solid');
+
+			expect(parseFloat(borderRightWidth)).toBeGreaterThan(0);
+
+			expect(borderRightColor).not.toBe('rgba(0, 0, 0, 0)');
+		});
+	}
+);
+
+test(
 	'Side navigation remains visible after Liferay.Portlet.refresh call',
 	{tag: '@LPD-86410'},
 	async ({contentDashboardPage, page, site}) => {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93647

## What Is Being Fixed

The grey divider line that separates the Control Panel's side navigation from the page content was not visible.

## How It Is Being Fixed

The side navigation is a Clay `SidePanel`/`c-slideout` component that renders outside any `.cadmin` scope, yet its styles referenced cadmin color variables (`$cadmin-secondary-l0`, `$cadmin-light-l1`, `$cadmin-secondary`). Since `LPD-85958` those compile to `.cadmin`-scoped `var(--cadmin-*)` custom properties, so outside that scope they resolve to nothing and the `border-right` shorthand becomes invalid — `border-style` falls back to `none` and the divider disappears. Instead of scoping the component as cadmin (which pulls in Clay's cadmin sidebar component styles and breaks the header layout and the slideout push), `side_navigation.scss` now imports `atlas-custom-properties/_variables` and uses the atlas equivalents (`$secondary-l0`, `$light-l1`, `$secondary`), which the admin theme emits globally at `:root`, so they resolve everywhere and stay theme-responsive. This restores the divider without affecting the slideout push or the header.
