### PR TITLE
LPD-93967 Announce asset category and tag selectors to screen readers

### DIFF
--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/js/asset_categories_selector/AssetVocabularyCategoriesSelector.js
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/js/asset_categories_selector/AssetVocabularyCategoriesSelector.js
@@ -184,6 +184,7 @@ function AssetVocabulariesCategoriesSelector({
 					<label
 						className={showVocabularyLabel ? '' : 'sr-only'}
 						htmlFor={inputName + '_MultiSelect'}
+						id={inputName + '_MultiSelectLabel'}
 					>
 						{label}
 
@@ -203,6 +204,11 @@ function AssetVocabulariesCategoriesSelector({
 					<ClayInput.GroupItem>
 						<ClayMultiSelect
 							allowsCustomLabel={false}
+							aria-labelledby={
+								label
+									? inputName + '_MultiSelectLabel'
+									: undefined
+							}
 							clearAllTitle={Liferay.Language.get('clear-all')}
 							id={inputName + '_MultiSelect'}
 							inputName={inputName}

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/js/asset_tags_selector/AssetTagsSelector.js
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/js/asset_tags_selector/AssetTagsSelector.js
@@ -255,6 +255,7 @@ function AssetTagsSelector({
 				<label
 					className={showLabel ? '' : 'sr-only'}
 					htmlFor={inputName + '_MultiSelect'}
+					id={inputName + '_MultiSelectLabel'}
 				>
 					{label}
 				</label>
@@ -267,6 +268,7 @@ function AssetTagsSelector({
 									? `${inputName}_MultiSelectHelpText`
 									: undefined
 							}
+							aria-labelledby={inputName + '_MultiSelectLabel'}
 							clearAllTitle={Liferay.Language.get('clear-all')}
 							id={inputName + '_MultiSelect'}
 							inputName={inputName}

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/js/asset_tags_selector/AssetTagsSelector.js
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/js/asset_tags_selector/AssetTagsSelector.js
@@ -268,7 +268,11 @@ function AssetTagsSelector({
 									? `${inputName}_MultiSelectHelpText`
 									: undefined
 							}
-							aria-labelledby={inputName + '_MultiSelectLabel'}
+							aria-labelledby={
+								label
+									? inputName + '_MultiSelectLabel'
+									: undefined
+							}
 							clearAllTitle={Liferay.Language.get('clear-all')}
 							id={inputName + '_MultiSelect'}
 							inputName={inputName}

--- a/modules/apps/asset/asset-taglib/test/asset_categories_selector/AssetVocabularyCategoriesSelector.js
+++ b/modules/apps/asset/asset-taglib/test/asset_categories_selector/AssetVocabularyCategoriesSelector.js
@@ -16,6 +16,18 @@ const DEFAULT_PROPS = {
 	inputName: '',
 	portletURL: '',
 };
+
+let capturedProps;
+
+jest.mock('@clayui/multi-select', () => ({
+	__esModule: true,
+	default: (props) => {
+		capturedProps = props;
+
+		return null;
+	},
+}));
+
 jest.mock('@clayui/data-provider', () => {
 	const originalModule = jest.requireActual('@clayui/data-provider');
 
@@ -30,11 +42,42 @@ jest.mock('@clayui/data-provider', () => {
 });
 
 describe('AssetVocabularyCategoriesSelector', () => {
+	beforeEach(() => {
+		capturedProps = undefined;
+	});
+
 	it('refetch is not called in the first component render', () => {
 		render(<AssetVocabularyCategoriesSelector {...DEFAULT_PROPS} />);
 
 		const {refetch} = useResource();
 
 		expect(refetch).not.toHaveBeenCalled();
+	});
+
+	it('gives the combobox an accessible name via aria-labelledby', () => {
+		const {container} = render(
+			<AssetVocabularyCategoriesSelector
+				{...DEFAULT_PROPS}
+				inputName="assetCategoryIds_42"
+				label="My Vocabulary"
+			/>
+		);
+
+		const labelId = 'assetCategoryIds_42_MultiSelectLabel';
+
+		expect(capturedProps['aria-labelledby']).toBe(labelId);
+
+		const label = container.querySelector(`#${labelId}`);
+
+		expect(label).toBeInTheDocument();
+		expect(label.tagName).toBe('LABEL');
+		expect(label).toHaveAttribute('for', 'assetCategoryIds_42_MultiSelect');
+		expect(label).toHaveTextContent('My Vocabulary');
+	});
+
+	it('does not set aria-labelledby when there is no label', () => {
+		render(<AssetVocabularyCategoriesSelector {...DEFAULT_PROPS} />);
+
+		expect(capturedProps['aria-labelledby']).toBeUndefined();
 	});
 });

--- a/modules/apps/asset/asset-taglib/test/asset_tags_selector/AssetTagsSelector.js
+++ b/modules/apps/asset/asset-taglib/test/asset_tags_selector/AssetTagsSelector.js
@@ -18,11 +18,13 @@ const DEFAULT_PROPS = {
 	selectedItems: [],
 };
 
+let capturedProps;
 let capturedSourceItems;
 
 jest.mock('@clayui/multi-select', () => ({
 	__esModule: true,
 	default: (props) => {
+		capturedProps = props;
 		capturedSourceItems = props.sourceItems;
 
 		return null;
@@ -44,7 +46,24 @@ const setResource = (resource) =>
 
 describe('AssetTagsSelector', () => {
 	beforeEach(() => {
+		capturedProps = undefined;
 		capturedSourceItems = undefined;
+	});
+
+	it('gives the combobox an accessible name via aria-labelledby', () => {
+		setResource([]);
+
+		const {container} = render(<AssetTagsSelector {...DEFAULT_PROPS} />);
+
+		const labelId = 'tags_MultiSelectLabel';
+
+		expect(capturedProps['aria-labelledby']).toBe(labelId);
+
+		const label = container.querySelector(`#${labelId}`);
+
+		expect(label).toBeInTheDocument();
+		expect(label.tagName).toBe('LABEL');
+		expect(label).toHaveAttribute('for', 'tags_MultiSelect');
 	});
 
 	it('Remove duplicates from the list', () => {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93967

## What Is Being Fixed

The asset Categories and Tags selectors (the comboboxes in the Categorization panel when creating or editing web content / a Journal article) do not expose a reliable programmatic accessible name. They derived their name solely from a visible label associated through `htmlFor` matching the `id` that ClayMultiSelect forwards down to its inner `input[role=combobox]`. That routing is fragile and version-sensitive, so the focusable combobox could end up with no accessible name and screen readers would not announce the field's purpose. Reported via Customer Issue Analysis LPP-64343.

## How It Is Being Fixed

Following the recommendation on LPP-64343, the relationship is now made explicit rather than left to Clay's internal id forwarding. Each visible label gets an `id`, and that id is passed as `aria-labelledby` on the corresponding ClayMultiSelect, which forwards it onto the combobox input. For the categories selector the attribute is only set when a vocabulary label is present. Jest coverage was added to both selectors asserting the combobox receives an `aria-labelledby` that points at the label element.

## PR Check

**pr-check: PASS** — tested on `1235024b8f6ffc75be114b0038cc7e6065c9db97`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Deploy | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "1235024b8f6ffc75be114b0038cc7e6065c9db97"} -->
