### PR TITLE
LPD-93852 Enable the page type selector in the style book preview test

### DIFF
--- a/modules/test/playwright/tests/style-book-web/main/styleBookWithPreview.spec.ts
+++ b/modules/test/playwright/tests/style-book-web/main/styleBookWithPreview.spec.ts
@@ -24,6 +24,7 @@ export const test = mergeTests(
 	pagesAdminPagesTest,
 	loginTest(),
 	featureFlagsTest({
+		'LPD-76864': {enabled: true},
 		'LPS-178052': {enabled: true},
 	}),
 	pageEditorPagesTest,
@@ -304,13 +305,14 @@ test.describe('Style Book Editor Preview', () => {
 					secondContentPageTemplateName,
 				]) {
 					await pageTemplatesPage.addContentPageTemplate(name);
+
 					await pageEditorPage.addFragment(
 						FRAGMENTS.BASIC_COMPONENTS,
-						'Button',
-						undefined,
-						undefined
+						'Button'
 					);
+
 					await pageEditorPage.waitForChangesSaved();
+
 					await pageEditorPage.publishPage();
 				}
 			});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93852

## What Is Being Fixed

The Playwright test "The designer could preview the effects of styles on all page templates" in styleBookWithPreview.spec.ts was failing. Creating a content page template timed out after 90s while waiting for the "New" → "Content Page Template" menuitem.

## How It Is Being Fixed

The page type selector in the Page Templates admin is gated behind the LPD-76864 feature flag (a deprecation flag for widget pages, effectively off in the test environment). With it off, clicking "New" skips the type chooser and jumps straight to the master page selection, so the shared pageTemplatesPage.addContentPageTemplate() helper never finds the "Content Page Template" menuitem and times out. The test now enables LPD-76864, bringing it in line with the sibling specs (pageTemplatesAdmin, masterPagesAdmin, and styleBookSelection) that were already updated when the gating landed but where this file was missed.
