### PR TITLE
LPD-93726 Page Editor use atlas-custom-properties and cadmin variables only when selector is qualified by .cadmin

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -89,6 +89,7 @@
         -e '!**/.classpath' \
         -e '!**/.project' \
         -e '!**/.settings' \
+        -e '!**/CLAUDE*.md' \
         -e '!*.*.properties' \
         -e '!.gradle' \
         -e '!.gradle/**/*' \

--- a/modules/apps/adaptive-media/adaptive-media-image-api/src/main/java/com/liferay/adaptive/media/image/optimizer/BaseAMImageOptimizer.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-api/src/main/java/com/liferay/adaptive/media/image/optimizer/BaseAMImageOptimizer.java
@@ -164,8 +164,8 @@ public abstract class BaseAMImageOptimizer implements AMImageOptimizer {
 					configurationEntryUuid, total, successCounter,
 					errorCounter));
 		}
-		catch (PortalException portalException) {
-			_log.error(portalException);
+		catch (Exception exception) {
+			_log.error(exception);
 		}
 	}
 

--- a/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/processor/AMImageAMProcessor.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl/src/main/java/com/liferay/adaptive/media/image/internal/processor/AMImageAMProcessor.java
@@ -89,11 +89,6 @@ public final class AMImageAMProcessor implements AMProcessor<FileVersion> {
 				return;
 			}
 
-			if (amImageEntry != null) {
-				_amImageEntryLocalService.deleteAMImageEntry(
-					amImageEntry.getAmImageEntryId());
-			}
-
 			AMImageScaler amImageScaler =
 				_amImageScalerRegistry.getAMImageScaler(
 					fileVersion.getMimeType());
