### PR TITLE
LPD-94804 Match side navigation header background to the menu body

### DIFF
--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_sidebar.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_sidebar.scss
@@ -338,7 +338,7 @@ $sidebar-light: map-deep-merge(
 		color: var(--sidebar-light-color, $gray-900),
 		sidebar-header: (
 			background-color:
-				var(--sidebar-light-sidebar-header-background-color, $white),
+				var(--sidebar-light-sidebar-header-background-color, inherit),
 			border:
 				var(--sidebar-light-sidebar-header-border, 0px solid $gray-300),
 		),


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94804

## What Is Being Fixed

A white rectangular block rendered at the top of the product menu — the Side Navigation panel opened from the Applications panel, Control Panel, or Commerce — clashing with the menu content.

## How It Is Being Fixed

The Side Navigation panel body uses the `light-l1` token, but the Clay `sidebar-header` remained at its default white background, so the header showed as a white block over the grey body. The fix paints the header with the same `light-l1` token through a combined `&, & .sidebar-header` rule, so header and body share one flat background.

## Why Are There No Tests?

This is a visual-only CSS fix — a single SCSS background-color change. The behavior is only coverable by functional (Playwright/Poshi) tests, the last-resort tier; the change carries no logic to unit-test.

## PR Check

**pr-check: PASS** — tested on `6631644`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |

<!-- pr-check {"result": "success", "sha": "6631644794a8137d9b54f01ab612e623beef7068"} -->