### PR TITLE
LPD-93241 Increase contrast of Clay date picker date cells

### DIFF
--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_date-picker.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_date-picker.scss
@@ -446,7 +446,7 @@ $date-picker-date: () !default;
 $date-picker-date: map-deep-merge(
 	(
 		border-radius: var(--date-picker-date-border-radius, 100px),
-		color: var(--date-picker-date-color, $gray-600),
+		color: var(--date-picker-date-color, $gray-900),
 		cursor: $link-cursor,
 		position: relative,
 
@@ -490,7 +490,7 @@ $date-picker-date: map-deep-merge(
 $date-picker-previous-month-date: () !default;
 $date-picker-previous-month-date: map-deep-merge(
 	(
-		color: var(--date-picker-previous-month-date-color, $gray-500),
+		color: var(--date-picker-previous-month-date-color, $gray-600),
 		active: (
 			background-color:
 				var(
@@ -506,7 +506,7 @@ $date-picker-previous-month-date: map-deep-merge(
 $date-picker-next-month-date: () !default;
 $date-picker-next-month-date: map-deep-merge(
 	(
-		color: var(--date-picker-next-month-date-color, $gray-500),
+		color: var(--date-picker-next-month-date-color, $gray-600),
 		active: (
 			background-color:
 				var(

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas/variables/_date-picker.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas/variables/_date-picker.scss
@@ -75,6 +75,9 @@ $date-picker-nav-select: map-deep-merge(
 $date-picker-date: () !default;
 $date-picker-date: map-deep-merge(
 	(
+		color: $gray-900,
+		opacity: null,
+
 		hover: (
 			color: $gray-900,
 		),
@@ -95,7 +98,7 @@ $date-picker-date: map-deep-merge(
 $date-picker-previous-month-date: () !default;
 $date-picker-previous-month-date: map-deep-merge(
 	(
-		color: $gray-500,
+		color: $gray-600,
 		opacity: null,
 
 		focus: (
@@ -113,7 +116,7 @@ $date-picker-previous-month-date: map-deep-merge(
 $date-picker-next-month-date: () !default;
 $date-picker-next-month-date: map-deep-merge(
 	(
-		color: $gray-500,
+		color: $gray-600,
 		opacity: null,
 
 		focus: (

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/variables/_date-picker.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/variables/_date-picker.scss
@@ -322,7 +322,7 @@ $cadmin-date-picker-date: () !default;
 $cadmin-date-picker-date: map-deep-merge(
 	(
 		border-radius: 100px,
-		color: $cadmin-gray-600,
+		color: $cadmin-gray-900,
 		cursor: $cadmin-link-cursor,
 		position: relative,
 
@@ -355,7 +355,7 @@ $cadmin-date-picker-date: map-deep-merge(
 $cadmin-date-picker-previous-month-date: () !default;
 $cadmin-date-picker-previous-month-date: map-deep-merge(
 	(
-		color: $cadmin-gray-500,
+		color: $cadmin-gray-600,
 
 		active: (
 			background-color: $cadmin-primary-l2,
@@ -368,7 +368,7 @@ $cadmin-date-picker-previous-month-date: map-deep-merge(
 $cadmin-date-picker-next-month-date: () !default;
 $cadmin-date-picker-next-month-date: map-deep-merge(
 	(
-		color: $cadmin-gray-500,
+		color: $cadmin-gray-600,
 
 		active: (
 			background-color: $cadmin-primary-l2,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93241

## What Is Being Fixed

The current-month date cells in the Clay date picker had no explicit color in $date-picker-date, and the previous- and next-month spillover cells used $gray-500, which only reaches roughly 2.6:1 contrast against the dropdown background and fails WCAG AA. The visual hierarchy between active and spillover cells was also flat.

## How It Is Being Fixed

Set the current-month color to `$gray-900`, `$cadmin-gray-900`, and` var(--date-picker-date-color, $gray-900)` across the atlas, cadmin, and atlas-custom-properties Sass variants, and switch the spillover cells to `$gray-600 / $cadmin-gray-600`. Both ratios now clear AA and the dark current-month emphasis preserves the visual hierarchy between active and spillover cells.

This solution has been provided and validated by Design team, thanks @marcoscv-work! 

<img width="1294" height="668" alt="Screenshot 2026-06-08 at 15 16 07" src="https://github.com/user-attachments/assets/693029cb-bc3b-42b2-aa8f-61d84d9c6559" />


## Why Are There No Tests?

Visual color-contrast changes have no programmatic test path; they are verified by inspection against the Figma/design spec referenced in LPD-93241.

## PR Check

**pr-check: PASS** — tested on `09d35b71d6411d0929e0c7137e0f3123e9415585`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Deploy | PASS |
| Structural Smoke | FAIL (ignored — baseline, `Log4jConfigUtil` not in diff) |

<!-- pr-check {"result": "success", "sha": "09d35b71d6411d0929e0c7137e0f3123e9415585"} -->