### PR TITLE
LPD-94658 Investigate test failure modules-semantic-versioning[modules/apps/product-navigation]

### DIFF
--- a/modules/apps/product-navigation/product-navigation-taglib/bnd.bnd
+++ b/modules/apps/product-navigation/product-navigation-taglib/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Product Navigation Taglib
 Bundle-SymbolicName: com.liferay.product.navigation.taglib
-Bundle-Version: 7.0.18
+Bundle-Version: 7.1.0
 Export-Package:\
 	com.liferay.product.navigation.taglib.display.context,\
 	com.liferay.product.navigation.taglib.servlet.taglib

--- a/modules/apps/product-navigation/product-navigation-taglib/package.json
+++ b/modules/apps/product-navigation/product-navigation-taglib/package.json
@@ -16,5 +16,5 @@
 		"checkFormat": "node-scripts format --check",
 		"format": "node-scripts format"
 	},
-	"version": "7.0.18"
+	"version": "7.1.0"
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94658

## What Is Being Fixed

The `modules-semantic-versioning` check failed on `modules/apps/product-navigation/product-navigation-taglib` with `[Baseline Warning] Bundle Version Change Recommended: 7.1.0`. A prior change (LPD-93507) added `com.liferay.product.navigation.taglib.display.context` to the bundle's `Export-Package` so an integration test could reach `ProductNavigationControlMenuTagDisplayContext`. Exposing a new package is a backward-compatible API addition, which under semantic versioning requires a minor bundle version bump, but the version had only been auto-incremented at the micro level to `7.0.18`. That undershot the required bump, so the baseline task flagged it.

## How It Is Being Fixed

The bundle version is raised from `7.0.18` to the recommended `7.1.0` in `bnd.bnd`, and `package.json` is brought in line with the same version. The newly exported package already carries the correct `packageinfo` version (`1.0.0`), and the unchanged `servlet.taglib` package stays at `2.0.0`, so no further versioning changes are needed. A clean rebuild now baselines with an empty report.

## Why Are There No Tests?

This is a version-metadata-only change with no code behavior to exercise. The semantic-versioning baseline check is itself the gate for this fix, and it passes after the bump.

## PR Check

**pr-check: PASS** — tested on `f351c8161fd5cd968af73886deba60b66fbd1e92`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Baseline | PASS |
| Per-Module Compile | PASS |
| Structural Smoke | PASS |

<!-- pr-check {"result": "success", "sha": "f351c8161fd5cd968af73886deba60b66fbd1e92"} -->