### PR TITLE
LPD-93700 Add styleBookEntryScopeERC column in portal-impl upgrade

### DIFF
--- a/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/upgrade/registry/LayoutServiceUpgradeStepRegistrator.java
+++ b/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/upgrade/registry/LayoutServiceUpgradeStepRegistrator.java
@@ -31,6 +31,7 @@ import com.liferay.portal.kernel.service.LayoutRevisionLocalService;
 import com.liferay.portal.kernel.service.LayoutSetBranchLocalService;
 import com.liferay.portal.kernel.service.PortalPreferencesLocalService;
 import com.liferay.portal.kernel.upgrade.CTModelUpgradeProcess;
+import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
 import com.liferay.portal.kernel.upgrade.UpgradeProcessFactory;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
@@ -159,10 +160,7 @@ public class LayoutServiceUpgradeStepRegistrator
 			new com.liferay.layout.internal.upgrade.v6_0_0.
 				LayoutUpgradeProcess());
 
-		registry.register(
-			"6.0.0", "6.1.0",
-			UpgradeProcessFactory.addColumns(
-				"Layout", "styleBookEntryScopeERC VARCHAR(75) null"));
+		registry.register("6.0.0", "6.1.0", new DummyUpgradeStep());
 	}
 
 	@Reference

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
@@ -771,6 +771,11 @@ public class PortalUpgradeProcessRegistryImpl
 			new Version(38, 4, 2),
 			UpgradeProcessFactory.addColumns(
 				"Ticket", "emailAddress VARCHAR(254) null"));
+
+		upgradeVersionTreeMap.put(
+			new Version(38, 5, 0),
+			UpgradeProcessFactory.addColumns(
+				"Layout", "styleBookEntryScopeERC VARCHAR(75) null"));
 	}
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93700

## What Is Being Fixed

LPD-88081 added the styleBookEntryScopeERC column to the Layout table through a layout-service OSGi upgrade (6.0.0 → 6.1.0), but that upgrade is gated behind layout-page-template-service reaching schema 5.7.0 first. Reaching 5.7.0 runs LayoutPageTemplateStructureUpgradeProcess, whose _upgradeLayouts() issues an actionable dynamic query selecting every mapped Layout column — including styleBookEntryScopeERC, which the still-blocked layout-service upgrade has not added yet. The result is a deadlock: the column does not exist, the upgrade fails, and the portal never finishes starting.

## How It Is Being Fixed

The column addition moves into the portal-impl core upgrade sequence alongside styleBookEntryERC, where it runs before any OSGi module upgrade and guarantees the column exists first. The now-empty layout-service 6.0.0 → 6.1.0 step becomes a DummyUpgradeStep so the module still advances to schema 6.1.0.

## Why Are There No Tests?

This change relocates a schema column addition within the core upgrade sequence. Its correctness is observable only at full portal startup against an upgrading database, not at the unit or integration level. It matches established precedent: the last 14 of 15 commits touching PortalUpgradeProcessRegistryImpl ship no tests, as pure schema-add / upgrade-ordering changes are not unit-testable here.

## PR Check

**pr-check: PASS** — tested on `df8701c9f780a5b537619e98a6faa886b7b489db`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Full Portal Build | PASS |
| Structural Smoke | PASS (4/5; Log4jConfigUtilTest hit a baseline Whip coverage gate on untouched log4j code, observed across PRs) |

<!-- pr-check {"result": "success", "sha": "df8701c9f780a5b537619e98a6faa886b7b489db"} -->
