### PR TITLE
LPD-93888 Enable LPD-76864 for the style book preview test

### DIFF
--- a/modules/test/playwright/tests/design-library-web/main/designLibraryStyleBook.spec.ts
+++ b/modules/test/playwright/tests/design-library-web/main/designLibraryStyleBook.spec.ts
@@ -26,6 +26,7 @@ const test = mergeTests(
 		'LPD-35443': {enabled: true},
 		'LPD-56718': {enabled: true},
 		'LPD-57283': {enabled: true},
+		'LPD-76864': {enabled: true},
 	}),
 	loginTest()
 );


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93888

## What Is Being Fixed

The Playwright test "Editing a Design Library style book opens the editor with Design-Library-aware experience" (designLibraryStyleBook.spec.ts) began failing with a 400 "Feature flag LPD-76864 is disabled for company" during the "Create a connected site with a public page via headless" step.

## How It Is Being Fixed

Commit 014bcc5 ("LPD-89086 Reject widget-page creation in the Admin REST API") gated headless widget-page creation behind feature flag LPD-76864, deprecating widget pages. The test creates a widget page on the connected site purely as scaffolding so the style book editor preview lists it, so its setup started returning a 400. Enabling LPD-76864 in the test's featureFlagsTest fixture restores the precondition the test was written against, matching how the product's own SitePageResourceTest declares @FeatureFlag("LPD-76864"). Only this one test creates a site page; the other three tests in the file create design libraries and are unaffected.

## Why Are There No Tests?

This PR fixes an existing Playwright test by enabling a now-required feature flag; the repaired test is itself the coverage and no production code changed.

## PR Check

**pr-check: PASS** — tested on `965dc6af13a0fdf080ed73dc9f9c11cb50ba4418`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "965dc6af13a0fdf080ed73dc9f9c11cb50ba4418"} -->