### PR TITLE
LPD-93570 Convert hardcoded colors to Clay for Dark mode integration

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/styles/_management_bar.scss
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/styles/_management_bar.scss
@@ -14,7 +14,7 @@
 		}
 
 		& + .management-bar {
-			border-top: 1px solid #eee;
+			border-top: 1px solid $border-color;
 			min-height: 3.5rem;
 		}
 	}

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/styles/_modal.scss
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/styles/_modal.scss
@@ -4,7 +4,7 @@
 
 		.loader-container {
 			align-items: center;
-			background: white;
+			background: $white;
 			bottom: 0;
 			display: flex;
 			left: 0;

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/styles/_side_panel.scss
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/styles/_side_panel.scss
@@ -1,7 +1,7 @@
 .fds-side-panel {
-	background-color: #f1f2f5;
+	background-color: $gray-200;
 	bottom: 0;
-	box-shadow: 0 0 0 rgba(39, 40, 51, 0.15);
+	box-shadow: 0 0 0 unquote('hsl(from #{$gray-900} h s l / 0.15)');
 	position: fixed;
 	right: 0;
 	top: 0;
@@ -16,8 +16,8 @@
 
 	.fds-side-panel-header {
 		align-items: center;
-		background: #f7f7f7;
-		border-bottom: 1px solid #e7e7ed;
+		background: $gray-100;
+		border-bottom: 1px solid $border-color;
 		display: flex;
 		height: 65px;
 		justify-content: space-between;
@@ -63,7 +63,8 @@
 	}
 
 	&.is-visible {
-		box-shadow: -10px 20px 30px rgba(39, 40, 51, 0.15);
+		box-shadow: -10px 20px 30px
+			unquote('hsl(from #{$gray-900} h s l / 0.15)');
 		transform: translateX(0);
 		visibility: visible;
 	}
@@ -93,7 +94,7 @@
 	}
 
 	.nav {
-		border-bottom: 1px solid #dddee7;
+		border-bottom: 1px solid $border-color;
 	}
 
 	.fds-side-menu {
@@ -139,7 +140,7 @@
 }
 
 .fds-side-panel-nav-cover {
-	background: white;
+	background: $white;
 	left: 0;
 	opacity: 0;
 	position: fixed;

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/styles/_variables.scss
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/styles/_variables.scss
@@ -1,34 +1,31 @@
-@import 'atlas-variables';
+@import 'atlas-custom-properties/variables';
 
 // Colors
 
-$border-color: #e7e7ed;
+$border-color: $gray-300;
 
-$danger-primary: #da1414;
-$danger-secondary: #f48989;
+$danger-primary: $danger;
+$danger-secondary: $danger-l1;
 
-$error-l1: lighten($danger-primary, 28%);
+$error-l1: $danger-l1;
 
-$gray-200: #f1f2f5;
-$gray-600: #6b6c7e;
+$info-bc: $info-l2;
+$info-primary: $info;
+$info-secondary: $info-l1;
 
-$info-bc: #eef2fa;
-$info-primary: #2e5aac;
-$info-secondary: #89a7e0;
-
-$primary-color: #0b5fff;
+$primary-color: $primary;
 
 $secondary-text: $gray-600;
 
-$step-tracker-active: #6b6c7e;
+$step-tracker-active: $gray-600;
 $step-tracker-completed: #6fcf97;
-$step-tracker-inactive: #cdced9;
+$step-tracker-inactive: $gray-400;
 
-$success-primary: #287d3d;
-$success-secondary: #5aca76;
+$success-primary: $success;
+$success-secondary: $success-l1;
 
-$warning-primary: #863a00;
-$warning-secondary: #ff8f39;
+$warning-primary: $warning-d2;
+$warning-secondary: $warning-l1;
 
 // Drop
 

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/styles/views/_cards.scss
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/styles/views/_cards.scss
@@ -23,7 +23,7 @@
 
 		&.active {
 			&:hover .card {
-				background-color: #d6e4ff;
+				background-color: $primary-l2;
 			}
 
 			.card {

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/styles/views/_list.scss
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/styles/views/_list.scss
@@ -10,7 +10,7 @@
 			background-color: $primary-l3;
 
 			&:hover {
-				background-color: #d6e4ff;
+				background-color: $primary-l2;
 			}
 		}
 	}

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/styles/views/_table.scss
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/styles/views/_table.scss
@@ -19,7 +19,7 @@
 			tbody
 			tr:hover:not(.table-disabled):not(.table-divider) {
 			&.table-active td {
-				background-color: #d6e4ff;
+				background-color: $primary-l2;
 			}
 
 			td {
@@ -83,7 +83,7 @@
 }
 
 .tooltip-table {
-	color: white;
+	color: $white;
 	font-weight: 600;
 	width: 100%;
 
@@ -91,7 +91,7 @@
 		border: none;
 
 		&:first-child {
-			color: darken(white, 10%);
+			color: unquote('hsl(from #{$white} h s calc(l - 10%))');
 			text-align: left;
 		}
 
@@ -105,7 +105,7 @@
 		position: relative;
 
 		&::after {
-			border-top: 1px solid rgba(255, 255, 255, 0.1);
+			border-top: 1px solid unquote('hsl(from #{$white} h s l / 0.1)');
 			content: '';
 			left: 0;
 			position: absolute;

--- a/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/BuilderScreen/BuilderListItem.scss
+++ b/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/BuilderScreen/BuilderListItem.scss
@@ -1,10 +1,12 @@
+@import 'atlas-custom-properties/_variables';
+
 .lfr-object {
 	&__object-custom-view-builder-item {
 		&--dragging {
 			background: transparent;
-			background-color: #f7f8f9;
+			background-color: $gray-100;
 			border-radius: 0;
-			box-shadow: 0 0 0 0.125rem #80acff;
+			box-shadow: 0 0 0 0.125rem $primary-l1;
 			cursor: grabbing;
 			margin-bottom: 5px;
 			margin-top: 5px;

--- a/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/Card.scss
+++ b/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/Card.scss
@@ -1,4 +1,4 @@
-@import 'atlas-variables';
+@import 'atlas-custom-properties/_variables';
 
 .lfr-objects__card {
 	background-color: $white;

--- a/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/CodeEditor/CodeMirrorEditor.scss
+++ b/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/CodeEditor/CodeMirrorEditor.scss
@@ -1,4 +1,4 @@
-@import 'atlas-variables';
+@import 'atlas-custom-properties/_variables';
 @import 'cadmin-variables';
 
 html#{$cadmin-selector} .cadmin .lfr-objects__editor,

--- a/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/CodeEditor/Sidebar.scss
+++ b/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/CodeEditor/Sidebar.scss
@@ -1,4 +1,4 @@
-@import 'atlas-variables';
+@import 'atlas-custom-properties/_variables';
 @import 'cadmin-variables';
 
 html#{$cadmin-selector} .cadmin .lfr-objects__code-editor-sidebar,

--- a/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/CodeEditor/index.scss
+++ b/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/CodeEditor/index.scss
@@ -1,4 +1,4 @@
-@import 'atlas-variables';
+@import 'atlas-custom-properties/_variables';
 @import 'cadmin-variables';
 
 html#{$cadmin-selector} .cadmin .lfr-objects__code-editor,

--- a/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/ManagementToolbar/index.scss
+++ b/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/ManagementToolbar/index.scss
@@ -1,3 +1,5 @@
+@import 'atlas-custom-properties/_variables';
+
 .lfr__management-toolbar {
 	position: sticky;
 	width: 100%;
@@ -8,6 +10,7 @@
 	}
 
 	&--box-shadow {
-		box-shadow: 0 0.125rem 0.75rem rgb(0 0 0 / 8%);
+		box-shadow: 0 0.125rem 0.75rem
+			unquote('hsl(from #{$black} h s l / 0.08)');
 	}
 }

--- a/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/Panel/Panel.scss
+++ b/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/Panel/Panel.scss
@@ -1,7 +1,7 @@
-@import 'atlas-variables';
+@import 'atlas-custom-properties/_variables';
 
-$borderColor: #cdced9;
-$bgColor: #fff;
+$borderColor: $gray-400;
+$bgColor: $white;
 
 .object-admin-panel {
 	background-color: $bgColor;

--- a/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/SidePanelContent.scss
+++ b/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/SidePanelContent.scss
@@ -1,4 +1,4 @@
-@import 'atlas-variables';
+@import 'atlas-custom-properties/_variables';
 
 .fds-side-panel-nav-cover {
 	visibility: hidden;

--- a/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/Toggle.scss
+++ b/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/Toggle.scss
@@ -1,4 +1,4 @@
-@import 'atlas-variables';
+@import 'atlas-custom-properties/_variables';
 
 .lfr-objects__toggle {
 	align-items: center;

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/css/main.scss
@@ -1,3 +1,4 @@
+@import 'atlas-custom-properties/_variables';
 @import 'atlas-variables';
 
 @import 'management-toolbar';

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/Layout/LayoutScreen/LayoutScreen.scss
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/Layout/LayoutScreen/LayoutScreen.scss
@@ -1,9 +1,11 @@
-$bgColor: #f7f8f9;
+@import 'atlas-custom-properties/_variables';
+
+$bgColor: $gray-100;
 
 .layout-tab {
 	&__add-tab-btn {
 		background-color: $bgColor;
-		border: 2px dashed #a7a9bc;
+		border: 2px dashed $gray-500;
 		border-radius: 4px;
 		display: grid;
 		margin-bottom: 1.5rem;
@@ -20,7 +22,7 @@ $bgColor: #f7f8f9;
 	}
 
 	&__field {
-		border: 1px solid #e7e7ed;
+		border: 1px solid $gray-300;
 	}
 
 	&__tab {
@@ -28,9 +30,9 @@ $bgColor: #f7f8f9;
 	}
 
 	&__tab-types {
-		border: 1px solid #cdced9;
+		border: 1px solid $gray-400;
 		border-radius: 4px;
-		color: #6b6c7e;
+		color: $gray-600;
 		cursor: pointer;
 		margin-bottom: 1rem;
 		padding: 1rem;
@@ -40,7 +42,7 @@ $bgColor: #f7f8f9;
 		}
 
 		&.active {
-			border: 2px solid #0b5fff;
+			border: 2px solid $primary;
 			color: initial;
 		}
 
@@ -59,8 +61,8 @@ $bgColor: #f7f8f9;
 	display: flex;
 
 	&__btn {
-		background-color: #fff;
-		border: 1px solid #e2e4ea;
+		background-color: $white;
+		border: 1px solid $light-d1;
 		border-radius: 4px;
 		display: flex;
 		flex-direction: row;
@@ -70,26 +72,26 @@ $bgColor: #f7f8f9;
 		width: 80px;
 
 		&:hover {
-			border-color: #ccced4;
+			border-color: $gray-400;
 
 			.box-btn-columns__item {
-				background-color: #ccd0d8;
+				background-color: $gray-400;
 			}
 		}
 
 		&.active,
 		&.active:hover {
-			background-color: #f0f5ff;
-			border-color: #0b5fff;
+			background-color: $primary-l3;
+			border-color: $primary;
 
 			.box-btn-columns__item {
-				background-color: #80acff;
+				background-color: $primary-l1;
 			}
 		}
 	}
 
 	&__item {
-		background-color: #e2e4ea;
+		background-color: $light-d1;
 		border-radius: 4px;
 		height: calc(100% - 8px);
 		margin: 4px;

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModalSelectObjectFields.scss
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModalSelectObjectFields.scss
@@ -1,4 +1,4 @@
-@import 'atlas-variables';
+@import 'atlas-custom-properties/_variables';
 
 .lfr-object__object-view-modal-select-object-fields {
 	&-empty-state {
@@ -19,7 +19,7 @@
 		}
 
 		.list-group-item {
-			background-color: #f7f8f9;
+			background-color: $gray-100;
 			border: 0;
 			padding-left: 16px;
 		}

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/Edges/Edge.scss
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/Edges/Edge.scss
@@ -1,3 +1,5 @@
+@import 'atlas-custom-properties/_variables';
+
 .lfr-objects__model-builder-many-edge-dropdown-item {
 	&-button {
 		align-items: center;
@@ -26,19 +28,19 @@
 	}
 	&.selected {
 		marker {
-			fill: #0b5fff !important;
+			fill: $primary !important;
 		}
 	}
 
 	&.react-flow__edge-treeStructureObjectRelationshipEdge {
 		&.selected {
 			marker {
-				fill: #2e5aac !important;
+				fill: $info !important;
 			}
 		}
 
 		marker {
-			fill: #89a7e0;
+			fill: $info-l1;
 		}
 	}
 
@@ -47,6 +49,6 @@
 	}
 
 	marker {
-		fill: #80acff;
+		fill: $primary-l1;
 	}
 }

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/EditObjectFolderHeader/EditObjectFolderHeader.scss
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/EditObjectFolderHeader/EditObjectFolderHeader.scss
@@ -1,6 +1,8 @@
+@import 'atlas-custom-properties/_variables';
+
 .lfr-objects__model-builder-header {
-	background-color: #fff;
-	border-bottom: 1px solid #f1f2f5;
+	background-color: $white;
+	border-bottom: 1px solid $gray-200;
 	display: flex;
 	justify-content: center;
 	padding: 1rem 0;
@@ -13,7 +15,7 @@
 
 	&-changes-saved {
 		align-items: center;
-		color: #287d3c;
+		color: $success;
 		display: flex;
 		font-size: 14px;
 		font-weight: 600;
@@ -45,12 +47,12 @@
 		}
 
 		&-erc-title {
-			color: #6b6c7e;
+			color: $gray-600;
 		}
 
 		&-label {
-			border-right: solid 1px #cdced9;
-			color: #272833;
+			border-right: solid 1px $gray-400;
+			color: $gray-900;
 			font-size: 18px;
 			font-weight: 600;
 			line-height: 150%;

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/EditObjectFolderHeader/ModalPublishObjectDefinitions.scss
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/EditObjectFolderHeader/ModalPublishObjectDefinitions.scss
@@ -1,3 +1,5 @@
+@import 'atlas-custom-properties/_variables';
+
 .lfr-object__object-view-modal-object-definitions {
 	.container-list {
 		max-height: 350px;
@@ -15,7 +17,7 @@
 		justify-content: space-between;
 
 		&.active {
-			background: #f0f5ff;
+			background: $primary-l3;
 		}
 		> div:first-child {
 			align-items: center;
@@ -23,7 +25,7 @@
 			gap: 20px;
 
 			> svg {
-				background: #fff;
+				background: $white;
 				border-radius: 5px;
 				height: 32px;
 				padding: 8px;

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/EmptyObjectFolderCard/EmptyObjectFolderCard.scss
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/EmptyObjectFolderCard/EmptyObjectFolderCard.scss
@@ -1,3 +1,5 @@
+@import 'atlas-custom-properties/_variables';
+
 .lfr-objects__model-builder-empty-object-folder-card {
 	&-body {
 		align-items: center;
@@ -7,8 +9,8 @@
 	}
 
 	&-container {
-		border: 2px solid #d3d6e0;
-		box-shadow: rgba(100, 100, 111, 0.2) 0 7px 29px 0;
+		border: 2px solid $light-d2;
+		box-shadow: unquote('hsl(from #{$gray-600} h s l / 0.2)') 0 7px 29px 0;
 		left: calc(50% - (17.5rem / 2));
 		max-height: 10.125rem;
 		max-width: 17.5rem;
@@ -18,7 +20,7 @@
 	}
 
 	&-description {
-		color: #6b6c7e;
+		color: $gray-600;
 		font-size: 14px;
 		text-align: center;
 	}

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/LeftSidebar/LeftSidebar.scss
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/LeftSidebar/LeftSidebar.scss
@@ -1,4 +1,4 @@
-@import 'atlas-variables';
+@import 'atlas-custom-properties/_variables';
 
 .lfr-objects__model-builder-left-sidebar {
 	display: flex;
@@ -69,7 +69,7 @@
 	}
 
 	&-item {
-		border: 2.5px solid #80acff;
+		border: 2.5px solid $primary-l1;
 		border-radius: 8px;
 	}
 
@@ -80,7 +80,7 @@
 
 	&-item-linked.treeview-link {
 		background-color: transparent;
-		color: #6b6c7e80;
+		color: unquote('hsl(from #{$secondary} h s l / 0.5)');
 	}
 
 	&-loading {

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/ObjectDefinitionNode/NodeContainer.scss
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/ObjectDefinitionNode/NodeContainer.scss
@@ -1,3 +1,5 @@
+@import 'atlas-custom-properties/_variables';
+
 @mixin nodeAnimation($translateYPx) {
 	transform: translateY($translateYPx);
 	transition:
@@ -8,8 +10,8 @@
 
 .lfr-objects__model-builder-node {
 	&-container {
-		background: #fff;
-		border-color: #d3d6e0;
+		background: $white;
+		border-color: $light-d2;
 		border-radius: 0.25rem;
 		border-style: solid;
 		border-width: 0.125rem;
@@ -18,17 +20,17 @@
 		@include nodeAnimation(4px);
 
 		&:active {
-			border-color: #0b5fff;
+			border-color: $primary;
 			border-width: 0.125rem;
 			cursor: grabbing;
 		}
 
 		&:hover {
-			border-color: #b3cdff;
+			border-color: $primary-l2;
 			border-width: 0.125rem;
 			box-shadow:
-				rgba(17, 17, 26, 0.1) 0 4px 16px,
-				rgba(17, 17, 26, 0.05) 0 8px 32px;
+				unquote('hsl(from #{$dark-d2} h s l / 0.1)') 0 4px 16px,
+				unquote('hsl(from #{$dark-d2} h s l / 0.05)') 0 8px 32px;
 
 			@include nodeAnimation(-4px);
 		}
@@ -38,11 +40,11 @@
 		}
 
 		&--selected {
-			border-color: #0b5fff !important;
+			border-color: $primary !important;
 			border-width: 0.125rem !important;
 			box-shadow:
-				rgba(17, 17, 26, 0.1) 0 4px 16px,
-				rgba(17, 17, 26, 0.05) 0 8px 32px;
+				unquote('hsl(from #{$dark-d2} h s l / 0.1)') 0 4px 16px,
+				unquote('hsl(from #{$dark-d2} h s l / 0.05)') 0 8px 32px;
 			@include nodeAnimation(4px);
 		}
 
@@ -50,7 +52,7 @@
 			padding-left: 1rem;
 
 			&::before {
-				background-color: #2e5aac;
+				background-color: $info;
 				border-bottom-left-radius: 0.15rem;
 				border-top-left-radius: 0.15rem;
 				bottom: 0;

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/ObjectDefinitionNode/ObjectDefinitionNodeFields.scss
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/ObjectDefinitionNode/ObjectDefinitionNodeFields.scss
@@ -1,7 +1,9 @@
+@import 'atlas-custom-properties/_variables';
+
 .lfr-objects__model-builder-node-field {
 	align-items: center;
-	border-top: 1px solid #f1f2f5;
-	color: #6b6c7e;
+	border-top: 1px solid $gray-200;
+	color: $gray-600;
 	cursor: pointer;
 	display: flex;
 	justify-content: space-between;
@@ -15,8 +17,8 @@
 	}
 
 	&:hover {
-		background: #f0f5ff;
-		color: #0b5fff !important;
+		background: $primary-l3;
+		color: $primary !important;
 	}
 
 	&-label {
@@ -30,7 +32,7 @@
 	}
 
 	&--selected {
-		background: #f0f5ff;
-		color: #0b5fff !important;
+		background: $primary-l3;
+		color: $primary !important;
 	}
 }

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/ObjectDefinitionNode/ObjectDefinitionNodeFooter.scss
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/ObjectDefinitionNode/ObjectDefinitionNodeFooter.scss
@@ -1,3 +1,5 @@
+@import 'atlas-custom-properties/_variables';
+
 .lfr-objects__model-builder-node {
 	&-button-container {
 		align-items: center;
@@ -7,7 +9,7 @@
 
 		button {
 			align-items: center;
-			border-color: #cdced9;
+			border-color: $gray-400;
 			display: flex;
 			height: 2rem;
 			justify-content: center;
@@ -27,7 +29,7 @@
 	&-show-all-fields {
 		&-button {
 			align-items: center;
-			color: #6b6c7e;
+			color: $gray-600;
 			cursor: pointer;
 			display: flex;
 			font-size: 12px;
@@ -36,7 +38,7 @@
 			margin-bottom: 0.5rem;
 
 			&:hover {
-				color: #0b5fff !important;
+				color: $primary !important;
 			}
 		}
 

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/ObjectDefinitionNode/ObjectDefinitionNodeHeader.scss
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/ObjectDefinitionNode/ObjectDefinitionNodeHeader.scss
@@ -1,4 +1,4 @@
-@import 'atlas-variables';
+@import 'atlas-custom-properties/_variables';
 
 hr {
 	margin: 6px;
@@ -6,7 +6,7 @@ hr {
 
 .lfr-objects__model-builder-node-header {
 	&-container {
-		background: #f7f8f9;
+		background: $gray-100;
 		border-radius: 0.25rem 0.25rem 0 0;
 		height: 5.3rem;
 		min-width: 17.5rem;

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/RightSidebar/RightSidebarObjectDefinitionDetails.scss
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/RightSidebar/RightSidebarObjectDefinitionDetails.scss
@@ -1,14 +1,16 @@
+@import 'atlas-custom-properties/_variables';
+
 .lfr-objects__model-builder-right-sidebar-object-definition-node {
 	&-details {
 		align-items: center;
-		border-bottom: 1px solid #f1f2f5;
+		border-bottom: 1px solid $gray-200;
 		display: flex;
 		height: 4rem;
 		justify-content: space-between;
 		padding: 1rem;
 
 		&-title {
-			color: #272833;
+			color: $gray-900;
 			font-size: 14px;
 			font-weight: 600;
 			height: 3.3rem;
@@ -35,7 +37,7 @@
 	}
 
 	&-content {
-		border-bottom: 1px solid #f1f2f5;
+		border-bottom: 1px solid $gray-200;
 		padding: 1rem 1rem 0;
 	}
 }

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/RightSidebar/RightSidebarObjectFieldDetails.scss
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/RightSidebar/RightSidebarObjectFieldDetails.scss
@@ -1,14 +1,16 @@
+@import 'atlas-custom-properties/_variables';
+
 .lfr-objects__model-builder-right-sidebar-definition-node {
 	&-content {
-		border-bottom: 1px solid #f1f2f5;
+		border-bottom: 1px solid $gray-200;
 		overflow-x: hidden;
 		padding: 1rem 1rem 0;
 	}
 
 	&-title {
 		align-items: center;
-		border-bottom: 1px solid #f1f2f5;
-		color: #272833;
+		border-bottom: 1px solid $gray-200;
+		color: $gray-900;
 		display: flex;
 		font-size: 16px;
 		font-weight: 600;

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/RightSidebar/RightSidebarObjectRelationshipDetails.scss
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/RightSidebar/RightSidebarObjectRelationshipDetails.scss
@@ -1,10 +1,12 @@
+@import 'atlas-custom-properties/_variables';
+
 .lfr-objects__model-builder-right-sidebar-object-relationship {
 	&-content {
 		padding: 1rem 1rem 1.5rem;
 	}
 
 	&-title {
-		color: #272833;
+		color: $gray-900;
 		font-size: 14px;
 		font-weight: 600;
 		line-height: 21px;
@@ -18,7 +20,7 @@
 
 		&-container {
 			align-items: center;
-			border-bottom: 1px solid #f1f2f5;
+			border-bottom: 1px solid $gray-200;
 			display: flex;
 			height: 4rem;
 			justify-content: space-between;

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectAction/PredefinedValuesTable.scss
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectAction/PredefinedValuesTable.scss
@@ -1,4 +1,4 @@
-@import 'atlas-variables';
+@import 'atlas-custom-properties/_variables';
 
 .lfr-object-web__predefined-values-card {
 	.lfr-objects__card-body {

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectAction/tabs/ActionContainer/CheckboxParameter.scss
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectAction/tabs/ActionContainer/CheckboxParameter.scss
@@ -1,4 +1,4 @@
-@import 'atlas-variables';
+@import 'atlas-custom-properties/_variables';
 
 .lfr-object__action-builder {
 	&-checkbox-parameter-container {

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectDetails/AllowFriendlyURLContainer.scss
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectDetails/AllowFriendlyURLContainer.scss
@@ -1,4 +1,4 @@
-@import 'atlas-variables';
+@import 'atlas-custom-properties/_variables';
 
 .lfr-objects__seo-container {
 	&-allow-friendly-url-container {

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectDetails/ConfigurationContainer.scss
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectDetails/ConfigurationContainer.scss
@@ -1,4 +1,4 @@
-@import 'atlas-variables';
+@import 'atlas-custom-properties/_variables';
 
 .lfr-objects__allow-standalone-entries {
 	align-items: center;

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectDetails/TranslationsContainer.scss
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectDetails/TranslationsContainer.scss
@@ -1,8 +1,10 @@
+@import 'atlas-custom-properties/_variables';
+
 .lfr-objects-translations-container {
 	display: flex;
 	gap: 10px;
 
 	&-tooltip-icon {
-		color: #6b6c7e;
+		color: $gray-600;
 	}
 }

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectField/EditObjectField.scss
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectField/EditObjectField.scss
@@ -1,4 +1,4 @@
-@import 'atlas-variables';
+@import 'atlas-custom-properties/_variables';
 
 .lfr-objects__edit-object-field {
 	background-color: $light;

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectField/Tabs/BasicInfo/TranslationOptionsContainer.scss
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectField/Tabs/BasicInfo/TranslationOptionsContainer.scss
@@ -1,8 +1,10 @@
+@import 'atlas-custom-properties/_variables';
+
 .lfr__objects-translation-options-container {
 	display: flex;
 	gap: 10px;
 
 	&-icon {
-		color: #a7a9bc;
+		color: $gray-500;
 	}
 }

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ViewObjectDefinitions/ViewObjectDefinitions.scss
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ViewObjectDefinitions/ViewObjectDefinitions.scss
@@ -1,4 +1,4 @@
-@import 'atlas-variables';
+@import 'atlas-custom-properties/_variables';
 
 .lfr__object-web-view-object-definitions {
 	display: flex;
@@ -70,5 +70,5 @@
 }
 
 .treeview-light .treeview-link.active {
-	background-color: #f0f5ff;
+	background-color: $primary-l3;
 }

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/object_entries/object_entry/ScheduleContainer.scss
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/object_entries/object_entry/ScheduleContainer.scss
@@ -1,4 +1,4 @@
-@import 'atlas-variables';
+@import 'atlas-custom-properties/_variables';
 
 .lfr-object__entries-schedule-panel {
 	&-content {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93570

## What Is Being Fixed

Hardcoded hex colors throughout the Objects and Frontend Data Set modules prevent Dark mode from rendering correctly. Literal hex values do not respond to Cadmin/Clay theming, so views, modals, sidepanels, and the Model Builder canvas stay in light-mode colors when the dark theme is active.

## How It Is Being Fixed

Replace literal hex values with the corresponding Clay/Atlas variables (`$primary`, `$border-color`, `$gray-*`, `$component-bg`, `$light`, `$dark`, and so on) and reuse existing semantic aliases where the module already defines them. The change spans Frontend Data Set styles (management bar, modal, side panel, cards, list, table) and Objects styles (builder screen, code editor, Model Builder canvas and sidebars, object details, predefined values, schedule container). No markup or runtime-behavior changes — only the values resolved at theme time.

## Why Are There No Tests?

Visual/styling-only change with no behavior change. Swapping hardcoded colors for Clay variables does not introduce or alter any runtime behavior, so unit, integration, and functional tests do not apply.

## PR Check

**pr-check: SKIPPED** — Log4jConfigUtilTest coverage failure exists on master and is unrelated to this SCSS-only branch

<!-- pr-check {"reason": "Log4jConfigUtilTest coverage failure exists on master and is unrelated to this SCSS-only branch", "result": "skipped", "sha": "8d420e822031beb742fd987b4ee1d00ccb6b0e20"} -->