@@ -108,9 +103,16 @@ public final class AMImageAMProcessor implements AMProcessor<FileVersion> {
 			try (InputStream inputStream =
 					amImageScaledImage.getInputStream()) {
 
+				FileVersion scaledFileVersion = _getScaledFileVersion(
+					amImageScaledImage, fileVersion);
+
+				if (amImageEntry != null) {
+					_amImageEntryLocalService.deleteAMImageEntry(
+						amImageEntry.getAmImageEntryId());
+				}
+
 				_amImageEntryLocalService.addAMImageEntry(
-					amImageConfigurationEntry,
-					_getScaledFileVersion(amImageScaledImage, fileVersion),
+					amImageConfigurationEntry, scaledFileVersion,
 					amImageScaledImage.getHeight(),
 					amImageScaledImage.getWidth(), inputStream,
 					amImageScaledImage.getSize());

--- a/modules/apps/adaptive-media/adaptive-media-image-impl/src/test/java/com/liferay/adaptive/media/image/internal/processor/AMImageProcessorImplTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl/src/test/java/com/liferay/adaptive/media/image/internal/processor/AMImageProcessorImplTest.java
@@ -28,6 +28,7 @@ import java.io.InputStream;
 import java.util.Collections;
 import java.util.Date;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -448,6 +449,72 @@ public class AMImageProcessorImplTest {
 			_amImageConfigurationHelper, Mockito.never()
 		).getAMImageConfigurationEntry(
 			Mockito.anyLong(), Mockito.nullable(String.class)
+		);
+	}
+
+	@Test
+	public void testProcessDoesNotDeleteAMImageEntryWhenScaleFails()
+		throws Exception {
+
+		Mockito.when(
+			_amImageValidator.isProcessingSupported(_fileVersion)
+		).thenReturn(
+			true
+		);
+
+		Mockito.when(
+			_amImageConfigurationHelper.getAMImageConfigurationEntry(
+				Mockito.anyLong(), Mockito.nullable(String.class))
+		).thenReturn(
+			new AMImageConfigurationEntryImpl(
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+				Collections.emptyMap())
+		);
+
+		Mockito.when(
+			_amImageEntryLocalService.fetchAMImageEntry(
+				Mockito.nullable(String.class), Mockito.anyLong())
+		).thenReturn(
+			_amImageEntry
+		);
+
+		Mockito.when(
+			_amImageScalerRegistry.getAMImageScaler(
+				Mockito.nullable(String.class))
+		).thenReturn(
+			_amImageScaler
+		);
+
+		Mockito.doThrow(
+			AMRuntimeException.IOException.class
+		).when(
+			_amImageScaler
+		).scaleImage(
+			Mockito.any(FileVersion.class),
+			Mockito.any(AMImageConfigurationEntry.class)
+		);
+
+		try {
+			_amImageAMProcessor.process(
+				_fileVersion, RandomTestUtil.randomString());
+
+			Assert.fail();
+		}
+		catch (AMRuntimeException.IOException ioException) {
+		}
+
+		Mockito.verify(
+			_amImageEntryLocalService, Mockito.never()
+		).deleteAMImageEntry(
+			Mockito.anyLong()
+		);
+
+		Mockito.verify(
+			_amImageEntryLocalService, Mockito.never()
+		).addAMImageEntry(
+			Mockito.any(AMImageConfigurationEntry.class),
+			Mockito.any(FileVersion.class), Mockito.anyInt(), Mockito.anyInt(),
+			Mockito.any(InputStream.class), Mockito.anyLong()
 		);
 	}
 

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_asset_entry_full_content.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_asset_entry_full_content.jsp
@@ -95,6 +95,7 @@ boolean viewMode = Objects.equals(ParamUtil.getString(PortalUtil.getOriginalServ
 						cssClass="header-back-to lfr-portal-tooltip"
 						href="<%= redirect %>"
 						icon="angle-left"
+						rel="nofollow"
 						title='<%= LanguageUtil.get(request, "back") %>'
 					/>
 				</c:if>

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/js/asset_categories_selector/AssetVocabularyCategoriesSelector.js
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/js/asset_categories_selector/AssetVocabularyCategoriesSelector.js
@@ -184,6 +184,7 @@ function AssetVocabulariesCategoriesSelector({
 					<label
 						className={showVocabularyLabel ? '' : 'sr-only'}
 						htmlFor={inputName + '_MultiSelect'}
+						id={inputName + '_MultiSelectLabel'}
 					>
 						{label}
 
@@ -203,6 +204,11 @@ function AssetVocabulariesCategoriesSelector({
 					<ClayInput.GroupItem>
 						<ClayMultiSelect
 							allowsCustomLabel={false}
+							aria-labelledby={
+								label
+									? inputName + '_MultiSelectLabel'
+									: undefined
+							}
 							clearAllTitle={Liferay.Language.get('clear-all')}
 							id={inputName + '_MultiSelect'}
 							inputName={inputName}

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/js/asset_tags_selector/AssetTagsSelector.js
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/js/asset_tags_selector/AssetTagsSelector.js
@@ -255,6 +255,7 @@ function AssetTagsSelector({
 				<label
 					className={showLabel ? '' : 'sr-only'}
 					htmlFor={inputName + '_MultiSelect'}
+					id={inputName + '_MultiSelectLabel'}
 				>
 					{label}
 				</label>
@@ -267,6 +268,7 @@ function AssetTagsSelector({
 									? `${inputName}_MultiSelectHelpText`
 									: undefined
 							}
+							aria-labelledby={inputName + '_MultiSelectLabel'}
 							clearAllTitle={Liferay.Language.get('clear-all')}
 							id={inputName + '_MultiSelect'}
 							inputName={inputName}

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/js/asset_tags_selector/AssetTagsSelector.js
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/js/asset_tags_selector/AssetTagsSelector.js
@@ -268,7 +268,11 @@ function AssetTagsSelector({
 									? `${inputName}_MultiSelectHelpText`
 									: undefined
 							}
-							aria-labelledby={inputName + '_MultiSelectLabel'}
+							aria-labelledby={
+								label
+									? inputName + '_MultiSelectLabel'
+									: undefined
+							}
 							clearAllTitle={Liferay.Language.get('clear-all')}
 							id={inputName + '_MultiSelect'}
 							inputName={inputName}

--- a/modules/apps/asset/asset-taglib/test/asset_categories_selector/AssetVocabularyCategoriesSelector.js
+++ b/modules/apps/asset/asset-taglib/test/asset_categories_selector/AssetVocabularyCategoriesSelector.js
@@ -16,6 +16,18 @@ const DEFAULT_PROPS = {
 	inputName: '',
 	portletURL: '',
 };
+
+let capturedProps;
+
+jest.mock('@clayui/multi-select', () => ({
+	__esModule: true,
+	default: (props) => {
+		capturedProps = props;
+
+		return null;
+	},
+}));
+
 jest.mock('@clayui/data-provider', () => {
 	const originalModule = jest.requireActual('@clayui/data-provider');
 
@@ -30,11 +42,42 @@ jest.mock('@clayui/data-provider', () => {
 });
 
 describe('AssetVocabularyCategoriesSelector', () => {
+	beforeEach(() => {
+		capturedProps = undefined;
+	});
+
 	it('refetch is not called in the first component render', () => {
 		render(<AssetVocabularyCategoriesSelector {...DEFAULT_PROPS} />);
 
 		const {refetch} = useResource();
 
 		expect(refetch).not.toHaveBeenCalled();
+	});
+
+	it('gives the combobox an accessible name via aria-labelledby', () => {
+		const {container} = render(
+			<AssetVocabularyCategoriesSelector
+				{...DEFAULT_PROPS}
+				inputName="assetCategoryIds_42"
+				label="My Vocabulary"
+			/>
+		);
+
+		const labelId = 'assetCategoryIds_42_MultiSelectLabel';
+
+		expect(capturedProps['aria-labelledby']).toBe(labelId);
+
+		const label = container.querySelector(`#${labelId}`);
+
+		expect(label).toBeInTheDocument();
+		expect(label.tagName).toBe('LABEL');
+		expect(label).toHaveAttribute('for', 'assetCategoryIds_42_MultiSelect');
+		expect(label).toHaveTextContent('My Vocabulary');
+	});
+
+	it('does not set aria-labelledby when there is no label', () => {
+		render(<AssetVocabularyCategoriesSelector {...DEFAULT_PROPS} />);
+
+		expect(capturedProps['aria-labelledby']).toBeUndefined();
 	});
 });

--- a/modules/apps/asset/asset-taglib/test/asset_tags_selector/AssetTagsSelector.js
+++ b/modules/apps/asset/asset-taglib/test/asset_tags_selector/AssetTagsSelector.js
@@ -18,11 +18,13 @@ const DEFAULT_PROPS = {
 	selectedItems: [],
 };
 
+let capturedProps;
 let capturedSourceItems;
 
 jest.mock('@clayui/multi-select', () => ({
 	__esModule: true,
 	default: (props) => {
+		capturedProps = props;
 		capturedSourceItems = props.sourceItems;
 
 		return null;
@@ -44,7 +46,24 @@ const setResource = (resource) =>
 
 describe('AssetTagsSelector', () => {
 	beforeEach(() => {
+		capturedProps = undefined;
 		capturedSourceItems = undefined;
+	});
+
+	it('gives the combobox an accessible name via aria-labelledby', () => {
+		setResource([]);
+
+		const {container} = render(<AssetTagsSelector {...DEFAULT_PROPS} />);
+
+		const labelId = 'tags_MultiSelectLabel';
+
+		expect(capturedProps['aria-labelledby']).toBe(labelId);
+
+		const label = container.querySelector(`#${labelId}`);
+
+		expect(label).toBeInTheDocument();
+		expect(label.tagName).toBe('LABEL');
+		expect(label).toHaveAttribute('for', 'tags_MultiSelect');
 	});
 
 	it('Remove duplicates from the list', () => {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/App.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/App.scss
@@ -1,3 +1,4 @@
+@import 'atlas-custom-properties/_variables';
 @import 'cadmin-variables';
 
 @import 'variables';

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/_AllowedFragments.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/_AllowedFragments.scss
@@ -1,5 +1,3 @@
-@import 'cadmin-variables';
-
 html#{$cadmin-selector} {
 	.cadmin {
 		.page-editor__allowed-fragment__modal {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/_DisabledArea.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/_DisabledArea.scss
@@ -4,7 +4,7 @@ html#{$cadmin-selector} {
 		position: relative;
 
 		&::after {
-			background-color: rgba(255, 255, 255, 0);
+			background-color: unquote('hsl(from #{$white} h s l / 0)');
 			content: '';
 			display: block;
 			height: 100%;
@@ -17,7 +17,7 @@ html#{$cadmin-selector} {
 		}
 
 		&:hover:after {
-			background-color: rgba(255, 255, 255, 0.4);
+			background-color: unquote('hsl(from #{$white} h s l / 0.4)');
 		}
 	}
 }

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/_DisplayPagePreviewItemSelector.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/_DisplayPagePreviewItemSelector.scss
@@ -1,5 +1,3 @@
-@import 'atlas-variables';
-
 html#{$cadmin-selector} {
 	.cadmin {
 		.dropdown-menu-select {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/_DropZone.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/_DropZone.scss
@@ -1,5 +1,3 @@
-@import 'cadmin-variables';
-
 html#{$cadmin-selector} {
 	.cadmin {
 		.page-editor__drop-zone {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/_FormValidationModal.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/_FormValidationModal.scss
@@ -3,10 +3,10 @@ html#{$cadmin-selector} {
 		font-size: 16px;
 
 		.modal-body {
-			color: $cadmin-secondary;
+			color: $secondary;
 
 			.panel-header {
-				border-bottom: 1px solid $cadmin-secondary-l2;
+				border-bottom: 1px solid $secondary-l2;
 				border-radius: 0;
 			}
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/_HTMLEditorModal.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/_HTMLEditorModal.scss
@@ -1,5 +1,3 @@
-@import 'atlas-variables';
-
 html#{$cadmin-selector} {
 	.page-editor__html-editor-modal {
 		&__editor-container {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/_Layout.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/_Layout.scss
@@ -42,7 +42,7 @@ html#{$cadmin-selector} {
 				background-color: $gray-100;
 				box-shadow: inset 0 0 0 1px $primary-l2;
 				color: $gray-500;
-				font-family: $cadmin-font-family-base;
+				font-family: $font-family-base;
 				font-size: 14px;
 				font-weight: 600;
 				margin-top: 0;
@@ -291,7 +291,7 @@ html#{$cadmin-selector} {
 
 			&__message,
 			&__title {
-				font-family: $cadmin-font-family-base;
+				font-family: $font-family-base;
 				text-align: center;
 			}
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/_LayoutBreadcrumbs.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/_LayoutBreadcrumbs.scss
@@ -1,5 +1,3 @@
-@import 'atlas-variables';
-
 $layoutBreadcrumbHeight: 30px;
 $prefix: '.page-editor__layout-breadcrumbs';
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/_LayoutViewport.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/_LayoutViewport.scss
@@ -6,7 +6,7 @@ html#{$cadmin-selector} #{$selector} {
 	position: relative;
 
 	&:not(.page-editor__layout-viewport--size-desktop) {
-		background-color: $cadmin-gray-400;
+		background-color: $gray-400;
 	}
 
 	#{$selector}__resizer {
@@ -82,9 +82,9 @@ html#{$cadmin-selector} #{$selector} {
 		z-index: 1;
 
 		span {
-			background-color: $cadmin-gray-800;
+			background-color: $gray-800;
 			border-radius: 4px;
-			color: $cadmin-light-l2;
+			color: $light-l2;
 			font-size: 14px;
 			font-weight: 600;
 			margin-right: 16px;
@@ -93,19 +93,19 @@ html#{$cadmin-selector} #{$selector} {
 	}
 
 	#{$selector}__handle {
-		background-color: $cadmin-gray-400;
+		background-color: $gray-400;
 		cursor: col-resize;
 		position: relative;
 		width: 16px;
 
 		&:active,
 		&:hover {
-			background-color: $cadmin-gray-500;
+			background-color: $gray-500;
 		}
 
 		&:before,
 		&:after {
-			border: 1px solid $cadmin-secondary;
+			border: 1px solid $secondary;
 			border-radius: 2px;
 			content: '';
 			height: 20px;

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/_NetworkstatusBar.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/_NetworkstatusBar.scss
@@ -1,5 +1,3 @@
-@import 'atlas-variables';
-
 html#{$cadmin-selector} {
 	.cadmin {
 		.page-editor__status-bar {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/fragment_configuration_fields/_AdvancedSelectField.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/fragment_configuration_fields/_AdvancedSelectField.scss
@@ -1,6 +1,3 @@
-@import 'atlas-variables';
-@import 'cadmin-variables';
-
 $prefix: '.page-editor__single-select-with-icon';
 
 html#{$cadmin-selector} .cadmin .page-editor__select-field {
@@ -56,7 +53,7 @@ html#{$cadmin-selector} .cadmin .page-editor__select-field {
 
 	label.page-editor__input-with-icon__label-icon,
 	#{$prefix} label#{$prefix}__label-icon {
-		font-size: $font-size-sm;
+		font-size: $cadmin-font-size-sm;
 	}
 
 	#{$prefix}__select,
@@ -81,6 +78,6 @@ html#{$cadmin-selector} .cadmin .page-editor__select-field {
 	}
 
 	#{$prefix}:focus-within {
-		box-shadow: $btn-focus-box-shadow;
+		box-shadow: $cadmin-btn-focus-box-shadow;
 	}
 }

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/fragment_configuration_fields/_CSSClassSelectorField.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/fragment_configuration_fields/_CSSClassSelectorField.scss
@@ -14,7 +14,7 @@ html#{$cadmin-selector} {
 
 			&:hover .label-item-after,
 			&:focus-within .label-item-after {
-				background: $white;
+				background: $cadmin-white;
 				opacity: 1;
 				right: 4px;
 				top: calc(100% - 16px);

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/fragment_configuration_fields/_CustomCSSField.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/fragment_configuration_fields/_CustomCSSField.scss
@@ -10,7 +10,7 @@ html#{$cadmin-selector} .cadmin .page-editor__custom-css-field {
 	}
 
 	&__editor-modal {
-		border: 1px solid $light-l1;
+		border: 1px solid $cadmin-light-l1;
 	}
 }
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/fragment_content/_FragmentContent.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/fragment_content/_FragmentContent.scss
@@ -21,7 +21,9 @@ html#{$cadmin-selector} {
 
 		.portlet {
 			> .cadmin.portlet-topper {
-				background-color: rgba(255, 255, 255, 0.95);
+				background-color: unquote(
+					'hsl(from #{$cadmin-white} h s l / 0.95)'
+				);
 				border: 1px solid $cadmin-info-l1;
 				border-radius: 3px;
 				height: 100%;
@@ -65,7 +67,7 @@ html#{$cadmin-selector} {
 		}
 
 		.portlet-msg-info {
-			font-family: $cadmin-font-family-base;
+			font-family: $font-family-base;
 		}
 	}
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/keyboard_movement/_KeyboardMovementPreview.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/keyboard_movement/_KeyboardMovementPreview.scss
@@ -1,5 +1,3 @@
-@import 'cadmin-variables';
-
 html#{$cadmin-selector} .cadmin .page-editor__keyboard-movement-preview {
 	left: 0;
 	pointer-events: none;
@@ -12,9 +10,11 @@ html#{$cadmin-selector} .cadmin .page-editor__keyboard-movement-preview {
 		background-color: $cadmin-white;
 		border: 1px solid $cadmin-gray-500;
 		border-radius: 4px;
-		box-shadow: 0 8px 16px rgba(39, 40, 51, 0.16);
+		box-shadow: unquote(
+			'0 8px 16px hsl(from #{$cadmin-gray-900} h s l / 0.16)'
+		);
 		display: flex;
-		font-family: $font-family-base;
+		font-family: $cadmin-font-family-base;
 		font-size: 0.75rem;
 		font-weight: 600;
 		height: 32px;

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/layout_data_items/_RowWithControls.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/layout_data_items/_RowWithControls.scss
@@ -12,7 +12,7 @@ html#{$cadmin-selector} {
 			animation: RowOverlayGridFadeIn ease 0.3s;
 			animation-fill-mode: forwards;
 			background: unquote(
-				'repeating-linear-gradient(to right, #{$cadmin-white}, #{$cadmin-white} 12px, hsl(from #{$cadmin-red} h s l / 0.08) 12px, hsl(from #{$cadmin-red} h s l / 0.08) 13px, #{$cadmin-white} 13px, #{$cadmin-white} 24px, hsl(from #{$cadmin-red} h s l / 0.04) 24px, hsl(from #{$cadmin-red} h s l / 0.04) 8.33%)'
+				'repeating-linear-gradient(to right, #{$white}, #{$white} 12px, hsl(from #{$red} h s l / 0.08) 12px, hsl(from #{$red} h s l / 0.08) 13px, #{$white} 13px, #{$white} 24px, hsl(from #{$red} h s l / 0.04) 24px, hsl(from #{$red} h s l / 0.04) 8.33%)'
 			);
 			background-position: -24px 0;
 			background-size: calc(100% + 24px);
@@ -29,7 +29,7 @@ html#{$cadmin-selector} {
 
 		&.no-gutters:before {
 			background: unquote(
-				'repeating-linear-gradient(to right, hsl(from #{$cadmin-red} h s l / 0.04), hsl(from #{$cadmin-red} h s l / 0.04) 12px, hsl(from #{$cadmin-red} h s l / 0.08) 12px, hsl(from #{$cadmin-red} h s l / 0.08) 13px, hsl(from #{$cadmin-red} h s l / 0.04) 13px, hsl(from #{$cadmin-red} h s l / 0.04) 8.33%)'
+				'repeating-linear-gradient(to right, hsl(from #{$red} h s l / 0.04), hsl(from #{$red} h s l / 0.04) 12px, hsl(from #{$red} h s l / 0.08) 12px, hsl(from #{$red} h s l / 0.08) 13px, hsl(from #{$red} h s l / 0.04) 13px, hsl(from #{$red} h s l / 0.04) 8.33%)'
 			);
 			background-position: -11px 0;
 			background-size: calc(100% + 1px);
@@ -38,7 +38,7 @@ html#{$cadmin-selector} {
 		&__border:after {
 			animation: RowOverlayGridFadeIn ease 0.3s;
 			animation-fill-mode: forwards;
-			border-left: dashed $cadmin-red thin;
+			border-left: dashed $red thin;
 			content: '';
 			left: 0;
 			opacity: 0;

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/topper/_Topper.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/topper/_Topper.scss
@@ -1,5 +1,5 @@
 $borderWidth: 2px;
-$color: $white;
+$color: $cadmin-white;
 $dragOverWidth: 6px;
 $showDuration: 0.15s;
 
@@ -94,7 +94,7 @@ html#{$cadmin-selector} {
 		&:not(.page-editor__col):after,
 		& > .page-editor__col__border:after {
 			box-shadow: unquote(
-				'inset 0 0 0 #{$borderWidth} hsl(from #{$cadmin-primary-l2} h s l / 0)'
+				'inset 0 0 0 #{$borderWidth} hsl(from #{$primary-l2} h s l / 0)'
 			);
 			content: '';
 			display: block;
@@ -126,56 +126,56 @@ html#{$cadmin-selector} {
 		}
 
 		&__content .alert {
-			font-family: $cadmin-font-family-base;
+			font-family: $font-family-base;
 		}
 
 		&.hovered:after {
-			box-shadow: inset 0 0 0 $borderWidth $cadmin-primary-l1;
+			box-shadow: inset 0 0 0 $borderWidth $primary-l1;
 			z-index: $portletTopperHoveredZIndex;
 		}
 
 		&.hovered.not-allowed {
-			color: $cadmin-gray-600;
+			color: $gray-600;
 		}
 
 		&.active:not(.page-editor__col),
 		&.active > .page-editor__col__border,
 		&.highlighted {
-			@include highlighted($cadmin-primary, $borderWidth);
+			@include highlighted($primary, $borderWidth);
 		}
 
 		&.highlighted-from-rule {
 			@include highlighted(
-				unquote('hsl(from #{$cadmin-primary} h s l / 0.5)'),
+				unquote('hsl(from #{$primary} h s l / 0.5)'),
 				4px
 			);
 
 			&:after {
 				background-color: unquote(
-					'hsl(from #{$cadmin-primary-l1} h s l / 0.2)'
+					'hsl(from #{$primary-l1} h s l / 0.2)'
 				);
 			}
 		}
 
 		&.drag-over-bottom:after {
-			border-bottom: $dragOverWidth solid $cadmin-primary-l1;
+			border-bottom: $dragOverWidth solid $primary-l1;
 		}
 
 		// For left and right, we use box-shadow instead of border because border is
 		// automatically inverted in rtl, and we don't want that behavior here
 
 		&.drag-over-left:after {
-			box-shadow: inset $dragOverWidth 0 0 0 $cadmin-primary-l1;
+			box-shadow: inset $dragOverWidth 0 0 0 $primary-l1;
 			transition: none;
 		}
 
 		&.drag-over-right:after {
-			box-shadow: inset (-$dragOverWidth) 0 0 0 $cadmin-primary-l1;
+			box-shadow: inset calc(#{$dragOverWidth} * -1) 0 0 0 $primary-l1;
 			transition: none;
 		}
 
 		&.drag-over-top:after {
-			border-top: $dragOverWidth solid $cadmin-primary-l1;
+			border-top: $dragOverWidth solid $primary-l1;
 		}
 
 		&.drag-over-bottom.page-editor__col {
@@ -184,7 +184,7 @@ html#{$cadmin-selector} {
 			}
 
 			&:before {
-				border-bottom: $dragOverWidth solid $cadmin-primary-l1;
+				border-bottom: $dragOverWidth solid $primary-l1;
 			}
 		}
 
@@ -194,7 +194,7 @@ html#{$cadmin-selector} {
 			}
 
 			&:before {
-				border-top: $dragOverWidth solid $cadmin-primary-l1;
+				border-top: $dragOverWidth solid $primary-l1;
 			}
 		}
 
@@ -205,35 +205,35 @@ html#{$cadmin-selector} {
 			),
 		&.drag-over-middle.page-editor__col.empty:before,
 		&.drag-over-middle .page-editor__collection__message {
-			box-shadow: inset 0 0 0 $dragOverWidth $cadmin-primary-l1;
+			box-shadow: inset 0 0 0 $dragOverWidth $primary-l1;
 		}
 
 		&.drag-over-middle
 			> .page-editor__topper__content
 			> .page-editor__container
 			> :last-child:after {
-			box-shadow: inset (-$dragOverWidth) 0 0 0 $cadmin-primary-l1;
+			box-shadow: inset calc(#{$dragOverWidth} * -1) 0 0 0 $primary-l1;
 			transition: none;
 		}
 
 		&.drag-over-middle.page-editor__col
 			> .page-editor__col__border
 			> :last-child:after {
-			border-bottom: $dragOverWidth solid $cadmin-primary-l1;
+			border-bottom: $dragOverWidth solid $primary-l1;
 		}
 
 		&.drag-over-middle .page-editor__no-fragments-state {
 			border: none;
-			box-shadow: inset 0 0 0 $dragOverWidth $cadmin-primary-l1;
+			box-shadow: inset 0 0 0 $dragOverWidth $primary-l1;
 
 			.page-editor__no-fragments-state__message {
-				color: $cadmin-gray-400;
+				color: $gray-400;
 			}
 		}
 
 		&.drag-over-middle.page-editor__collection-item
 			.page-editor__no-fragments-state {
-			box-shadow: inset 0 0 0 $dragOverWidth $cadmin-purple-l4;
+			box-shadow: inset 0 0 0 $dragOverWidth $purple-l4;
 		}
 
 		&.highlighted:after {
@@ -243,9 +243,9 @@ html#{$cadmin-selector} {
 		&--hovered:after {
 			box-shadow: none;
 			outline: unquote(
-				'#{$borderWidth} dashed hsl(from #{$cadmin-purple} h s l / 0.5)'
+				'#{$borderWidth} dashed hsl(from #{$purple} h s l / 0.5)'
 			);
-			outline-offset: -$borderWidth;
+			outline-offset: calc(#{$borderWidth} * -1);
 		}
 
 		& > .page-editor__topper__content {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/undo/_UndoHistory.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/undo/_UndoHistory.scss
@@ -1,5 +1,3 @@
-@import 'atlas-variables';
-
 html#{$cadmin-selector} {
 	.cadmin {
 		.page-editor__undo-history {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/_Button.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/_Button.scss
@@ -1,5 +1,3 @@
-@import 'cadmin-variables';
-
 html#{$cadmin-selector} {
 	.page-editor__button .loading-animation.loading-animation-sm {
 		font-size: 14.4px;

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/_ColorPalette.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/_ColorPalette.scss
@@ -1,5 +1,3 @@
-@import 'cadmin-variables';
-
 html#{$cadmin-selector} {
 	.cadmin {
 		.page-editor__color-palette {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/_Editor.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/_Editor.scss
@@ -1,5 +1,3 @@
-@import 'cadmin-variables';
-
 html#{$cadmin-selector} {
 	.cadmin {
 		.page-editor__editor {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/_InlineConfirm.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/_InlineConfirm.scss
@@ -1,5 +1,3 @@
-@import 'cadmin-variables';
-
 @keyframes inlineConfirmShow {
 	to {
 		opacity: 1;

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/_ItemSelector.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/_ItemSelector.scss
@@ -1,5 +1,3 @@
-@import 'cadmin-variables';
-
 html#{$cadmin-selector} {
 	.cadmin {
 		.page-editor__item-selector__content {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/_SearchForm.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/_SearchForm.scss
@@ -1,5 +1,3 @@
-@import 'cadmin-variables';
-
 html#{$cadmin-selector} {
 	.cadmin {
 		.search-icon {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/_SidebarPanelHeader.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/_SidebarPanelHeader.scss
@@ -1,5 +1,3 @@
-@import 'cadmin-variables';
-
 html#{$cadmin-selector} .cadmin .page-editor__sidebar__panel-header {
 	min-height: 32px;
 }

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/_Textarea.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/_Textarea.scss
@@ -1,5 +1,3 @@
-@import 'cadmin-variables';
-
 html#{$cadmin-selector} {
 	.cadmin {
 		.page-editor__textarea,

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/_BrowserSidebar.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/_BrowserSidebar.scss
@@ -1,5 +1,3 @@
-@import 'cadmin-variables';
-
 $tabsBottomMargin: 16px;
 
 html#{$cadmin-selector}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/_ItemConfiguration.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/_ItemConfiguration.scss
@@ -1,5 +1,3 @@
-@import 'cadmin-variables';
-
 html#{$cadmin-selector}
 	.cadmin
 	.page-editor__page-structure__item-configuration {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/_PageStructureSidebar.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/_PageStructureSidebar.scss
@@ -1,9 +1,7 @@
-@import 'cadmin-variables';
-
 html#{$cadmin-selector} {
 	.cadmin {
 		.page-editor__page-structure {
-			border-top: 1px solid $secondary-l3;
+			border-top: 1px solid $cadmin-secondary-l3;
 			display: flex;
 			flex-direction: column;
 			height: 100%;

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/_PageStructureSidebarSection.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/_PageStructureSidebarSection.scss
@@ -1,5 +1,3 @@
-@import 'cadmin-variables';
-
 html#{$cadmin-selector} {
 	.cadmin {
 		.page-editor__page-structure__section {
@@ -17,7 +15,7 @@ html#{$cadmin-selector} {
 
 			&__custom-styles {
 				border-bottom: 1px solid $cadmin-secondary-l3;
-				padding-bottom: $pageEditorSpacing * 2.5;
+				padding-bottom: calc(#{$pageEditorSpacing} * 2.5);
 			}
 
 			&__resize-handler {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/_StructureTree.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/_StructureTree.scss
@@ -1,5 +1,3 @@
-@import 'cadmin-variables';
-
 html#{$cadmin-selector} {
 	.cadmin {
 		.page-editor__page-structure__structure-tree {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/_StructureTreeNode.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/_StructureTreeNode.scss
@@ -1,6 +1,4 @@
-@import 'cadmin-variables';
-
-$treeNodeNameMappedColor: #8633ff;
+$treeNodeNameMappedColor: $cadmin-purple-d1;
 
 html#{$cadmin-selector} {
 	.cadmin {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/item_configuration_panels/_CommonStyles.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/item_configuration_panels/_CommonStyles.scss
@@ -1,5 +1,3 @@
-@import 'cadmin-variables';
-
 html#{$cadmin-selector} {
 	.cadmin {
 		.page-editor__common-styles {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/item_configuration_panels/_FieldSet.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/item_configuration_panels/_FieldSet.scss
@@ -1,5 +1,3 @@
-@import 'cadmin-variables';
-
 html#{$cadmin-selector} {
 	.cadmin {
 		.page-editor__sidebar__fieldset {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/item_configuration_panels/_MappingPanel.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/item_configuration_panels/_MappingPanel.scss
@@ -1,5 +1,3 @@
-@import 'cadmin-variables';
-
 html#{$cadmin-selector} {
 	.cadmin {
 		.page-editor__mapping-panel {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/comments/components/_FragmentComment.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/comments/components/_FragmentComment.scss
@@ -1,5 +1,3 @@
-@import 'cadmin-variables';
-
 @keyframes FragmentCommentDecrease {
 	from {
 		max-height: 100vh;
@@ -111,9 +109,9 @@ html#{$cadmin-selector} {
 
 				.form-control {
 					&:has(> .ck-focused) {
-						background-color: $input-focus-bg;
-						border-color: $input-focus-border-color;
-						box-shadow: $input-focus-box-shadow;
+						background-color: $cadmin-input-focus-bg;
+						border-color: $cadmin-input-focus-border-color;
+						box-shadow: $cadmin-input-focus-box-shadow;
 					}
 				}
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/_FragmentsSidebar.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/_FragmentsSidebar.scss
@@ -1,5 +1,3 @@
-@import 'cadmin-variables';
-
 html#{$cadmin-selector} {
 	.cadmin {
 		.components-options {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/_SearchResultsPanel.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/_SearchResultsPanel.scss
@@ -1,5 +1,3 @@
-@import 'cadmin-variables';
-
 html#{$cadmin-selector} {
 	.cadmin {
 		.page-editor__fragments-widgets__search-results-panel__filter-subtitle {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/_TabCollection.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/_TabCollection.scss
@@ -1,5 +1,3 @@
-@import 'cadmin-variables';
-
 html#{$cadmin-selector}
 	.cadmin
 	.page-editor__fragments-widgets__tab-collection {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/_TabItem.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/_TabItem.scss
@@ -1,5 +1,3 @@
-@import 'cadmin-variables';
-
 html#{$cadmin-selector} .cadmin .page-editor__fragments-widgets__tab {
 	&-card-item {
 		cursor: grab;

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/_TabsPanel.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/_TabsPanel.scss
@@ -1,5 +1,3 @@
-@import 'cadmin-variables';
-
 html#{$cadmin-selector} {
 	.cadmin {
 		.page-editor__sidebar__fragments-widgets-panel__tabs {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/reorder_sets_modal/_ReorderSetsModal.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/reorder_sets_modal/_ReorderSetsModal.scss
@@ -1,5 +1,3 @@
-@import 'atlas-variables';
-
 html#{$cadmin-selector} .page-editor__reorder-set-modal {
 	.card {
 		cursor: grab;

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page_content/components/_ContentsSidebar.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page_content/components/_ContentsSidebar.scss
@@ -1,5 +1,3 @@
-@import 'cadmin-variables';
-
 $selector: '.page-editor__page-contents';
 
 html#{$cadmin-selector} .cadmin #{$selector} {
@@ -41,6 +39,6 @@ html#{$cadmin-selector} .cadmin #{$selector} {
 	}
 
 	&__content-list {
-		border-top: 1px solid $secondary-l3;
+		border-top: 1px solid $cadmin-secondary-l3;
 	}
 }

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page_design_options/components/_PageDesignOptions.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page_design_options/components/_PageDesignOptions.scss
@@ -1,5 +1,3 @@
-@import 'cadmin-variables';
-
 html#{$cadmin-selector} {
 	.cadmin {
 		.page-editor__sidebar__page-design-options__tabs {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page_rules/components/_Rules.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page_rules/components/_Rules.scss
@@ -1,5 +1,3 @@
-@import 'cadmin-variables';
-
 html#{$cadmin-selector} .cadmin {
 	.page-editor__rule {
 		&:focus-visible,
@@ -26,7 +24,7 @@ html#{$cadmin-selector} .cadmin {
 	}
 
 	.layout__row-builder-item.page-editor__rule-builder-item--action {
-		border-left: 4px solid $purple;
+		border-left: 4px solid $cadmin-purple;
 	}
 
 	.page-editor__rule-builder-date-picker,

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/field/util/ObjectFieldUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/field/util/ObjectFieldUtil.java
@@ -493,12 +493,29 @@ public class ObjectFieldUtil {
 
 				return;
 			}
+			else if (Objects.equals(
+						objectField.getBusinessType(),
+						ObjectFieldConstants.BUSINESS_TYPE_RELATIONSHIP) &&
+					 Objects.equals(
+						 objectField.getRelationshipType(),
+						 ObjectRelationshipConstants.TYPE_ONE_TO_MANY)) {
 
-			BigDecimal bigDecimal1 = new BigDecimal(existingValue.toString());
-			BigDecimal bigDecimal2 = new BigDecimal(value.toString());
+				if (Objects.equals(existingValue, value) ||
+					((existingValue != null) && (value != null) &&
+					 Objects.equals(
+						 existingValue.toString(), value.toString()))) {
 
-			if (bigDecimal1.compareTo(bigDecimal2) == 0) {
-				return;
+					return;
+				}
+			}
+			else {
+				BigDecimal bigDecimal1 = new BigDecimal(
+					existingValue.toString());
+				BigDecimal bigDecimal2 = new BigDecimal(value.toString());
+
+				if (bigDecimal1.compareTo(bigDecimal2) == 0) {
+					return;
+				}
 			}
 		}
 		else if (Objects.equals(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -29,6 +29,7 @@ import com.liferay.object.rest.internal.jaxrs.exception.mapper.ObjectEntryManage
 import com.liferay.object.rest.internal.jaxrs.exception.mapper.ObjectEntryScopeExceptionMapper;
 import com.liferay.object.rest.internal.jaxrs.exception.mapper.ObjectEntryStatusExceptionMapper;
 import com.liferay.object.rest.internal.jaxrs.exception.mapper.ObjectEntryValuesExceptionMapper;
+import com.liferay.object.rest.internal.jaxrs.exception.mapper.ObjectFieldReadOnlyExceptionMapper;
 import com.liferay.object.rest.internal.jaxrs.exception.mapper.ObjectRelationshipDeletionTypeExceptionMapper;
 import com.liferay.object.rest.internal.jaxrs.exception.mapper.RequiredObjectEntryVersionExceptionMapper;
 import com.liferay.object.rest.internal.jaxrs.exception.mapper.RequiredObjectRelationshipExceptionMapper;
@@ -952,6 +953,7 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 				ObjectEntryScopeExceptionMapper::new,
 				() -> new ObjectEntryStatusExceptionMapper(_language),
 				() -> new ObjectEntryValuesExceptionMapper(_language),
+				ObjectFieldReadOnlyExceptionMapper::new,
 				() -> new ObjectRelationshipDeletionTypeExceptionMapper(
 					_language),
 				() -> new RequiredObjectEntryVersionExceptionMapper(_language),

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/jaxrs/exception/mapper/ObjectFieldReadOnlyExceptionMapper.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/jaxrs/exception/mapper/ObjectFieldReadOnlyExceptionMapper.java
@@ -1,0 +1,28 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.rest.internal.jaxrs.exception.mapper;
+
+import com.liferay.object.exception.ObjectFieldReadOnlyException;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.BaseExceptionMapper;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.Problem;
+
+import jakarta.ws.rs.ext.Provider;
+
+/**
+ * @author Yuri Monteiro
+ */
+@Provider
+public class ObjectFieldReadOnlyExceptionMapper
+	extends BaseExceptionMapper<ObjectFieldReadOnlyException> {
+
+	@Override
+	protected Problem getProblem(
+		ObjectFieldReadOnlyException objectFieldReadOnlyException) {
+
+		return new Problem(objectFieldReadOnlyException);
+	}
+
+}

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/field/util/test/ObjectFieldUtilTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/field/util/test/ObjectFieldUtilTest.java
@@ -8,8 +8,12 @@ package com.liferay.object.field.util.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.dynamic.data.mapping.expression.DDMExpressionFactory;
 import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.constants.ObjectFieldSettingConstants;
+import com.liferay.object.constants.ObjectRelationshipConstants;
 import com.liferay.object.exception.ObjectFieldReadOnlyException;
+import com.liferay.object.field.builder.ObjectFieldBuilder;
 import com.liferay.object.field.builder.TextObjectFieldBuilder;
+import com.liferay.object.field.setting.builder.ObjectFieldSettingBuilder;
 import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.model.ObjectField;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -23,6 +27,7 @@ import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.ClassRule;
@@ -45,6 +50,9 @@ public class ObjectFieldUtilTest {
 
 	@Test
 	public void testValidateReadOnlyObjectFields() throws PortalException {
+
+		// Conditional read only
+
 		ObjectField objectField = new TextObjectFieldBuilder(
 		).labelMap(
 			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString())
@@ -75,6 +83,110 @@ public class ObjectFieldUtilTest {
 				values
 			).put(
 				objectField.getName(), RandomTestUtil.randomString()
+			).build());
+
+		// One to many relationship
+
+		String objectRelationshipERCObjectFieldName =
+			"a" + RandomTestUtil.randomString();
+
+		ObjectField relationshipObjectField = new ObjectFieldBuilder(
+		).businessType(
+			ObjectFieldConstants.BUSINESS_TYPE_RELATIONSHIP
+		).dbType(
+			ObjectFieldConstants.DB_TYPE_LONG
+		).labelMap(
+			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString())
+		).name(
+			"a" + RandomTestUtil.randomString()
+		).objectFieldSettings(
+			Collections.singletonList(
+				new ObjectFieldSettingBuilder(
+				).name(
+					ObjectFieldSettingConstants.
+						NAME_OBJECT_RELATIONSHIP_ERC_OBJECT_FIELD_NAME
+				).value(
+					objectRelationshipERCObjectFieldName
+				).build())
+		).readOnly(
+			ObjectFieldConstants.READ_ONLY_TRUE
+		).relationshipType(
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY
+		).build();
+
+		AssertUtils.assertFailure(
+			ObjectFieldReadOnlyException.class,
+			"Object field " + relationshipObjectField.getName() +
+				" is read only",
+			() -> ObjectFieldUtil.validateReadOnlyObjectFields(
+				_ddmExpressionFactory, new HashMap<>(),
+				Collections.singletonList(relationshipObjectField),
+				HashMapBuilder.<String, Object>put(
+					relationshipObjectField.getName(),
+					RandomTestUtil.randomLong()
+				).build()));
+		AssertUtils.assertFailure(
+			ObjectFieldReadOnlyException.class,
+			"Object field " + relationshipObjectField.getName() +
+				" is read only",
+			() -> ObjectFieldUtil.validateReadOnlyObjectFields(
+				_ddmExpressionFactory, new HashMap<>(),
+				Collections.singletonList(relationshipObjectField),
+				HashMapBuilder.<String, Object>put(
+					objectRelationshipERCObjectFieldName,
+					RandomTestUtil.randomString()
+				).build()));
+
+		String externalReferenceCode = RandomTestUtil.randomString();
+
+		Map<String, Object> existingValues = HashMapBuilder.<String, Object>put(
+			objectRelationshipERCObjectFieldName, externalReferenceCode
+		).put(
+			relationshipObjectField.getName(), RandomTestUtil.randomLong()
+		).build();
+
+		AssertUtils.assertFailure(
+			ObjectFieldReadOnlyException.class,
+			"Object field " + relationshipObjectField.getName() +
+				" is read only",
+			() -> ObjectFieldUtil.validateReadOnlyObjectFields(
+				_ddmExpressionFactory, existingValues,
+				Collections.singletonList(relationshipObjectField),
+				Collections.singletonMap(
+					objectRelationshipERCObjectFieldName, null)));
+		AssertUtils.assertFailure(
+			ObjectFieldReadOnlyException.class,
+			"Object field " + relationshipObjectField.getName() +
+				" is read only",
+			() -> ObjectFieldUtil.validateReadOnlyObjectFields(
+				_ddmExpressionFactory, existingValues,
+				Collections.singletonList(relationshipObjectField),
+				HashMapBuilder.<String, Object>put(
+					objectRelationshipERCObjectFieldName,
+					RandomTestUtil.randomString()
+				).build()));
+
+		ObjectFieldUtil.validateReadOnlyObjectFields(
+			_ddmExpressionFactory, existingValues,
+			Collections.singletonList(relationshipObjectField),
+			HashMapBuilder.<String, Object>put(
+				objectRelationshipERCObjectFieldName, externalReferenceCode
+			).build());
+
+		int objectRelationshipId = RandomTestUtil.randomInt();
+
+		ObjectFieldUtil.validateReadOnlyObjectFields(
+			_ddmExpressionFactory,
+			HashMapBuilder.<String, Object>put(
+				objectRelationshipERCObjectFieldName, externalReferenceCode
+			).put(
+				relationshipObjectField.getName(),
+				Long.valueOf(objectRelationshipId)
+			).build(),
+			Collections.singletonList(relationshipObjectField),
+			HashMapBuilder.<String, Object>put(
+				relationshipObjectField.getName(),
+				Integer.valueOf(objectRelationshipId)
 			).build());
 	}
 

--- a/modules/apps/portal-workflow/portal-workflow-api/src/main/java/com/liferay/portal/workflow/constants/WorkflowDefinitionConstants.java
+++ b/modules/apps/portal-workflow/portal-workflow-api/src/main/java/com/liferay/portal/workflow/constants/WorkflowDefinitionConstants.java
@@ -33,6 +33,10 @@ public class WorkflowDefinitionConstants {
 		EXTERNAL_REFERENCE_CODE_MESSAGE_BOARDS_USER_STATS_MODERATION =
 			"L_MESSAGE_BOARDS_USER_STATS_MODERATION";
 
+	public static final String
+		EXTERNAL_REFERENCE_CODE_SEO_STUDIO_TITLE_GENERATOR =
+			"L_SEO_STUDIO_TITLE_GENERATOR";
+
 	public static final String EXTERNAL_REFERENCE_CODE_SINGLE_APPROVER =
 		"L_SINGLE_APPROVER";
 
@@ -54,6 +58,9 @@ public class WorkflowDefinitionConstants {
 
 	public static final String NAME_PAGE_BUILDER = "Page Builder";
 
+	public static final String NAME_SEO_STUDIO_TITLE_GENERATOR =
+		"SEO Studio Title Generator";
+
 	public static final String NAME_SINGLE_APPROVER = "Single Approver";
 
 	public static final String SCOPE_AI = "ai";
@@ -63,7 +70,7 @@ public class WorkflowDefinitionConstants {
 	public static final String[] SYSTEM_WORKFLOW_DEFINITION_NAMES = {
 		NAME_CHANGE_TONE, NAME_FIX_SPELLING_AND_GRAMMAR, NAME_IMPROVE_WRITING,
 		NAME_LIFERAY_SEARCH, NAME_MAKE_LONGER, NAME_MAKE_SHORTER,
-		NAME_PAGE_BUILDER
+		NAME_PAGE_BUILDER, NAME_SEO_STUDIO_TITLE_GENERATOR
 	};
 
 }

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/model/listener/AccountEntryUserRelModelListener.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/model/listener/AccountEntryUserRelModelListener.java
@@ -6,7 +6,10 @@
 package com.liferay.ai.hub.internal.model.listener;
 
 import com.liferay.account.manager.CurrentAccountEntryManager;
+import com.liferay.account.model.AccountEntry;
 import com.liferay.account.model.AccountEntryUserRel;
+import com.liferay.account.service.AccountEntryLocalService;
+import com.liferay.account.service.AccountEntryUserRelLocalService;
 import com.liferay.layout.utility.page.model.LayoutUtilityPageEntry;
 import com.liferay.layout.utility.page.service.LayoutUtilityPageEntryLocalService;
 import com.liferay.portal.kernel.exception.ModelListenerException;
@@ -65,6 +68,22 @@ public class AccountEntryUserRelModelListener
 			return;
 		}
 
+		AccountEntry aiHubAccountEntry =
+			_accountEntryLocalService.fetchAccountEntryByExternalReferenceCode(
+				"L_AI_HUB", serviceContext.getCompanyId());
+
+		if (aiHubAccountEntry != null) {
+			if (accountEntryUserRel.getAccountEntryId() ==
+					aiHubAccountEntry.getAccountEntryId()) {
+
+				return;
+			}
+
+			_accountEntryUserRelLocalService.addAccountEntryUserRels(
+				aiHubAccountEntry.getAccountEntryId(),
+				new long[] {accountEntryUserRel.getAccountUserId()});
+		}
+
 		_currentAccountEntryManager.setCurrentAccountEntry(
 			accountEntryUserRel.getAccountEntryId(), groupId,
 			accountEntryUserRel.getAccountUserId());
@@ -72,6 +91,12 @@ public class AccountEntryUserRelModelListener
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		AccountEntryUserRelModelListener.class);
+
+	@Reference
+	private AccountEntryLocalService _accountEntryLocalService;
+
+	@Reference
+	private AccountEntryUserRelLocalService _accountEntryUserRelLocalService;
 
 	@Reference
 	private CurrentAccountEntryManager _currentAccountEntryManager;

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/model/listener/AccountEntryUserRelModelListener.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/model/listener/AccountEntryUserRelModelListener.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.ModelListener;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.service.UserLocalService;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -82,6 +83,9 @@ public class AccountEntryUserRelModelListener
 			_accountEntryUserRelLocalService.addAccountEntryUserRels(
 				aiHubAccountEntry.getAccountEntryId(),
 				new long[] {accountEntryUserRel.getAccountUserId()});
+
+			_userLocalService.addGroupUsers(
+				groupId, new long[] {accountEntryUserRel.getAccountUserId()});
 		}
 
 		_currentAccountEntryManager.setCurrentAccountEntry(
@@ -104,5 +108,8 @@ public class AccountEntryUserRelModelListener
 	@Reference
 	private LayoutUtilityPageEntryLocalService
 		_layoutUtilityPageEntryLocalService;
+
+	@Reference
+	private UserLocalService _userLocalService;
 
 }

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer-test/src/testIntegration/java/com/liferay/ai/hub/site/initializer/internal/test/AIHubSiteInitializerTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer-test/src/testIntegration/java/com/liferay/ai/hub/site/initializer/internal/test/AIHubSiteInitializerTest.java
@@ -281,24 +281,35 @@ public class AIHubSiteInitializerTest {
 			"L_AI_HUB_CONTENT_RETRIEVER",
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 		_assertWorkflowDefinitionExists(
+			_ACCOUNT_EXTERNAL_REFERENCE_CODE_AI_HUB,
 			WorkflowDefinitionConstants.EXTERNAL_REFERENCE_CODE_CHANGE_TONE,
 			WorkflowDefinitionConstants.NAME_CHANGE_TONE);
 		_assertWorkflowDefinitionExists(
+			_ACCOUNT_EXTERNAL_REFERENCE_CODE_AI_HUB,
 			WorkflowDefinitionConstants.
 				EXTERNAL_REFERENCE_CODE_FIX_SPELLING_AND_GRAMMAR,
 			WorkflowDefinitionConstants.NAME_FIX_SPELLING_AND_GRAMMAR);
 		_assertWorkflowDefinitionExists(
+			_ACCOUNT_EXTERNAL_REFERENCE_CODE_AI_HUB,
 			WorkflowDefinitionConstants.EXTERNAL_REFERENCE_CODE_IMPROVE_WRITING,
 			WorkflowDefinitionConstants.NAME_IMPROVE_WRITING);
 		_assertWorkflowDefinitionExists(
+			_ACCOUNT_EXTERNAL_REFERENCE_CODE_AI_HUB,
 			WorkflowDefinitionConstants.EXTERNAL_REFERENCE_CODE_LIFERAY_SEARCH,
 			WorkflowDefinitionConstants.NAME_LIFERAY_SEARCH);
 		_assertWorkflowDefinitionExists(
+			_ACCOUNT_EXTERNAL_REFERENCE_CODE_AI_HUB,
 			WorkflowDefinitionConstants.EXTERNAL_REFERENCE_CODE_MAKE_LONGER,
 			WorkflowDefinitionConstants.NAME_MAKE_LONGER);
 		_assertWorkflowDefinitionExists(
+			_ACCOUNT_EXTERNAL_REFERENCE_CODE_AI_HUB,
 			WorkflowDefinitionConstants.EXTERNAL_REFERENCE_CODE_MAKE_SHORTER,
 			WorkflowDefinitionConstants.NAME_MAKE_SHORTER);
+		_assertWorkflowDefinitionExists(
+			_ACCOUNT_EXTERNAL_REFERENCE_CODE_SEO_STUDIO,
+			WorkflowDefinitionConstants.
+				EXTERNAL_REFERENCE_CODE_SEO_STUDIO_TITLE_GENERATOR,
+			WorkflowDefinitionConstants.NAME_SEO_STUDIO_TITLE_GENERATOR);
 	}
 
 	private void _assertAccountRoleExists(
@@ -536,6 +547,7 @@ public class AIHubSiteInitializerTest {
 	}
 
 	private void _assertWorkflowDefinitionExists(
+			String accountEntryExternalReferenceCode,
 			String externalReferenceCode, String name)
 		throws Exception {
 
@@ -547,12 +559,19 @@ public class AIHubSiteInitializerTest {
 
 		AccountEntry accountEntry =
 			_accountEntryLocalService.getAccountEntryByExternalReferenceCode(
-				"L_AI_HUB", TestPropsValues.getCompanyId());
+				accountEntryExternalReferenceCode,
+				TestPropsValues.getCompanyId());
 
 		Assert.assertEquals(
 			accountEntry.getAccountEntryGroupId(),
 			workflowDefinition.getGroupId());
 	}
+
+	private static final String _ACCOUNT_EXTERNAL_REFERENCE_CODE_AI_HUB =
+		"L_AI_HUB";
+
+	private static final String _ACCOUNT_EXTERNAL_REFERENCE_CODE_SEO_STUDIO =
+		"L_SEO_STUDIO";
 
 	@Inject
 	private AccountEntryLocalService _accountEntryLocalService;

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/accounts.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/accounts.json
@@ -3,5 +3,10 @@
 		"externalReferenceCode": "L_AI_HUB",
 		"name": "Liferay AI Hub",
 		"type": "business"
+	},
+	{
+		"externalReferenceCode": "L_SEO_STUDIO",
+		"name": "Liferay SEO Studio",
+		"type": "business"
 	}
 ]

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/object-entries/agent-definition-object-entries.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/object-entries/agent-definition-object-entries.json
@@ -90,6 +90,19 @@
 				"en_US": "Page Builder"
 			},
 			"workflowDefinitionName": "Page Builder"
+		},
+		{
+			"active": true,
+			"description": "This agent analyzes the raw content of a webpage and generates an SEO-optimized HTML title tag to fix a missing or empty title.",
+			"externalReferenceCode": "L_SEO_STUDIO_TITLE_GENERATOR",
+			"inputVariables": "pageContent",
+			"outputVariable": "titleTag",
+			"r_accountToAIHubAgentDefinitions_accountEntryERC": "L_SEO_STUDIO",
+			"system": true,
+			"title_i18n": {
+				"en_US": "SEO Studio Title Generator"
+			},
+			"workflowDefinitionName": "SEO Studio Title Generator"
 		}
 	],
 	"objectDefinitionName": "AIHubAgentDefinition"

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/workflow-definitions/seo-studio-title-generator-workflow-definition/workflow-definition.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/workflow-definitions/seo-studio-title-generator-workflow-definition/workflow-definition.json
@@ -1,0 +1,11 @@
+{
+	"active": true,
+	"externalReferenceCode": "L_SEO_STUDIO_TITLE_GENERATOR",
+	"groupExternalReferenceCode": "[$ACCOUNT_ENTRY_GROUP_ERC:L_SEO_STUDIO$]",
+	"name": "SEO Studio Title Generator",
+	"scope": "ai",
+	"title": "SEO Studio Title Generator",
+	"title_i18n": {
+		"en_US": "SEO Studio Title Generator"
+	}
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/workflow-definitions/seo-studio-title-generator-workflow-definition/workflow-definition.xml
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/workflow-definitions/seo-studio-title-generator-workflow-definition/workflow-definition.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0"?>
+
+<workflow-definition
+	xmlns="urn:liferay.com:liferay-workflow_7.4.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="urn:liferay.com:liferay-workflow_7.4.0 http://www.liferay.com/dtd/liferay-workflow-definition_7_4_0.xsd"
+>
+	<name>SEO Studio Title Generator</name>
+	<version>1</version>
+	<llm>
+		<name>seoStudioTitleGenerator</name>
+		<metadata>
+			<![CDATA[
+				{
+					"xy": [
+						276,
+						242
+					]
+				}
+			]]>
+		</metadata>
+		<labels>
+			<label language-id="en_US">
+				SEO Studio Title Generator
+			</label>
+		</labels>
+		<input-variables>
+			<![CDATA[
+[
+	{
+		"name": "pageContent",
+		"type": "string"
+	}
+]
+]]>
+		</input-variables>
+		<output-variables>
+			<![CDATA[
+[
+	{
+		"name": "titleTag",
+		"type": "string"
+	}
+]
+]]>
+		</output-variables>
+		<prompt>
+			<![CDATA[You are an expert SEO Specialist. Your task is to analyze the raw content of a webpage and generate a perfectly optimized HTML <title> tag to fix a missing or empty title.
+
+SEO CONSTRAINTS & RULES:
+- Length: The entire title tag must be between 30 and 60 characters. Do not exceed 60 characters.
+- Keyword Optimization: Extract the primary topic/keyword from the content. Front-load this primary keyword (place it near the beginning of the title).
+- Formatting: Write the title in Title Case.
+- Style: Avoid generic terms like "Home", "Page", or "Index". Make it descriptive, accurately reflecting the core intent of the page content (e.g., informational, transactional, commercial). Do not use clickbait or keyword-stuffed lists.
+
+OUTPUT FORMAT:
+Return ONLY the valid HTML <title> tag.
+Do not include any introductory text, markdown formatting (like ```html), or conversational explanations. Your entire response must start with "<title>" and end with "</title>".
+Example of acceptable output:
+<title>Best Espresso Machines for Home Brewing</title>]]>
+		</prompt>
+		<tools>
+			<![CDATA[[]]]>
+		</tools>
+		<transitions>
+			<transition>
+				<labels>
+					<label language-id="en_US">
+						End
+					</label>
+				</labels>
+				<name>end</name>
+				<target>end</target>
+				<default>true</default>
+			</transition>
+		</transitions>
+		<user-message>
+			<![CDATA[Page Content: {{pageContent}}]]>
+		</user-message>
+	</llm>
+	<state>
+		<name>start</name>
+		<metadata>
+			<![CDATA[
+				{
+					"xy": [
+						273,
+						25
+					]
+				}
+			]]>
+		</metadata>
+		<initial>true</initial>
+		<labels>
+			<label language-id="en_US">
+				Start
+			</label>
+		</labels>
+		<transitions>
+			<transition>
+				<labels>
+					<label language-id="en_US">
+						SEO Studio Title Generator
+					</label>
+				</labels>
+				<name>seoStudioTitleGenerator</name>
+				<target>seoStudioTitleGenerator</target>
+				<default>true</default>
+			</transition>
+		</transitions>
+	</state>
+	<state>
+		<name>end</name>
+		<metadata>
+			<![CDATA[
+				{
+					"terminal": true,
+					"xy": [
+						277,
+						459
+					]
+				}
+			]]>
+		</metadata>
+		<labels>
+			<label language-id="en_US">
+				End
+			</label>
+		</labels>
+	</state>
+</workflow-definition>

--- a/modules/dxp/apps/ai-hub/ai-hub-test/src/testIntegration/java/com/liferay/ai/hub/internal/model/listener/test/AccountEntryUserRelModelListenerTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-test/src/testIntegration/java/com/liferay/ai/hub/internal/model/listener/test/AccountEntryUserRelModelListenerTest.java
@@ -16,6 +16,7 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.portlet.PortalPreferences;
 import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -105,6 +106,10 @@ public class AccountEntryUserRelModelListenerTest {
 			_accountEntryUserRelLocalService.hasAccountEntryUserRel(
 				aiHubAccountEntry.getAccountEntryId(), user.getUserId()));
 
+		Assert.assertTrue(
+			_userLocalService.hasGroupUser(
+				group.getGroupId(), user.getUserId()));
+
 		Assert.assertEquals(
 			0,
 			_getCurrentAccountEntryId(
@@ -151,5 +156,8 @@ public class AccountEntryUserRelModelListenerTest {
 
 	@Inject
 	private SiteInitializerRegistry _siteInitializerRegistry;
+
+	@Inject
+	private UserLocalService _userLocalService;
 
 }

--- a/modules/dxp/apps/ai-hub/ai-hub-test/src/testIntegration/java/com/liferay/ai/hub/internal/model/listener/test/AccountEntryUserRelModelListenerTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-test/src/testIntegration/java/com/liferay/ai/hub/internal/model/listener/test/AccountEntryUserRelModelListenerTest.java
@@ -93,6 +93,18 @@ public class AccountEntryUserRelModelListenerTest {
 		_accountEntryUserRelLocalService.addAccountEntryUserRels(
 			accountEntry2.getAccountEntryId(), new long[] {user.getUserId()});
 
+		Assert.assertTrue(
+			_accountEntryUserRelLocalService.hasAccountEntryUserRel(
+				accountEntry2.getAccountEntryId(), user.getUserId()));
+
+		AccountEntry aiHubAccountEntry =
+			_accountEntryLocalService.fetchAccountEntryByExternalReferenceCode(
+				"L_AI_HUB", TestPropsValues.getCompanyId());
+
+		Assert.assertTrue(
+			_accountEntryUserRelLocalService.hasAccountEntryUserRel(
+				aiHubAccountEntry.getAccountEntryId(), user.getUserId()));
+
 		Assert.assertEquals(
 			0,
 			_getCurrentAccountEntryId(

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/collectionFiltersCMSCategorization.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/collectionFiltersCMSCategorization.spec.ts
@@ -155,24 +155,24 @@ test(
 		});
 
 		await test.step('CMS category is available in the category filter selector', async () => {
-			await page
-				.getByLabel('of the following')
-				.selectOption('assetCategories');
+			const filterFieldSelect = page.getByLabel('of the following');
+
+			await expect(async () => {
+				if (!(await filterFieldSelect.isVisible())) {
+					await page.getByRole('button', {name: 'Filter'}).click();
+				}
+
+				await expect(filterFieldSelect).toBeVisible({timeout: 2000});
+			}).toPass({timeout: 2000});
+
+			await filterFieldSelect.selectOption('assetCategories');
 
 			await page
 				.getByRole('button', {exact: true, name: 'Select'})
 				.click();
 
-			const categoryFrame = page.frameLocator(
-				'iframe[title="Select Categories"]'
-			);
-
-			await categoryFrame
-				.getByRole('button', {name: vocabularyName})
-				.click();
-
 			await expect(
-				categoryFrame.getByText(categoryName, {exact: true})
+				page.getByText(categoryName, {exact: true})
 			).toBeVisible();
 		});
 	}

--- a/modules/test/playwright/utils/waitForAlert.ts
+++ b/modules/test/playwright/utils/waitForAlert.ts
@@ -1,5 +1,7 @@
 import {FrameLocator, Page, expect} from '@playwright/test';
 
+import {clickAndExpectToBeHidden} from './clickAndExpectToBeHidden';
+
 /**
  * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
@@ -57,8 +59,9 @@ export async function waitForAlert(
 	}
 
 	if (autoClose) {
-		await alert.getByLabel(closeText).click();
-
-		await alert.waitFor({state: 'hidden'});
+		await clickAndExpectToBeHidden({
+			target: alert,
+			trigger: alert.getByLabel(closeText),
+		});
 	}
 }

--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -3667,6 +3667,22 @@
 	},
 	{
 		"classNames": [
+			"SoyDataFactory"
+		],
+		"from": "createSoyHTMLData(String paramName)",
+		"hasMessage": true,
+		"issueKey": "LPD-35240"
+	},
+	{
+		"classNames": [
+			"SoyDataFactory"
+		],
+		"from": "createSoyRawData(String paramName)",
+		"hasMessage": true,
+		"issueKey": "LPD-35240"
+	},
+	{
+		"classNames": [
 			"UpgradeProcess"
 		],
 		"classStructurePattern": true,

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_35240.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/upgrade-catch-all-check/LPD_35240.testjava
@@ -1,0 +1,26 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies.upgrade;
+
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Regisson Aguiar
+ */
+public class LPD_35240 {
+
+	public void method(String html) {
+		_soyDataFactory.createSoyHTMLData(html);
+		_soyDataFactory.createSoyHTMLData(null);
+
+		_soyDataFactory.createSoyRawData(html);
+		_soyDataFactory.createSoyRawData(null);
+	}
+
+	@Reference
+	private SoyDataFactory _soyDataFactory;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93726

## What Is Being Fixed

In the Page Editor SCSS, partials repeatedly imported `cadmin-variables` even though `App.scss` already imported it for the whole bundle, and atlas tokens (`$primary`, `$purple`, `$gray-100`, `$white`, and so on) were not directly available, so every reference had to use the `$cadmin-*` alias.

## How It Is Being Fixed

`App.scss` now imports `atlas-custom-properties/_variables` alongside `cadmin-variables` once for the whole bundle, so both sets are available everywhere. The redundant per-partial `@import 'cadmin-variables';` lines are dropped. Inside `.cadmin`-qualified selectors in `_Layout.scss`, bare atlas tokens (`$primary`, `$purple`, `$gray-100`, `$success-l1`, `$light-l1`, `$font-family-base`, `$white`) replace their `$cadmin-*` aliases. The two are equivalent inside `.cadmin` scope, so the rendered result is unchanged.

## Why Are There No Tests?

Visual SCSS refactor only — no behavior changes to assert.

## PR Check

**pr-check: SKIPPED** — CSS-only, no test impact

<!-- pr-check {"reason": "CSS-only, no test impact", "result": "skipped", "sha": "8d0615106a74f06e422fee4bf84f322c0f516b22"} -->
