### PR TITLE
LPD-93302 Support dark mode in the side navigation skeleton

### DIFF
--- a/modules/apps/application-list/application-list-taglib/src/main/resources/META-INF/resources/css/side_navigation.scss
+++ b/modules/apps/application-list/application-list-taglib/src/main/resources/META-INF/resources/css/side_navigation.scss
@@ -1,7 +1,7 @@
 @import 'atlas-custom-properties/_variables';
 
 .side-navigation-container {
-	--skeleton-shimmer-color: 247, 248, 249;
+	--skeleton-shimmer-color: var(--light-l1);
 
 	input:not(:focus-within) {
 		background-image: clay-icon(search, #6b6c7e);
@@ -24,13 +24,19 @@
 			overflow: hidden;
 			position: relative;
 
+			.side-navigation-skeleton {
+				aspect-ratio: 320 / 650;
+				color: $secondary-l3;
+				width: 100%;
+			}
+
 			&::after {
 				animation: shimmer 1.6s infinite;
 				background: linear-gradient(
 					90deg,
-					rgba(var(--skeleton-shimmer-color), 0) 0%,
-					rgba(var(--skeleton-shimmer-color), 0.6) 50%,
-					rgba(var(--skeleton-shimmer-color), 0) 100%
+					rgb(from var(--skeleton-shimmer-color) r g b / 0) 0%,
+					rgb(from var(--skeleton-shimmer-color) r g b / 0.6) 50%,
+					rgb(from var(--skeleton-shimmer-color) r g b / 0) 100%
 				);
 				content: '';
 				inset: 0;

--- a/modules/apps/application-list/application-list-taglib/src/main/resources/META-INF/resources/side_navigation/page.jsp
+++ b/modules/apps/application-list/application-list-taglib/src/main/resources/META-INF/resources/side_navigation/page.jsp
@@ -14,7 +14,9 @@ SideNavigationDisplayContext sideNavigationDisplayContext = new SideNavigationDi
 <div class="side-navigation-container c-slideout-container<%= sideNavigationDisplayContext.isVisible() ? " c-slideout-push-start" : "" %>" id="com_liferay_application_list_taglib_side_navigation_container">
 	<div class="c-slideout c-slideout-fixed c-slideout-push c-slideout-start<%= sideNavigationDisplayContext.isVisible() ? " c-slideout-shown" : "" %>">
 		<section class="skeleton sidebar sidebar-light<%= sideNavigationDisplayContext.isVisible() ? " c-slideout-show" : "" %>" data-qa-id="sideNavigation" data-testid="sideNavigation">
-			<img alt="" src="<%= String.format("%s/skeletons/homes_side_navigation.svg", themeDisplay.getPathThemeImages()) %>" />
+			<svg class="side-navigation-skeleton">
+				<use href="<%= String.format("%s/skeletons/homes_side_navigation.svg#homes-side-navigation", themeDisplay.getPathThemeImages()) %>" />
+			</svg>
 		</section>
 	</div>
 

--- a/modules/apps/frontend-theme/frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled/images/skeletons/homes_side_navigation.svg
+++ b/modules/apps/frontend-theme/frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled/images/skeletons/homes_side_navigation.svg
@@ -1,44 +1,46 @@
-<svg fill="none" height="651" viewBox="0 0 320 651" width="320" xmlns="http://www.w3.org/2000/svg">
-	<path d="M12 28C12 25.7909 13.7909 24 16 24H40C42.2091 24 44 25.7909 44 28V52C44 54.2091 42.2091 56 40 56H16C13.7909 56 12 54.2091 12 52V28Z" fill="#E7E7ED" />
-	<rect fill="#E7E7ED" height="18" rx="4" width="131.911" x="52" y="31" />
-	<rect fill="#E7E7ED" height="20" rx="4" width="20" x="241" y="30" />
-	<rect fill="#E7E7ED" height="20" rx="4" width="20" x="282" y="30" />
-	<rect fill="#E7E7ED" height="30.75" rx="4" width="288" x="16" y="85" />
-	<rect fill="#E7E7ED" height="24" rx="4" width="24" x="16" y="154.75" />
-	<rect fill="#E7E7ED" height="18" rx="4" width="58.687" x="48" y="157.75" />
-	<rect fill="#E7E7ED" height="18" rx="4" width="74.2454" x="16" y="202.75" />
-	<mask height="7" id="mask0_6102_38008" maskUnits="userSpaceOnUse" style="mask-type:alpha" width="10" x="291" y="208">
-		<path d="M296.672 214.309L300.722 210.199C301.515 209.356 300.437 208.21 299.659 209.035L296 212.758L292.3 209.013C291.578 208.245 290.518 209.428 291.243 210.199L295.302 214.319C295.792 214.851 296.089 214.939 296.672 214.309Z" fill="#6B6C7E" />
-	</mask>
-	<g mask="url(#mask0_6102_38008)">
-		<rect fill="#E7E7ED" height="16" width="16" x="288" y="203.75" />
-	</g>
-	<rect fill="#E7E7ED" height="24" opacity="0.95" rx="4" width="24" x="16" y="244.75" />
-	<rect fill="#E7E7ED" height="18" opacity="0.95" rx="4" width="198.939" x="48" y="247.75" />
-	<rect fill="#E7E7ED" fill-opacity="0.95" height="24" rx="4" width="24" x="16" y="288.75" />
-	<rect fill="#E7E7ED" fill-opacity="0.95" height="18" rx="4" width="176" x="48" y="291.75" />
-	<rect fill="#E7E7ED" fill-opacity="0.75" height="24" rx="4" width="24" x="16" y="332.75" />
-	<rect fill="#E7E7ED" fill-opacity="0.75" height="18" rx="4" width="256" x="48" y="335.75" />
-	<rect fill="#E7E7ED" fill-opacity="0.65" height="24" rx="4" width="24" x="16" y="376.75" />
-	<rect fill="#E7E7ED" fill-opacity="0.65" height="18" rx="4" width="219.064" x="48" y="379.75" />
-	<rect fill="#E7E7ED" fill-opacity="0.55" height="24" rx="4" width="24" x="16" y="420.75" />
-	<rect fill="#E7E7ED" fill-opacity="0.55" height="18" rx="4" width="256" x="48" y="423.75" />
-	<rect fill="#E7E7ED" fill-opacity="0.45" height="18" rx="4" width="100" x="16" y="465.75" />
-	<mask height="7" id="mask1_6102_38008" maskUnits="userSpaceOnUse" style="mask-type:alpha" width="10" x="291" y="471">
-		<path d="M296.672 477.309L300.722 473.199C301.515 472.356 300.437 471.21 299.659 472.035L296 475.758L292.3 472.013C291.578 471.245 290.518 472.428 291.243 473.199L295.302 477.319C295.792 477.851 296.089 477.939 296.672 477.309Z" fill="#6B6C7E" />
-	</mask>
-	<g mask="url(#mask1_6102_38008)">
-		<rect fill="#E7E7ED" height="16" width="16" x="288" y="466.75" />
-	</g>
-	<rect fill="#E7E7ED" fill-opacity="0.35" height="24" rx="4" width="24" x="16" y="507.75" />
-	<rect fill="#E7E7ED" fill-opacity="0.35" height="18" rx="4" width="138.715" x="48" y="510.75" />
-	<rect fill="#E7E7ED" fill-opacity="0.85" height="18" opacity="0.25" rx="4" width="100" x="16" y="552.75" />
-	<mask height="7" id="mask2_6102_38008" maskUnits="userSpaceOnUse" style="mask-type:alpha" width="10" x="291" y="558">
-		<path d="M296.672 564.309L300.722 560.199C301.515 559.356 300.437 558.21 299.659 559.035L296 562.758L292.3 559.013C291.578 558.245 290.518 559.428 291.243 560.199L295.302 564.319C295.792 564.851 296.089 564.939 296.672 564.309Z" fill="#6B6C7E" />
-	</mask>
-	<g mask="url(#mask2_6102_38008)">
-		<rect fill="#E7E7ED" height="16" opacity="0.25" width="16" x="288" y="553.75" />
-	</g>
-	<rect fill="#E7E7ED" fill-opacity="0.15" height="24" rx="4" width="24" x="16" y="594.75" />
-	<rect fill="#E7E7ED" fill-opacity="0.15" height="18" rx="4" width="176" x="48" y="597.75" />
+<svg xmlns="http://www.w3.org/2000/svg">
+	<symbol fill="none" id="homes-side-navigation" viewBox="0 0 320 650">
+		<path d="M12 28C12 25.7909 13.7909 24 16 24H40C42.2091 24 44 25.7909 44 28V52C44 54.2091 42.2091 56 40 56H16C13.7909 56 12 54.2091 12 52V28Z" fill="currentColor" />
+		<rect fill="currentColor" height="18" rx="4" width="131.911" x="52" y="31" />
+		<rect fill="currentColor" height="20" rx="4" width="20" x="241" y="30" />
+		<rect fill="currentColor" height="20" rx="4" width="20" x="282" y="30" />
+		<rect fill="currentColor" height="30.75" rx="4" width="288" x="16" y="85" />
+		<rect fill="currentColor" height="24" rx="4" width="24" x="16" y="154.75" />
+		<rect fill="currentColor" height="18" rx="4" width="58.687" x="48" y="157.75" />
+		<rect fill="currentColor" height="18" rx="4" width="74.2454" x="16" y="202.75" />
+		<mask height="7" id="mask0_6102_38008" maskUnits="userSpaceOnUse" style="mask-type:alpha" width="10" x="291" y="208">
+			<path d="M296.672 214.309L300.722 210.199C301.515 209.356 300.437 208.21 299.659 209.035L296 212.758L292.3 209.013C291.578 208.245 290.518 209.428 291.243 210.199L295.302 214.319C295.792 214.851 296.089 214.939 296.672 214.309Z" fill="#6B6C7E" />
+		</mask>
+		<g mask="url(#mask0_6102_38008)">
+			<rect fill="currentColor" height="16" width="16" x="288" y="203.75" />
+		</g>
+		<rect fill="currentColor" height="24" opacity="0.95" rx="4" width="24" x="16" y="244.75" />
+		<rect fill="currentColor" height="18" opacity="0.95" rx="4" width="198.939" x="48" y="247.75" />
+		<rect fill="currentColor" fill-opacity="0.95" height="24" rx="4" width="24" x="16" y="288.75" />
+		<rect fill="currentColor" fill-opacity="0.95" height="18" rx="4" width="176" x="48" y="291.75" />
+		<rect fill="currentColor" fill-opacity="0.75" height="24" rx="4" width="24" x="16" y="332.75" />
+		<rect fill="currentColor" fill-opacity="0.75" height="18" rx="4" width="256" x="48" y="335.75" />
+		<rect fill="currentColor" fill-opacity="0.65" height="24" rx="4" width="24" x="16" y="376.75" />
+		<rect fill="currentColor" fill-opacity="0.65" height="18" rx="4" width="219.064" x="48" y="379.75" />
+		<rect fill="currentColor" fill-opacity="0.55" height="24" rx="4" width="24" x="16" y="420.75" />
+		<rect fill="currentColor" fill-opacity="0.55" height="18" rx="4" width="256" x="48" y="423.75" />
+		<rect fill="currentColor" fill-opacity="0.45" height="18" rx="4" width="100" x="16" y="465.75" />
+		<mask height="7" id="mask1_6102_38008" maskUnits="userSpaceOnUse" style="mask-type:alpha" width="10" x="291" y="471">
+			<path d="M296.672 477.309L300.722 473.199C301.515 472.356 300.437 471.21 299.659 472.035L296 475.758L292.3 472.013C291.578 471.245 290.518 472.428 291.243 473.199L295.302 477.319C295.792 477.851 296.089 477.939 296.672 477.309Z" fill="#6B6C7E" />
+		</mask>
+		<g mask="url(#mask1_6102_38008)">
+			<rect fill="currentColor" height="16" width="16" x="288" y="466.75" />
+		</g>
+		<rect fill="currentColor" fill-opacity="0.35" height="24" rx="4" width="24" x="16" y="507.75" />
+		<rect fill="currentColor" fill-opacity="0.35" height="18" rx="4" width="138.715" x="48" y="510.75" />
+		<rect fill="currentColor" fill-opacity="0.85" height="18" opacity="0.25" rx="4" width="100" x="16" y="552.75" />
+		<mask height="7" id="mask2_6102_38008" maskUnits="userSpaceOnUse" style="mask-type:alpha" width="10" x="291" y="558">
+			<path d="M296.672 564.309L300.722 560.199C301.515 559.356 300.437 558.21 299.659 559.035L296 562.758L292.3 559.013C291.578 558.245 290.518 559.428 291.243 560.199L295.302 564.319C295.792 564.851 296.089 564.939 296.672 564.309Z" fill="#6B6C7E" />
+		</mask>
+		<g mask="url(#mask2_6102_38008)">
+			<rect fill="currentColor" height="16" opacity="0.25" width="16" x="288" y="553.75" />
+		</g>
+		<rect fill="currentColor" fill-opacity="0.15" height="24" rx="4" width="24" x="16" y="594.75" />
+		<rect fill="currentColor" fill-opacity="0.15" height="18" rx="4" width="176" x="48" y="597.75" />
+	</symbol>
 </svg>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93302

## What Is Being Fixed

The loading skeleton of the new side navigation (`com_liferay_application_list_taglib_side_navigation_container`) did not adapt to dark mode. Both the shimmer animation and the placeholder shapes stayed light, clashing with the dark sidebar background.

## How It Is Being Fixed

The shimmer color is now bound to the same token as the sidebar background (`--light-l1`) and derived with relative color syntax, so it inverts with the theme. The skeleton illustration is painted like a Lexicon icon: the SVG is now a `<symbol>` whose shapes use `fill="currentColor"` and is referenced through `<use>`, so its color comes from the host CSS token (`--secondary-l3`) and inverts in dark mode. The illustration scales fluidly through `aspect-ratio` and `width: 100%`.

## Why Are There No Tests?

This is a purely visual change (dark-mode CSS and SVG) with no testable logic; it was verified manually in the browser.

## Demo

A demo video is attached:

https://github.com/user-attachments/assets/d215ed7d-86ee-47ef-83cd-8d52df08fd20

## PR Check

**pr-check: PASS** — tested on `8dae5465c96c6b8b4cb457055694e916ad54c624`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JSP Compile | PASS |
| Theme Build | PASS |

<!-- pr-check {"result": "success", "sha": "8dae5465c96c6b8b4cb457055694e916ad54c624"} -->
