### PR TITLE
LPD-93982 Locate the maintenance mode indicator by its accessible name

### DIFF
--- a/modules/test/playwright/tests/product-navigation-control-menu-web/main/controlMenu.spec.ts
+++ b/modules/test/playwright/tests/product-navigation-control-menu-web/main/controlMenu.spec.ts
@@ -180,7 +180,7 @@ test('Check if the maintenance mode indicator is displaying correctly', async ({
 	page,
 }) => {
 	const infoButton = page.getByRole('button', {
-		name: 'Open Maintenance Mode Definition',
+		name: 'Maintenance',
 	});
 
 	await test.step('should show only the info icon without "Maintenance" text', async () => {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93982

## What Is Being Fixed

The Playwright test "Check if the maintenance mode indicator is displaying correctly" (controlMenu.spec.ts) began failing: getByRole('button', {name: 'Open Maintenance Mode Definition'}) timed out because the button could not be found by that name.

## How It Is Being Fixed

Commit c729e94 ("LPD-83291 Add an accessible icon-only variant to the Feature Indicator") added an aria-label to the icon-only Feature Indicator button. For an icon-only button the aria-label becomes the accessible name and overrides the title, so the maintenance indicator's accessible name changed from "Open Maintenance Mode Definition" (the title) to "Maintenance" (the label) — the intended behavior of that accessibility commit. The indicator still renders correctly; the test's locator is updated to match the new accessible name. The remaining assertions (icon-only rendering, empty text, info-circle icon, popover on click) are unchanged.

## Why Are There No Tests?

This PR fixes an existing Playwright test by updating a stale accessible-name locator after an intentional accessibility change; the repaired test is itself the coverage and no production code changed.

## PR Check

**pr-check: PASS** — tested on `d35e24f850e444ee9fe549dc7058ef0d1c38e4b9`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "d35e24f850e444ee9fe549dc7058ef0d1c38e4b9"} -->