### PR TITLE
LPD-94630 Fix unitless 0 fallback for --multi-step-divider-spacer-x in atlas CSS

### DIFF
--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_multi-step-nav.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_multi-step-nav.scss
@@ -84,7 +84,7 @@ $data-multi-step-icon-before-content: unquote(
 
 $multi-step-divider-bg: var(--multi-step-divider-bg, $gray-200) !default;
 $multi-step-divider-height: var(--multi-step-divider-height, 4px) !default;
-$multi-step-divider-spacer-x: var(--multi-step-divider-spacer-x, 0) !default;
+$multi-step-divider-spacer-x: var(--multi-step-divider-spacer-x, 0px) !default;
 $multi-step-divider-top: var(
 	--multi-step-divider-top,
 	calc(#{$multi-step-divider-height} * 0.5 + #{$multi-step-icon-size} * 0.5)


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94630

## What Is Being Fixed

In Chrome, `ClayMultiStepNav` with the `center` prop misaligns step indicator circles — they pin to the left edge instead of centering under their labels. The root cause is in the atlas CSS custom property fallback: `--multi-step-divider-spacer-x` uses `0` (unitless) as its fallback value. Chrome rejects `calc(32px + 0 * 2)` as invalid because `0 * 2` produces a dimensionless `<number>` and `<length> + <number>` is not valid in `calc()`. The computed `width` falls back to `auto`, so the indicator stretches to fill its parent, and the `left: 50%; transform: translateX(-50%)` pair cancels out, leaving circles pinned at the left.

## How It Is Being Fixed

Change the fallback value for `$multi-step-divider-spacer-x` in `atlas-custom-properties/variables/_multi-step-nav.scss` from `0` to `0px`. A length with an explicit `px` unit makes the `calc()` expression valid in all browsers.

## Why Are There No Tests?

Clay CSS has no unit tests for SCSS custom property compilation; the fix was verified by deploying the built JAR and confirming the indicator width computed correctly in the browser.

## Screenshots

Before:
<img width="1080" height="157" alt="image" src="https://github.com/user-attachments/assets/2e946c1b-22aa-4130-906d-139a6f407770" />

After:
<img width="1080" height="157" alt="image" src="https://github.com/user-attachments/assets/98e6066e-7459-42ac-935a-ad57cfb1d67d" />

## PR Check

**pr-check: PASS** — tested on `21826a682727bbbe91a3cffa4370bfed2d3ea0fe`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Theme Build | PASS |

<!-- pr-check {"result": "success", "sha": "21826a682727bbbe91a3cffa4370bfed2d3ea0fe"} -->